### PR TITLE
Adding demos for FreeRTOS port for c28x based microcontrollers

### DIFF
--- a/C2000_F2838x_C28x_CCS/CCS/freertos_ex1_c28x_port_val.projectspec
+++ b/C2000_F2838x_C28x_CCS/CCS/freertos_ex1_c28x_port_val.projectspec
@@ -1,0 +1,82 @@
+<projectSpec>
+  <project
+        name="freertos_ex1_c28x_port_val"
+        device="TMS320F28388D"
+        cgtVersion="20.2.1.LTS"
+        outputFormat="ELF"
+        launchWizard="False"
+        linkerCommandFile=""
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="--product ${C2000WARE_ROOT}/.metadata/sdk.json --device F2838x"
+        >
+    <configuration name="CPU1_FLASH" compilerBuildOptions="--opt_level=off -I${PROJECT_ROOT}/device -I${PROJECT_ROOT}/print_support -I${C2000WARE_DLIB_ROOT} -I${FreeRTOS_ROOT}/Source/include -I${FreeRTOS_SOURCE_INCLUDE} -I${FreeRTOS_SOURCE_PORT} -I${FreeRTOS_STD_DEMO_TASKS} -I${FreeRTOS_STD_DEMO_CINCLUDE} -v28 -ml -mt --define=_FLASH --cla_support=cla2 --float_support=fpu32 --tmu_support=tmu0 --define=DEBUG  --define=CPU1  --diag_warning=225  --diag_suppress=10063" linkerBuildOptions="--entry_point code_start --stack_size=256  --heap_size=64 " />
+	
+    <pathVariable name="C2000WARE_ROOT" path="C:/ti/c2000/C2000Ware_4_00_00_00" scope="project" />
+    <pathVariable name="C2000WARE_DLIB_ROOT" path="${C2000WARE_ROOT}/driverlib/f2838x/driverlib" scope="project" />
+    <pathVariable name="FreeRTOS_ROOT" path="../../.." scope="project" />
+    <pathVariable name="FreeRTOS_SOURCE_INCLUDE" path="${FreeRTOS_ROOT}/Source/include" scope="project" />
+    <pathVariable name="FreeRTOS_SOURCE_PORT" path="${FreeRTOS_ROOT}/Source/portable/CCS/C2000_C28x" scope="project" />
+    <pathVariable name="FreeRTOS_STD_DEMO_TASKS" path="${FreeRTOS_ROOT}/Demo/Common/Minimal" scope="project" />
+    <pathVariable name="FreeRTOS_STD_DEMO_CINCLUDE" path="${FreeRTOS_ROOT}/Demo/Common/include" scope="project" />
+	
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/include/driverlib.h" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/include/device.h" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/source/device.c" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/targetConfigs/TMS320F28388D.ccxml" targetDirectory="targetConfigs" />
+    <file action="copy" path="../port_validation/2838x_FreeRTOS_FLASH_lnk_cpu1.cmd" targetDirectory="" applicableConfigurations="CPU1_FLASH" />
+    <file action="copy" path="${C2000WARE_DLIB_ROOT}/" targetDirectory="device" excludeFromBuild="True" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/source/f2838x_codestartbranch.asm" targetDirectory="device" />
+    <file action="link" path="${C2000WARE_DLIB_ROOT}/ccs/Debug/driverlib.lib" targetDirectory="" />
+	
+	<file action="link" path="${FreeRTOS_ROOT}/Source/include" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/portable/CCS/C2000_C28x" targetDirectory="FreeRTOS/Source/portable/CCS" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/portable/MemMang/heap_4.c" targetDirectory="FreeRTOS/Source/portable/MemMang" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/croutine.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/event_groups.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/list.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/queue.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/stream_buffer.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/tasks.c" targetDirectory="FreeRTOS/Source" />
+    <file action="link" path="${FreeRTOS_ROOT}/Source/timers.c" targetDirectory="FreeRTOS/Source" />
+	
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/include" targetDirectory="FullDemo" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/AbortDelay.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/BlockQ.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/blocktim.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/countsem.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/death.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/dynamic.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/EventGroupsDemo.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/flop.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/GenQTest.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/integer.c" targetDirectory="FullDemo/Minimal" />
+    <file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/IntSemTest.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/MessageBufferAMP.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/MessageBufferDemo.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/PollQ.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/QPeek.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/QueueOverwrite.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/QueueSet.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/QueueSetPolling.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/recmutex.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/semtest.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/StaticAllocation.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/StreamBufferDemo.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/StreamBufferInterrupt.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/TaskNotify.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/TaskNotifyArray.c" targetDirectory="FullDemo/Minimal" />
+	<file action="link" path="${FreeRTOS_ROOT}/Demo/Common/Minimal/TimerDemo.c" targetDirectory="FullDemo/Minimal" />
+	
+	<file action="copy" path="../print_support/uart_drv.c" targetDirectory="print_support" />
+	<file action="copy" path="../print_support/uart_drv.h" targetDirectory="print_support" />
+	<file action="copy" path="../print_support/printf-stdarg.c" targetDirectory="print_support" />
+	
+	<file action="copy" path="../port_validation/FreeRTOSConfig.h" targetDirectory="" />
+    <file action="copy" path="../port_validation/TestRunner.c" targetDirectory="" />
+    <file action="copy" path="../port_validation/TestRunner.h" targetDirectory="" />
+    <file action="copy" path="../port_validation/RegTests.c" targetDirectory="" />
+    <file action="copy" path="../port_validation/RegTests.h" targetDirectory="" />
+	
+    <file action="copy" path="../freertos_ex1_c28x_port_val.c" targetDirectory="" />
+  </project>
+</projectSpec>

--- a/C2000_F2838x_C28x_CCS/CCS/freertos_ex2_led_blinky.projectspec
+++ b/C2000_F2838x_C28x_CCS/CCS/freertos_ex2_led_blinky.projectspec
@@ -1,0 +1,35 @@
+<projectSpec>
+  <project
+        name="freertos_ex2_led_blinky"
+        device="TMS320F28388D"
+        cgtVersion="20.2.1.LTS"
+        outputFormat="ELF"
+        launchWizard="False"
+        linkerCommandFile=""
+        enableSysConfigTool="true"
+        sysConfigBuildOptions="--product ${C2000WARE_ROOT}/.metadata/sdk.json --device F2838x"
+        >
+    <configuration name="CPU1_RAM" compilerBuildOptions="--opt_level=off -I${PROJECT_ROOT}/device -I${C2000WARE_DLIB_ROOT} -I${Free_RTOS}/portable/CCS/C2000_C28x -I${Free_RTOS}/include -v28 -ml -mt --cla_support=cla2 --float_support=fpu32 --tmu_support=tmu0 --define=DEBUG  --define=CPU1  --diag_warning=225  --diag_suppress=10063" linkerBuildOptions="--entry_point code_start --stack_size=0x100  --heap_size=0x200 --define RAM" />
+    <configuration name="CPU1_FLASH" compilerBuildOptions="--opt_level=off -I${PROJECT_ROOT}/device -I${C2000WARE_DLIB_ROOT} -I${Free_RTOS}/portable/CCS/C2000_C28x -I${Free_RTOS}/include -v28 -ml -mt --define=_FLASH --cla_support=cla2 --float_support=fpu64 --tmu_support=tmu0 --define=DEBUG  --define=CPU1  --diag_warning=225  --diag_suppress=10063" linkerBuildOptions="--entry_point code_start --stack_size=0x100  --heap_size=0x200 " />
+    <pathVariable name="C2000WARE_ROOT" path="C:/ti/c2000/C2000Ware_3_02_00_00" scope="project" />
+    <pathVariable name="C2000WARE_DLIB_ROOT" path="${C2000WARE_ROOT}/driverlib/f2838x/driverlib" scope="project" />
+    <pathVariable name="Free_RTOS" path="../../../Source/" scope="project" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/include/driverlib.h" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/include/device.h" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/source/device.c" targetDirectory="device" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/targetConfigs/TMS320F28388D.ccxml" targetDirectory="targetConfigs" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/cmd/2838x_RAM_lnk_cpu1.cmd" targetDirectory="" applicableConfigurations="CPU1_RAM" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/cmd/2838x_FLASH_lnk_cpu1.cmd" targetDirectory="" applicableConfigurations="CPU1_FLASH" />
+    <file action="copy" path="${C2000WARE_DLIB_ROOT}/" targetDirectory="device" excludeFromBuild="True" />
+    <file action="copy" path="${C2000WARE_ROOT}/device_support/f2838x/common/source/f2838x_codestartbranch.asm" targetDirectory="device" />
+    <file action="link" path="${C2000WARE_DLIB_ROOT}/ccs/Debug/driverlib.lib" targetDirectory="" />
+    <file action="copy" path="../freertos_ex2_led_blinky.c" targetDirectory="" />
+	<file action="copy" path="../FreeRTOSConfig.h" targetDirectory="" />
+	<file action="link" path="${Free_RTOS}/tasks.c" targetDirectory="FreeRTOS" />
+	<file action="link" path="${Free_RTOS}/queue.c" targetDirectory="FreeRTOS" />
+	<file action="link" path="${Free_RTOS}/list.c" targetDirectory="FreeRTOS" />
+	<file action="link" path="${Free_RTOS}/portable/CCS/C2000_C28x/port.c" targetDirectory="FreeRTOS/port" />
+	<file action="link" path="${Free_RTOS}/portable/CCS/C2000_C28x/portasm.asm" targetDirectory="FreeRTOS/port" />
+	<file action="link" path="${Free_RTOS}/portable/CCS/C2000_C28x/portmacro.h" targetDirectory="FreeRTOS/port" />
+  </project>
+</projectSpec>

--- a/C2000_F2838x_C28x_CCS/FreeRTOSConfig.h
+++ b/C2000_F2838x_C28x_CCS/FreeRTOSConfig.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2021 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+//--------------------------------------------------------------------------------------------------
+// Application specific definitions.
+//
+// These definitions should be adjusted for your particular hardware and
+// application requirements.
+//
+// THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+// FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+//
+// See http://www.freertos.org/a00110.html.
+//--------------------------------------------------------------------------------------------------
+
+#define configUSE_PREEMPTION                1
+#define configUSE_IDLE_HOOK                 0
+#define configUSE_TICK_HOOK                 0
+#define configCPU_CLOCK_HZ                  ( ( unsigned long ) 200000000 )
+#define configTICK_RATE_HZ                  ( ( TickType_t ) 1000 )
+#define configMAX_PRIORITIES                ( 5 )
+#define configMINIMAL_STACK_SIZE            ( ( unsigned short ) 128 )
+#define configTOTAL_HEAP_SIZE               ( ( size_t ) ( 17 * 1024 ) )
+#define configMAX_TASK_NAME_LEN             ( 16 )
+#define configUSE_TRACE_FACILITY            0
+#define configUSE_16_BIT_TICKS              0
+#define configIDLE_SHOULD_YIELD             0
+#define configCHECK_FOR_STACK_OVERFLOW      2
+#define configSUPPORT_STATIC_ALLOCATION     1
+#define configSUPPORT_DYNAMIC_ALLOCATION    0
+
+// Set the following definitions to 1 to include the API function, or zero
+// to exclude the API function.
+
+#define INCLUDE_vTaskPrioritySet            0
+#define INCLUDE_uxTaskPriorityGet           0
+#define INCLUDE_vTaskDelete                 0
+#define INCLUDE_vTaskCleanUpResources       0
+#define INCLUDE_vTaskSuspend                0
+#define INCLUDE_vTaskDelayUntil             0
+#define INCLUDE_vTaskDelay                  1
+
+#endif /* FREERTOS_CONFIG_H */
+

--- a/C2000_F2838x_C28x_CCS/README.md
+++ b/C2000_F2838x_C28x_CCS/README.md
@@ -1,0 +1,54 @@
+
+OVERVIEW
+
+This directory contains demo projects for TMS320F2838xD (C2000 compiler 20.2.1.LTS) for the TMDSCNCD28388D controlcard board.
+
+LIST OF EXAMPLES:
+1. freertos_ex1_c28x_port_val
+2. freertos_ex2_led_blinky
+
+1. freertos_ex1_c28x_port_val Demo
+
+This example implements the standard test demos detailed in following link:https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/Demo/ThirdParty/Template/README.md
+
+The whole functionality is included in the freertos_ex1_c28x_port_val.c file by calling the void vStartTests( void ) function which contains the tests available in the [FreeRTOS/Demo/Common/Minimal](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/Common/Minimal).  
+
+This example uses the "check" task to periodically inspect the standard demo tasks in order to ensure all the tasks are functioning as expected. The "check" task blinks LED2 post inspecting all the standard demos tasks.
+
+To see the console output for the test results, serial port(SCIA) sould be configured as: 
+ - baud rate 9600
+ - data 8-bit
+ - parity none
+ - stop bits 1-bit
+ - flow control none
+ 
+NOTE:
+a. To avoid memory issues, the tests are grouped into 2 sections. Update TESTGROUP to select the desired group or alternatively run tests one by one by defining configSTART_<Test_Name>_TESTS macros to 0 or 1 as needed.
+b. configSTART_INTERRUPT_QUEUE_TESTS are not added in this demo.
+
+
+2. freertos_ex2_led_blinky Demo
+
+This example demonstrates a simple blinky demo which uses various RTOS features to blink the two onboard LEDs.
+
+QUICK START:
+To run the demos on TMDSCNCD28388D controlcard, the following steps are required:
+ - Install Code Compser Studio(CCS): https://www.ti.com/tool/CCSTUDIO
+ - Install latest C2000Ware package: https://www.ti.com/tool/C2000WARE
+ - Update the C2000WARE_ROOT and FreeRTOS_ROOT path variable in the example projectspec files available at following location in the repo: FreeRTOS-Partner-Supported-Demos\C2000_F2838x_C28x_CCS\CCS
+ - Import the example project file in CCS
+ - Build and debug the project
+
+TOOL CHAIN SUPPORT:
+Code Composer Studio™ IDE (CCS) v11.1.0 or newer
+C2000 Compiler v20.2.1.LTS or newer
+C2000Ware_3_01_00_00 or newer
+FreeRTOSv202112.00
+
+KNOWN ISSUES:
+Support for "fpu64" is not added yet to the port. The examples should specify "fpu32" as option for floating point.
+
+REFERENCES:
+https://www.ti.com/tool/TMDSCNCD28388D
+https://www.ti.com/tool/C2000WARE
+https://www.ti.com/tool/CCSTUDIO

--- a/C2000_F2838x_C28x_CCS/freertos_ex1_c28x_port_val.c
+++ b/C2000_F2838x_C28x_CCS/freertos_ex1_c28x_port_val.c
@@ -1,0 +1,462 @@
+//#############################################################################
+//
+// FILE:   freertos_ex1_c28x_port_val.c
+//
+// TITLE:  FreeRTOS C28x Port Validation
+//
+//! This example validates the FreeRTOS C28x port and is based on the project
+//! template detailed in the below shown link:
+//! https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/Demo/ThirdParty/Template/README.md
+//! 
+//! The project configures following tests for the c28x port and periodically
+//! blinks LED2 available on the controlcard.
+//! #define configSTART_TASK_NOTIFY_TESTS             1
+//! #define configSTART_TASK_NOTIFY_ARRAY_TESTS       1
+//! #define configSTART_BLOCKING_QUEUE_TESTS          1
+//! #define configSTART_SEMAPHORE_TESTS               1
+//! #define configSTART_POLLED_QUEUE_TESTS            1
+//! #define configSTART_INTEGER_MATH_TESTS            1
+//! #define configSTART_GENERIC_QUEUE_TESTS           1
+//! #define configSTART_PEEK_QUEUE_TESTS              1
+//! #define configSTART_MATH_TESTS                    1
+//! #define configSTART_RECURSIVE_MUTEX_TESTS         1
+//! #define configSTART_COUNTING_SEMAPHORE_TESTS      1
+//! #define configSTART_QUEUE_SET_TESTS               1
+//! #define configSTART_QUEUE_OVERWRITE_TESTS         1
+//! #define configSTART_EVENT_GROUP_TESTS             1
+//! #define configSTART_INTERRUPT_SEMAPHORE_TESTS     1
+//! #define configSTART_QUEUE_SET_POLLING_TESTS       1
+//! #define configSTART_BLOCK_TIME_TESTS              1
+//! #define configSTART_ABORT_DELAY_TESTS             1
+//! #define configSTART_MESSAGE_BUFFER_TESTS          1
+//! #define configSTART_STREAM_BUFFER_TESTS           1
+//! #define configSTART_STREAM_BUFFER_INTERRUPT_TESTS 1
+//! #define configSTART_TIMER_TESTS                   1
+//! #define configSTART_REGISTER_TESTS                1
+//! #define configSTART_DELETE_SELF_TESTS             1
+//! 
+//! For running the application open the COM port with the following settings
+//! using a terminal:
+//!  -  Find correct COM port
+//!  -  Bits per second = 9600
+//!  -  Data Bits = 8
+//!  -  Parity = None
+//!  -  Stop Bits = 1
+//!  -  Hardware Control = None
+//!  The program will print out the test results on COM port
+//! 
+//! External Connections:
+//! Connect the SCI-A port to a PC via a transceiver and cable.
+//! 
+//! Watch Variables:
+//!  - pcStatusMessage: Captures the validation result. The same result can also
+//!                     be checked over COM port.
+//
+//#############################################################################
+//
+//
+// $Copyright:
+// Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.co/
+//
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions 
+// are met:
+// 
+//   Redistributions of source code must retain the above copyright 
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the 
+//   documentation and/or other materials provided with the   
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// $
+//#############################################################################
+
+//
+// Included Files
+//
+#include <stdio.h>
+#include "driverlib.h"
+#include "device.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+#include "TestRunner.h"
+#include <assert.h>
+#include <file.h>
+#include "uart_drv.h"
+
+//
+// Function Declarations
+//
+void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName);
+void vApplicationMallocFailedHook( void );
+void vApplicationIdleHook( void );
+void vApplicationTickHook(void);
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize );
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize );
+void vApplicationSetupTimerInterrupt( void );
+void vMainAssertCalled( const char *pcFileName, uint32_t ulLineNumber );
+void vMainToggleLED( void );
+void configCPUTimer(uint32_t cpuTimer, uint32_t period);
+void *malloc( size_t xSize );
+#pragma WEAK (malloc)
+
+//
+// UART stdout redirection configuration related APIs
+//
+void UartSetup();
+void UartPutChar(uint16_t charToWrite);
+
+extern int checkPrintf();
+
+void main(void)
+{
+    /* Startup and Hardware initialization. */
+    //
+    // Initializes device clock and peripherals
+    //
+    Device_init();
+
+    //
+    // Initializes PIE and clears PIE registers. Disables CPU interrupts.
+    //
+    Interrupt_initModule();
+
+    Device_initGPIO();
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_LED1, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_LED1, GPIO_DIR_MODE_OUT);
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_LED2, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_LED2, GPIO_DIR_MODE_OUT);
+
+    GPIO_writePin(DEVICE_GPIO_PIN_LED1, 1);
+    GPIO_writePin(DEVICE_GPIO_PIN_LED2, 1);
+
+    //
+	// Disable all the interrupts and clear all CPU interrupt flags:
+	//
+	DINT;
+    IER = 0x0000;
+    IFR = 0x0000;
+
+    //
+    // Initializes the PIE vector table with pointers to the shell Interrupt
+    // Service Routines (ISR).
+    //
+    Interrupt_initVectorTable();
+
+    //
+    // Redirect STDOUT to SCI
+    //
+    //**************************************************************************
+    // NOTE: SCI Configuration for this example is done in UartSetup()
+    // As an alternative, the user can configure SCI here in the main, and then
+    // provide an empty UartSetup() function. UartSetup() must be defined, even
+    // if it is empty.
+    //**************************************************************************
+    FILE *uart = NULL;
+
+    //
+    // Add the UART device.  When fopen is called with a filename that
+    // begins "uart:", the UART device will be used to handle the file.
+    //
+    add_device("uart",
+               _SSA,
+               UART_open,
+               UART_close,
+               UART_read,
+               UART_write,
+               UART_lseek,
+               UART_unlink,
+               UART_rename);
+
+    //
+    // Assign stdout to be a UART device!
+    //
+    assert(freopen("uart:", "w", stdout) != NULL);
+
+    //
+    // Uncomment to check printf() functionality
+    // if no output is seen on COM port.
+    // checkPrintf();
+
+    /* Start tests. */
+    vStartTests();
+
+    /* Should never reach here. */
+    for( ; ; );
+}
+
+//
+// Configures the timer used for generating the FreeRTOS tick interrupt
+//
+void vApplicationSetupTimerInterrupt( void )
+{
+    // Start the timer than activate timer interrupt to switch into first task.
+    Interrupt_register(INT_TIMER2, &portTICK_ISR);
+
+    CPUTimer_setPeriod(CPUTIMER2_BASE, 0xFFFFFFFF);
+    CPUTimer_setPreScaler(CPUTIMER2_BASE, 0);
+    CPUTimer_stopTimer(CPUTIMER2_BASE);
+    CPUTimer_reloadTimerCounter(CPUTIMER2_BASE);
+
+    configCPUTimer(CPUTIMER2_BASE, 1000000 / configTICK_RATE_HZ);
+
+    CPUTimer_enableInterrupt(CPUTIMER2_BASE);
+
+    Interrupt_enable(INT_TIMER2);
+    CPUTimer_startTimer(CPUTIMER2_BASE);
+}
+
+//
+// Application must provide an implementation of vApplicationGetIdleTaskMemory()
+// to provide the memory that is used by the Idle task if configUSE_STATIC_ALLOCATION
+// is set to 1.
+//
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                    StackType_t **ppxIdleTaskStackBuffer,
+                                    uint32_t *pulIdleTaskStackSize )
+{
+    /* If the buffers to be provided to the Idle task are declared inside this
+    function then they must be declared static - otherwise they will be allocated on
+    the stack and so not exists after this function exits. */
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Idle task's
+    state will be stored. */
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+    /* Pass out the array that will be used as the Idle task's stack. */
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+
+//
+// Application must provide an implementation of vApplicationGetTimerTaskMemory()
+// to provide the memory that is used by the Timer service task if both
+// configUSE_STATIC_ALLOCATION and configUSE_TIMERS are set to 1.
+//
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                     StackType_t **ppxTimerTaskStackBuffer,
+                                     uint32_t *pulTimerTaskStackSize )
+{
+    /* If the buffers to be provided to the Timer task are declared inside this
+    function then they must be declared static - otherwise they will be allocated on
+    the stack and so not exists after this function exits. */
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Timer
+    task's state will be stored. */
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+
+//
+// Hook function for catching pvPortMalloc() failures
+//
+void vApplicationMallocFailedHook( void )
+{
+    /* vApplicationMallocFailedHook() will only be called if
+    configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h. It is a hook
+    function that will get called if a call to pvPortMalloc() fails.
+    pvPortMalloc() is called internally by the kernel whenever a task, queue,
+    timer or semaphore is created.  It is also called by various parts of the
+    demo application.  If heap_1.c or heap_2.c are used, then the size of the
+    heap available to pvPortMalloc() is defined by configTOTAL_HEAP_SIZE in
+    FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
+    to query the size of free heap space that remains (although it does not
+    provide information on how the remaining heap might be fragmented). */
+    taskDISABLE_INTERRUPTS();
+    for( ;; );
+}
+
+//
+// Hook function for idle task
+//
+void vApplicationIdleHook( void )
+{
+    /* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set
+    to 1 in FreeRTOSConfig.h.  It will be called on each iteration of the idle
+    task.  It is essential that code added to this hook function never attempts
+    to block in any way (for example, call xQueueReceive() with a block time
+    specified, or call vTaskDelay()).  If the application makes use of the
+    vTaskDelete() API function (as this demo application does) then it is also
+    important that vApplicationIdleHook() is permitted to return to its calling
+    function, because it is the responsibility of the idle task to clean up
+    memory allocated by the kernel to any task that has since been deleted. */
+}
+
+//
+// Checks run time stack overflow
+//
+void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
+{
+    ( void ) pcTaskName;
+    ( void ) pxTask;
+
+    /* Run time stack overflow checking is performed if
+    configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
+    function is called if a stack overflow is detected. */
+    taskDISABLE_INTERRUPTS();
+    for( ;; );
+}
+
+//
+// Catch asserts so the file and line number of the assert can be viewed.
+//
+void vMainAssertCalled( const char *pcFileName, uint32_t ulLineNumber )
+{
+volatile BaseType_t xSetToNonZeroToStepOutOfLoop = 0;
+
+    taskENTER_CRITICAL();
+    while( xSetToNonZeroToStepOutOfLoop == 0 )
+    {
+        /* Use the variables to prevent compiler warnings and in an attempt to
+        ensure they can be viewed in the debugger.  If the variables get
+        optimised away then set copy their values to file scope or globals then
+        view the variables they are copied to. */
+        ( void ) pcFileName;
+        ( void ) ulLineNumber;
+    }
+}
+
+//
+// Traps malloc calls
+//
+void *malloc( size_t xSize )
+{
+    /* There should not be a heap defined, so trap any attempts to call
+    malloc. */
+    taskDISABLE_INTERRUPTS();
+    for( ;; );
+}
+
+//
+// Toggles onboard LED2
+//
+void vMainToggleLED( void )
+{
+    GPIO_togglePin(DEVICE_GPIO_PIN_LED2);
+}
+
+//
+// configCPUTimer - This function initializes the selected timer to the
+// period specified by the "freq" and "period" variables. The "freq" is
+// CPU frequency in Hz and the period in uSeconds. The timer is held in
+// the stopped state after configuration.
+//
+void
+configCPUTimer(uint32_t cpuTimer, uint32_t period)
+{
+    uint32_t temp, freq = DEVICE_SYSCLK_FREQ;
+
+    //
+    // Initialize timer period:
+    //
+    temp = ((freq / 1000000) * period);
+    CPUTimer_setPeriod(cpuTimer, temp);
+
+    //
+    // Set pre-scale counter to divide by 1 (SYSCLKOUT):
+    //
+    CPUTimer_setPreScaler(cpuTimer, 0);
+
+    //
+    // Initializes timer control register. The timer is stopped, reloaded,
+    // free run disabled, and interrupt enabled.
+    // Additionally, the free and soft bits are set
+    //
+    CPUTimer_stopTimer(cpuTimer);
+    CPUTimer_reloadTimerCounter(cpuTimer);
+    CPUTimer_setEmulationMode(cpuTimer,
+                              CPUTIMER_EMULATIONMODE_STOPAFTERNEXTDECREMENT);
+    CPUTimer_enableInterrupt(cpuTimer);
+
+}
+
+//
+// Configures SCIA
+//
+void UartSetup()
+{
+    //
+    // DEVICE_GPIO_PIN_SCIRXDA is the SCI Rx pin.
+    //
+    GPIO_setMasterCore(DEVICE_GPIO_PIN_SCIRXDA, GPIO_CORE_CPU1);
+    GPIO_setPinConfig(DEVICE_GPIO_CFG_SCIRXDA);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_SCIRXDA, GPIO_DIR_MODE_IN);
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_SCIRXDA, GPIO_PIN_TYPE_STD);
+    GPIO_setQualificationMode(DEVICE_GPIO_PIN_SCIRXDA, GPIO_QUAL_ASYNC);
+
+    //
+    // DEVICE_GPIO_PIN_SCITXDA is the SCI Tx pin.
+    //
+    GPIO_setMasterCore(DEVICE_GPIO_PIN_SCITXDA, GPIO_CORE_CPU1);
+    GPIO_setPinConfig(DEVICE_GPIO_CFG_SCITXDA);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_SCITXDA, GPIO_DIR_MODE_OUT);
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_SCITXDA, GPIO_PIN_TYPE_STD);
+    GPIO_setQualificationMode(DEVICE_GPIO_PIN_SCITXDA, GPIO_QUAL_ASYNC);
+
+    //
+    // Initialize SCIA and its FIFO.
+    //
+    SCI_performSoftwareReset(SCIA_BASE);
+
+    //
+    // Configure SCIA with FIFO
+    //
+    SCI_setConfig(SCIA_BASE, DEVICE_LSPCLK_FREQ, 9600, (SCI_CONFIG_WLEN_8 |
+                                                        SCI_CONFIG_STOP_ONE |
+                                                        SCI_CONFIG_PAR_NONE));
+    SCI_resetChannels(SCIA_BASE);
+    SCI_resetRxFIFO(SCIA_BASE);
+    SCI_resetTxFIFO(SCIA_BASE);
+    SCI_enableFIFO(SCIA_BASE);
+    SCI_enableModule(SCIA_BASE);
+    SCI_performSoftwareReset(SCIA_BASE);
+}
+
+//
+// Implements SCI based putchar()
+//
+void UartPutChar(uint16_t charToWrite)
+{
+    SCI_writeCharBlockingFIFO(SCIA_BASE, charToWrite);
+}
+
+//
+// End of File
+//

--- a/C2000_F2838x_C28x_CCS/freertos_ex2_led_blinky.c
+++ b/C2000_F2838x_C28x_CCS/freertos_ex2_led_blinky.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2022 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "driverlib.h"
+#include "device.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+
+#define STACK_SIZE  256U
+#define RED         0xDEADBEAF
+#define BLUE        0xBAADF00D
+
+static StaticTask_t redTaskBuffer;
+static StackType_t  redTaskStack[STACK_SIZE];
+
+static StaticTask_t blueTaskBuffer;
+static StackType_t  blueTaskStack[STACK_SIZE];
+
+static StaticTask_t idleTaskBuffer;
+static StackType_t  idleTaskStack[STACK_SIZE];
+
+static SemaphoreHandle_t xSemaphore = NULL;
+static StaticSemaphore_t xSemaphoreBuffer;
+
+//-------------------------------------------------------------------------------------------------
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
+{
+    while(1);
+}
+
+//-------------------------------------------------------------------------------------------------
+static void blueLedToggle(void)
+{
+    static uint32_t counter = 0;
+
+    counter++;
+    GPIO_writePin(31, counter & 1);
+}
+
+//-------------------------------------------------------------------------------------------------
+static void redLedToggle(void)
+{
+    static uint32_t counter = 0;
+
+    counter++;
+    GPIO_writePin(34, counter & 1);
+}
+
+//-------------------------------------------------------------------------------------------------
+static void ledToggle(uint32_t led)
+{
+    if(RED == led)
+    {
+        redLedToggle();
+    }
+    else
+    if(BLUE == led)
+    {
+        blueLedToggle();
+    } 
+}
+
+//
+// configCPUTimer - This function initializes the selected timer to the
+// period specified by the "freq" and "period" variables. The "freq" is
+// CPU frequency in Hz and the period in uSeconds. The timer is held in
+// the stopped state after configuration.
+//
+void
+configCPUTimer(uint32_t cpuTimer, uint32_t period)
+{
+    uint32_t temp, freq = DEVICE_SYSCLK_FREQ;
+
+    //
+    // Initialize timer period:
+    //
+    temp = ((freq / 1000000) * period);
+    CPUTimer_setPeriod(cpuTimer, temp);
+
+    //
+    // Set pre-scale counter to divide by 1 (SYSCLKOUT):
+    //
+    CPUTimer_setPreScaler(cpuTimer, 0);
+
+    //
+    // Initializes timer control register. The timer is stopped, reloaded,
+    // free run disabled, and interrupt enabled.
+    // Additionally, the free and soft bits are set
+    //
+    CPUTimer_stopTimer(cpuTimer);
+    CPUTimer_reloadTimerCounter(cpuTimer);
+    CPUTimer_setEmulationMode(cpuTimer,
+                              CPUTIMER_EMULATIONMODE_STOPAFTERNEXTDECREMENT);
+    CPUTimer_enableInterrupt(cpuTimer);
+
+}
+
+//-------------------------------------------------------------------------------------------------
+void vApplicationSetupTimerInterrupt( void )
+{
+    // Start the timer than activate timer interrupt to switch into first task.
+    Interrupt_register(INT_TIMER2, &portTICK_ISR);
+
+    CPUTimer_setPeriod(CPUTIMER2_BASE, 0xFFFFFFFF);
+    CPUTimer_setPreScaler(CPUTIMER2_BASE, 0);
+    CPUTimer_stopTimer(CPUTIMER2_BASE);
+    CPUTimer_reloadTimerCounter(CPUTIMER2_BASE);
+
+    configCPUTimer(CPUTIMER2_BASE, 1000000 / configTICK_RATE_HZ);
+
+    CPUTimer_enableInterrupt(CPUTIMER2_BASE);
+
+    Interrupt_enable(INT_TIMER2);
+    CPUTimer_startTimer(CPUTIMER2_BASE);
+
+}
+
+//-------------------------------------------------------------------------------------------------
+interrupt void timer1_ISR( void )
+{
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+    xSemaphoreGiveFromISR( xSemaphore, &xHigherPriorityTaskWoken );
+
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+//-------------------------------------------------------------------------------------------------
+static void setupTimer1( void )
+{
+    Interrupt_register(INT_TIMER1, &timer1_ISR);
+
+    CPUTimer_setPeriod(CPUTIMER1_BASE, 0xFFFFFFFF);
+    CPUTimer_setPreScaler(CPUTIMER1_BASE, 0);
+    CPUTimer_stopTimer(CPUTIMER1_BASE);
+    CPUTimer_reloadTimerCounter(CPUTIMER1_BASE);
+
+    configCPUTimer(CPUTIMER1_BASE, 100000);
+
+    CPUTimer_enableInterrupt(CPUTIMER1_BASE);
+
+    Interrupt_enable(INT_TIMER1);
+    CPUTimer_startTimer(CPUTIMER1_BASE);
+}
+
+//-------------------------------------------------------------------------------------------------
+void LED_TaskRed(void * pvParameters)
+{
+    for(;;)
+    {
+        if(xSemaphoreTake( xSemaphore, portMAX_DELAY ) == pdTRUE)
+        {
+            ledToggle((uint32_t)pvParameters);
+        }
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+void LED_TaskBlue(void * pvParameters)
+{
+    for(;;)
+    {
+        ledToggle((uint32_t)pvParameters);
+        vTaskDelay(250 / portTICK_PERIOD_MS);
+    }
+}
+
+//-------------------------------------------------------------------------------------------------
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize )
+{
+    *ppxIdleTaskTCBBuffer = &idleTaskBuffer;
+    *ppxIdleTaskStackBuffer = idleTaskStack;
+    *pulIdleTaskStackSize = STACK_SIZE;
+}
+
+//-------------------------------------------------------------------------------------------------
+void main(void)
+{
+    //
+    // Initializes device clock and peripherals
+    //
+    Device_init();
+
+    //
+    // Initializes PIE and clears PIE registers. Disables CPU interrupts.
+    //
+    Interrupt_initModule();
+
+    Device_initGPIO();
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_LED1, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_LED1, GPIO_DIR_MODE_OUT);
+    GPIO_setPadConfig(DEVICE_GPIO_PIN_LED2, GPIO_PIN_TYPE_STD);
+    GPIO_setDirectionMode(DEVICE_GPIO_PIN_LED2, GPIO_DIR_MODE_OUT);
+
+    GPIO_writePin(DEVICE_GPIO_PIN_LED1, 1);
+    GPIO_writePin(DEVICE_GPIO_PIN_LED2, 1);
+
+    // Step 3. Clear all interrupts and initialize PIE vector table:
+    // Disable CPU interrupts
+    DINT;
+
+
+    // Disable CPU interrupts and clear all CPU interrupt flags:
+    IER = 0x0000;
+    IFR = 0x0000;
+
+    //
+    // Initializes the PIE vector table with pointers to the shell Interrupt
+    // Service Routines (ISR).
+    //
+    Interrupt_initVectorTable();
+
+    xSemaphore = xSemaphoreCreateBinaryStatic( &xSemaphoreBuffer );
+
+    setupTimer1();
+
+    // Enable global Interrupts and higher priority real-time debug events:
+    EINT;  // Enable Global interrupt INTM
+    ERTM;  // Enable Global realtime interrupt DBGM
+
+    // Create the task without using any dynamic memory allocation.
+    xTaskCreateStatic(LED_TaskRed,          // Function that implements the task.
+                      "Red LED task",       // Text name for the task.
+                      STACK_SIZE,           // Number of indexes in the xStack array.
+                      ( void * ) RED,       // Parameter passed into the task.
+                      tskIDLE_PRIORITY + 2, // Priority at which the task is created.
+                      redTaskStack,         // Array to use as the task's stack.
+                      &redTaskBuffer );     // Variable to hold the task's data structure.
+
+    xTaskCreateStatic(LED_TaskBlue,         // Function that implements the task.
+                      "Blue LED task",      // Text name for the task.
+                      STACK_SIZE,           // Number of indexes in the xStack array.
+                      ( void * ) BLUE,      // Parameter passed into the task.
+                      tskIDLE_PRIORITY + 1, // Priority at which the task is created.
+                      blueTaskStack,        // Array to use as the task's stack.
+                      &blueTaskBuffer );    // Variable to hold the task's data structure.
+
+    vTaskStartScheduler();
+}

--- a/C2000_F2838x_C28x_CCS/port_validation/2838x_FreeRTOS_FLASH_lnk_cpu1.cmd
+++ b/C2000_F2838x_C28x_CCS/port_validation/2838x_FreeRTOS_FLASH_lnk_cpu1.cmd
@@ -1,0 +1,169 @@
+
+MEMORY
+{
+   /* BEGIN is used for the "boot to Flash" bootloader mode   */
+   BEGIN            : origin = 0x080000, length = 0x000002
+   BOOT_RSVD        : origin = 0x000002, length = 0x0001AF     /* Part of M0, BOOT rom will use this for stack */
+   RAMM0            : origin = 0x0001B1, length = 0x00024F
+   RAMM1            : origin = 0x000400, length = 0x0003F8     /* on-chip RAM block M1 */
+//   RAMM1_RSVD       : origin = 0x0007F8, length = 0x000008     /* Reserve and do not use for code as per the errata advisory "Memory: Prefetching Beyond Valid Memory" */
+
+   /*
+   RAMLS0           : origin = 0x008000, length = 0x000800
+   RAMLS1           : origin = 0x008800, length = 0x000800
+   RAMLS2           : origin = 0x009000, length = 0x000800
+   RAMLS3           : origin = 0x009800, length = 0x000800
+   RAMLS4           : origin = 0x00A000, length = 0x000800
+   RAMLS5           : origin = 0x00A800, length = 0x000800
+   RAMLS6           : origin = 0x00B000, length = 0x000800
+   RAMLS7           : origin = 0x00B800, length = 0x000800
+   */
+
+   RAMLSxDxGSx      : origin = 0x008000, length = 0x008000
+   RAMGSx           : origin = 0x010000, length = 0x00CFF8
+   /*
+   RAMD0            : origin = 0x00C000, length = 0x000800
+   RAMD1            : origin = 0x00C800, length = 0x000800
+   RAMGS0           : origin = 0x00D000, length = 0x001000
+   RAMGS1           : origin = 0x00E000, length = 0x001000
+   RAMGS2           : origin = 0x00F000, length = 0x001000
+   RAMGS3           : origin = 0x010000, length = 0x001000
+   RAMGS4           : origin = 0x011000, length = 0x001000
+   RAMGS5           : origin = 0x012000, length = 0x001000
+   RAMGS6           : origin = 0x013000, length = 0x001000
+   RAMGS7           : origin = 0x014000, length = 0x001000
+   RAMGS8           : origin = 0x015000, length = 0x001000
+   RAMGS9           : origin = 0x016000, length = 0x001000
+   RAMGS10          : origin = 0x017000, length = 0x001000
+   RAMGS11          : origin = 0x018000, length = 0x001000
+   RAMGS12          : origin = 0x019000, length = 0x001000
+   RAMGS13          : origin = 0x01A000, length = 0x001000
+   RAMGS14          : origin = 0x01B000, length = 0x001000
+   RAMGS15          : origin = 0x01C000, length = 0x000FF8
+   */
+
+//   RAMGS15_RSVD     : origin = 0x01CFF8, length = 0x000008     /* Reserve and do not use for code as per the errata advisory "Memory: Prefetching Beyond Valid Memory" */
+
+   /* Flash sectors */
+   FLASH0           : origin = 0x080002, length = 0x001FFE  /* on-chip Flash */
+   FLASH1           : origin = 0x082000, length = 0x002000  /* on-chip Flash */
+   FLASH2           : origin = 0x084000, length = 0x002000  /* on-chip Flash */
+   FLASH3           : origin = 0x086000, length = 0x002000  /* on-chip Flash */
+   FLASH4           : origin = 0x088000, length = 0x008000  /* on-chip Flash */
+   FLASH5           : origin = 0x090000, length = 0x008000  /* on-chip Flash */
+   FLASH6           : origin = 0x098000, length = 0x008000  /* on-chip Flash */
+   FLASH7           : origin = 0x0A0000, length = 0x008000  /* on-chip Flash */
+   FLASH8           : origin = 0x0A8000, length = 0x008000  /* on-chip Flash */
+   FLASH9           : origin = 0x0B0000, length = 0x008000  /* on-chip Flash */
+   FLASH10          : origin = 0x0B8000, length = 0x002000  /* on-chip Flash */
+   FLASH11          : origin = 0x0BA000, length = 0x002000  /* on-chip Flash */
+   FLASH12          : origin = 0x0BC000, length = 0x002000  /* on-chip Flash */
+   FLASH13          : origin = 0x0BE000, length = 0x001FF0  /* on-chip Flash */
+//   FLASH13_RSVD     : origin = 0x0BFFF0, length = 0x000010  /* Reserve and do not use for code as per the errata advisory "Memory: Prefetching Beyond Valid Memory" */
+
+   CPU1TOCPU2RAM   : origin = 0x03A000, length = 0x000800
+   CPU2TOCPU1RAM   : origin = 0x03B000, length = 0x000800
+   CPUTOCMRAM      : origin = 0x039000, length = 0x000800
+   CMTOCPURAM      : origin = 0x038000, length = 0x000800
+
+   CANA_MSG_RAM     : origin = 0x049000, length = 0x000800
+   CANB_MSG_RAM     : origin = 0x04B000, length = 0x000800
+
+   RESET            : origin = 0x3FFFC0, length = 0x000002
+}
+
+SECTIONS
+{
+   codestart           : > BEGIN, ALIGN(8)
+   .text               : >> FLASH1 | FLASH2 | FLASH3 | FLASH4, ALIGN(8)
+   .cinit              : > FLASH4, ALIGN(8)
+   .switch             : > FLASH1, ALIGN(8)
+   .reset              : > RESET, TYPE = DSECT /* not used, */
+   .stack              : > RAMLSxDxGSx
+
+#if defined(__TI_EABI__)
+   .init_array      : > FLASH1, ALIGN(8)
+   .bss             : > RAMGSx
+   .bss:output      : > RAMGSx
+   .bss:cio         : > RAMM0
+   .data            : > RAMGSx
+   .sysmem          : > RAMLSxDxGSx
+   .rtosstatic
+   {
+     freertos_ex1_c28x_port_val.obj(.bss)
+   } >> RAMM1 | RAMM0
+   .bssPortHeap
+   {
+     heap_4.obj (.bss)
+   } >> RAMLSxDxGSx
+
+   /* Initalized sections go in Flash */
+   .const           : > FLASH5, ALIGN(8)
+#else
+   .pinit           : > FLASH1, ALIGN(8)
+   .ebss            : > RAMGSx
+   .esysmem         : > RAMLSxDxGSx
+   .cio             : > RAMM0
+   /* Initalized sections go in Flash */
+   .econst          : >> FLASH4 | FLASH5, ALIGN(8)
+   .ertosstatic
+   {
+     freertos_testproj1_c28x.obj(.ebss)
+   } >> RAMM1 | RAMM0
+   .ebssPortHeap
+   {
+     heap_4.obj (.ebss)
+   } >> RAMLSxDxGSx
+#endif
+
+/*
+   ramgs0 : > RAMGS0, type=NOINIT
+   ramgs1 : > RAMGS1, type=NOINIT
+   */
+   
+   ramm0 : > RAMM0, type=NOINIT
+   ramm1 : > RAMM1, type=NOINIT
+   MSGRAM_CPU1_TO_CPU2 : > CPU1TOCPU2RAM, type=NOINIT
+   MSGRAM_CPU2_TO_CPU1 : > CPU2TOCPU1RAM, type=NOINIT
+   MSGRAM_CPU_TO_CM    : > CPUTOCMRAM, type=NOINIT
+   MSGRAM_CM_TO_CPU    : > CMTOCPURAM, type=NOINIT
+
+   /* The following section definition are for SDFM examples */
+   /*
+   Filter_RegsFile  : > RAMGS0
+   Filter1_RegsFile : > RAMGS1, fill=0x1111
+   Filter2_RegsFile : > RAMGS2, fill=0x2222
+   Filter3_RegsFile : > RAMGS3, fill=0x3333
+   Filter4_RegsFile : > RAMGS4, fill=0x4444
+   Difference_RegsFile : >RAMGS5, fill=0x3333
+   */
+
+   #if defined(__TI_EABI__)
+       .TI.ramfunc : {} LOAD = FLASH3,
+                        RUN = RAMGSx,
+                        LOAD_START(RamfuncsLoadStart),
+                        LOAD_SIZE(RamfuncsLoadSize),
+                        LOAD_END(RamfuncsLoadEnd),
+                        RUN_START(RamfuncsRunStart),
+                        RUN_SIZE(RamfuncsRunSize),
+                        RUN_END(RamfuncsRunEnd),
+                        ALIGN(8)
+   #else
+       .TI.ramfunc : {} LOAD = FLASH3,
+                        RUN = RAMGSx,
+                        LOAD_START(_RamfuncsLoadStart),
+                        LOAD_SIZE(_RamfuncsLoadSize),
+                        LOAD_END(_RamfuncsLoadEnd),
+                        RUN_START(_RamfuncsRunStart),
+                        RUN_SIZE(_RamfuncsRunSize),
+                        RUN_END(_RamfuncsRunEnd),
+                        ALIGN(8)
+   #endif
+
+}
+
+/*
+//===========================================================================
+// End of file.
+//===========================================================================
+*/

--- a/C2000_F2838x_C28x_CCS/port_validation/FreeRTOSConfig.h
+++ b/C2000_F2838x_C28x_CCS/port_validation/FreeRTOSConfig.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2021 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+/* Constants related to the behaviour or the scheduler. */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION  0
+#define configTICK_RATE_HZ                  ( ( portTickType ) 1000 )
+#define configUSE_PREEMPTION                1
+#define configUSE_TIME_SLICING              1
+#define configMAX_PRIORITIES                16
+#define configIDLE_SHOULD_YIELD             1
+#define configUSE_16_BIT_TICKS              0 /* Only for 8 and 16-bit hardware. */
+
+/* Constants used to specify if only static allocation is to be supported (in
+which case a heap_n.c file is not required), only dynamic allocation is to be
+supported, or if both static and dynamic allocation are supported. */
+#define configSUPPORT_STATIC_ALLOCATION         1
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+//#define configAPPLICATION_ALLOCATED_HEAP        1
+
+/* Constants that describe the hardware and memory usage. */
+#define configCPU_CLOCK_HZ                  ( ( unsigned long ) 200000000 )
+#define configMINIMAL_STACK_SIZE                ( ( uint16_t ) 256 )
+#define configMAX_TASK_NAME_LEN                 ( 12 )
+
+/* Note heap_5.c is used so this only defines the part of the heap that is in
+the first block of RAM on the LPC device.  See the initialisation of the heap
+in main.c. */
+#define configTOTAL_HEAP_SIZE                   ( ( size_t ) ( 32000 ) )
+
+/* Constants that build features in or out. */
+#define configUSE_MUTEXES                       1
+#define configUSE_TICKLESS_IDLE                 0
+#define configUSE_APPLICATION_TASK_TAG          0
+#define configUSE_NEWLIB_REENTRANT              0
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES     ( 2 )
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_QUEUE_SETS                    1
+#define configUSE_TASK_NOTIFICATIONS            1
+
+/* Constants that define which hook (callback) functions should be used. */
+#define configUSE_IDLE_HOOK                     1
+#define configUSE_TICK_HOOK                     1
+#define configUSE_MALLOC_FAILED_HOOK            1
+
+/* Constants provided for debugging and optimisation assistance. */
+#define configCHECK_FOR_STACK_OVERFLOW          2
+void vMainAssertCalled( const char *pcFileName, uint32_t ulLineNumber );
+#define configASSERT( x ) if( ( x ) == 0 ) { vMainAssertCalled( __FILE__, __LINE__ ); }
+#define configQUEUE_REGISTRY_SIZE               10
+
+/* Software timer definitions. */
+#define configUSE_TIMERS                        1
+#define configTIMER_TASK_PRIORITY               ( 3 )
+#define configTIMER_QUEUE_LENGTH                5
+#define configTIMER_TASK_STACK_DEPTH            ( configMINIMAL_STACK_SIZE  )
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function.  NOTE:  Setting an INCLUDE_ parameter to 0 is only
+necessary if the linker does not automatically remove functions that are not
+referenced anyway. */
+#define INCLUDE_vTaskPrioritySet                1
+#define INCLUDE_uxTaskPriorityGet               1
+#define INCLUDE_vTaskDelete                     1
+#define INCLUDE_vTaskCleanUpResources           0
+#define INCLUDE_vTaskSuspend                    1
+#define INCLUDE_vTaskDelayUntil                 1
+#define INCLUDE_vTaskDelay                      1
+#define INCLUDE_uxTaskGetStackHighWaterMark     0
+#define INCLUDE_xTaskGetIdleTaskHandle          0
+#define INCLUDE_xTaskGetHandle                  1
+#define INCLUDE_eTaskGetState                   1
+#define INCLUDE_xTaskResumeFromISR              0
+#define INCLUDE_xTaskGetCurrentTaskHandle       1
+#define INCLUDE_xTaskGetSchedulerState          0
+#define INCLUDE_xSemaphoreGetMutexHolder        1
+#define INCLUDE_xTimerPendFunctionCall          1
+
+//
+// Adding for test project
+//
+#define INCLUDE_xTaskAbortDelay                 1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+format the raw data provided by the uxTaskGetSystemState() function in to human
+readable ASCII form.  See the notes in the implementation of vTaskList() within
+FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+/* Dimensions a buffer that can be used by the FreeRTOS+CLI command
+interpreter.  See the FreeRTOS+CLI documentation for more information:
+http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_CLI/ */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE       2048
+
+/* The trace facility is turned on to make some functions available for use in
+CLI commands. */
+#define configUSE_TRACE_FACILITY            1
+
+/* Constants related to the generation of run time stats. */
+#define configGENERATE_RUN_TIME_STATS           0
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
+#define portGET_RUN_TIME_COUNTER_VALUE()        0
+
+/* The test that checks the trigger level on stream buffers requires an
+allowable margin of error on slower processors (slower than the Win32
+machine on which the test is developed). */
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN   4
+
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES 3
+#define configPRINTF( X ) printf( X )
+
+// Minimal Test related configuration
+#define TESTGROUP      2                     // Selects appropriate test group
+#if(TESTGROUP == 1)
+#define configSTART_TASK_NOTIFY_TESTS             1
+#define configSTART_TASK_NOTIFY_ARRAY_TESTS       1
+#define configSTART_BLOCKING_QUEUE_TESTS          1
+#define configSTART_SEMAPHORE_TESTS               1
+#define configSTART_POLLED_QUEUE_TESTS            1
+#define configSTART_INTEGER_MATH_TESTS            1
+#define configSTART_GENERIC_QUEUE_TESTS           1
+#define configSTART_PEEK_QUEUE_TESTS              1
+#define configSTART_MATH_TESTS                    1
+#elif(TESTGROUP == 2)
+#define configSTART_RECURSIVE_MUTEX_TESTS         1
+#define configSTART_COUNTING_SEMAPHORE_TESTS      1
+#define configSTART_QUEUE_SET_TESTS               1
+#define configSTART_QUEUE_OVERWRITE_TESTS         1
+#define configSTART_EVENT_GROUP_TESTS             1
+#define configSTART_INTERRUPT_SEMAPHORE_TESTS     1
+#define configSTART_QUEUE_SET_POLLING_TESTS       1
+#define configSTART_BLOCK_TIME_TESTS              1
+#define configSTART_ABORT_DELAY_TESTS             1
+#define configSTART_MESSAGE_BUFFER_TESTS          1
+#define configSTART_STREAM_BUFFER_TESTS           1
+#define configSTART_STREAM_BUFFER_INTERRUPT_TESTS 1
+#define configSTART_TIMER_TESTS                   1
+#define configSTART_INTERRUPT_QUEUE_TESTS         0
+#define configSTART_REGISTER_TESTS                1
+#define configSTART_DELETE_SELF_TESTS             1
+#endif
+#endif /* FREERTOS_CONFIG_H */
+

--- a/C2000_F2838x_C28x_CCS/port_validation/README.md
+++ b/C2000_F2838x_C28x_CCS/port_validation/README.md
@@ -1,0 +1,177 @@
+# Create a Test Project
+
+## Initial Setup
+
+1. Create a new directory in the [FreeRTOS Partner Supported Demos Repository](https://github.com/FreeRTOS/FreeRTOS-Partner-Supported-Demos/tree/main)
+   or [FreeRTOS Community Supported Demos Repository](https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos/tree/main).
+   The suggested name for the directory is `<hardware_name>_<compiler_name>`.
+2. Create a project for your hardware and tool-chain in this directory.
+3. Copy all the files in the [FreeRTOS/Demo/ThirdParty/Template](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/ThirdParty/Template)
+   directory to your project directory:
+   * `IntQueueTimer.h`
+   * `IntQueueTimer.c`
+   * `TestRunner.h`
+   * `TestRunner.c`
+   * `RegTests.h`
+   * `RegTests.c`
+
+## Project Configuration
+
+1. Compile the following additional files in your project:
+   * All files in the [FreeRTOS/Demo/Common/Minimal](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/Common/Minimal) directory except
+     `comtest_strings.c`, `crhook.c` , `comtest.c` ,`crflash.c`,`flash.c`, `flash_timer.c` and `sp_flop.c`.
+2. Add the following paths to your include search path:
+   * `FreeRTOS/Demo/Common/include`.
+3. Call the `void vStartTests( void )` function from your `main` function after
+   doing all the hardware initialization. Note that this function starts the
+   scheduler and therefore, never returns.
+```c
+#include "TestRunner.h"
+
+void main( void )
+{
+    /* Startup and Hardware initialization. */
+
+    /* Start tests. */
+    vStartTests();
+
+    /* Should never reach here. */
+    for( ; ; );
+}
+```
+
+## Set up FreeRTOSConfig.h
+
+1. Enable tick hook by adding the following line in your `FreeRTOSConfig.h`:
+```c
+#define configUSE_TICK_HOOK 1
+```
+2. Set the task notification array size to 3 by adding the following line in
+   your `FreeRTOSConfig.h`:
+```c
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES 3
+```
+3. Enable printing by mapping `configPRINTF` to your print function. Note that
+   `configPRINTF` calls are wrapped in double parentheses to support C89. If you
+    have a thread-safe `printf` function, the following is what should be added
+    in your `FreeRTOSConfig.h`:
+```c
+#define configPRINTF( X ) printf X
+```
+4. Add the following defines in your `FreeRTOSConfig.h`:
+```c
+#define configSTART_TASK_NOTIFY_TESTS             0
+#define configSTART_TASK_NOTIFY_ARRAY_TESTS       0
+#define configSTART_BLOCKING_QUEUE_TESTS          0
+#define configSTART_SEMAPHORE_TESTS               0
+#define configSTART_POLLED_QUEUE_TESTS            0
+#define configSTART_INTEGER_MATH_TESTS            0
+#define configSTART_GENERIC_QUEUE_TESTS           0
+#define configSTART_PEEK_QUEUE_TESTS              0
+#define configSTART_MATH_TESTS                    0
+#define configSTART_RECURSIVE_MUTEX_TESTS         0
+#define configSTART_COUNTING_SEMAPHORE_TESTS      0
+#define configSTART_QUEUE_SET_TESTS               0
+#define configSTART_QUEUE_OVERWRITE_TESTS         0
+#define configSTART_EVENT_GROUP_TESTS             0
+#define configSTART_INTERRUPT_SEMAPHORE_TESTS     0
+#define configSTART_QUEUE_SET_POLLING_TESTS       0
+#define configSTART_BLOCK_TIME_TESTS              0
+#define configSTART_ABORT_DELAY_TESTS             0
+#define configSTART_MESSAGE_BUFFER_TESTS          0
+#define configSTART_STREAM_BUFFER_TESTS           0
+#define configSTART_STREAM_BUFFER_INTERRUPT_TESTS 0
+#define configSTART_TIMER_TESTS                   0
+#define configSTART_INTERRUPT_QUEUE_TESTS         0
+#define configSTART_REGISTER_TESTS                0
+#define configSTART_DELETE_SELF_TESTS             0
+```
+
+## Create and Run Register Tests
+
+1. Fill the definitions of the following functions in the `RegTests.c` file
+   copied in the [Initial Setup](#Initial-Setup) step:
+   * `prvRegisterTest1Task`
+   * `prvRegisterTest2Task`
+   * `prvRegisterTest3Task`
+   * `prvRegisterTest4Task`
+2. Define `configSTART_REGISTER_TESTS` to `1` in your `FreeRTOSConfig.h`:
+```c
+#define configSTART_REGISTER_TESTS                1
+```
+3. Build and run the register tests. The output should look like the following:
+```
+No errors
+No errors
+No errors
+No errors
+```
+
+## Setup and Run Interrupt Nesting Tests
+
+1. If your hardware **does not** support interrupt nesting, skip this section.
+2. Fill the `void vInitialiseTimerForIntQueueTest( void )` function in the
+   `IntQueueTimer.c` file copied in the [Initial Setup](#Initial-Setup) step to
+   initialize and start a hardware timer. Make sure that the timer interrupt
+   runs at a logical priority less than or equal to `configMAX_SYSCALL_INTERRUPT_PRIORITY`.
+   The following is an example for ARM MPS2 which starts TIM0 timer:
+```c
+void vInitialiseTimerForIntQueueTest( void )
+{
+    /* Clear interrupt. */
+    CMSDK_TIMER0->INTCLEAR = ( 1ul <<  0 );
+
+    /* Reload value is slightly offset from the other timer. */
+    CMSDK_TIMER0->RELOAD = ( configCPU_CLOCK_HZ / tmrTIMER_0_FREQUENCY ) + 1UL;
+    CMSDK_TIMER0->CTRL   = ( ( 1ul <<  3 ) | ( 1ul <<  0 ) );
+
+    NVIC_SetPriority( TIMER0_IRQn, configMAX_SYSCALL_INTERRUPT_PRIORITY );
+    NVIC_EnableIRQ( TIMER0_IRQn );
+}
+```
+3. Either install `void IntQueueTestTimerHandler( void )` function as the timer
+   interrupt handler or call it from the timer interrupt handler of the above
+   timer. The following is an example for ARM MPS2 which calls
+   `IntQueueTestTimerHandler` from the TIM0 handler:
+```c
+void TIMER0_Handler( void )
+{
+    /* Clear interrupt. */
+    CMSDK_TIMER0->INTCLEAR = ( 1ul <<  0 );
+
+    IntQueueTestTimerHandler();
+}
+```
+4. Define `configSTART_INTERRUPT_QUEUE_TESTS` to `1` in your `FreeRTOSConfig.h`:
+```c
+#define configSTART_INTERRUPT_QUEUE_TESTS         1
+```
+5. Build and run the tests. The output should look like the following:
+```
+No errors
+No errors
+No errors
+No errors
+```
+
+## Running All Tests
+
+1. Define all the `configSTART_<Test_Name>_TESTS` macros to `1` in your 
+`FreeRTOSConfig.h`.
+2. Build and run the tests. The output should look like the following:
+```
+No errors
+No errors
+No errors
+No errors
+```
+3. If you cannot fit all the tests in one binary because of Flash or RAM space,
+you can run tests one by one or in groups by defining
+`configSTART_<Test_Name>_TESTS` macros to `0` or `1` as needed.
+
+## Add README
+Add a `README.md` file in the project directory with the following information:
+* Link to the hardware page.
+* How to setup tool-chain.
+* How to build and run the project.
+* Any other relevant information.

--- a/C2000_F2838x_C28x_CCS/port_validation/RegTests.c
+++ b/C2000_F2838x_C28x_CCS/port_validation/RegTests.c
@@ -1,0 +1,318 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/* Scheduler include files. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Interface include files. */
+#include "RegTests.h"
+
+/* Tasks that implement register tests. */
+static void prvRegisterTest1Task( void *pvParameters );
+static void prvRegisterTest2Task( void *pvParameters );
+static void prvRegisterTest3Task( void *pvParameters );
+static void prvRegisterTest4Task( void *pvParameters );
+
+/* Flag that will be latched to pdTRUE should any unexpected behaviour be
+detected in any of the tasks. */
+static volatile BaseType_t xErrorDetected = pdFALSE;
+
+/* Counters that are incremented on each cycle of a test.  This is used to
+detect a stalled task - a test that is no longer running. */
+static volatile uint32_t ulRegisterTest1Counter = 0;
+static volatile uint32_t ulRegisterTest2Counter = 0;
+static volatile uint32_t ulRegisterTest3Counter = 0;
+static volatile uint32_t ulRegisterTest4Counter = 0;
+/*-----------------------------------------------------------*/
+
+static void prvRegisterTest1Task( void *pvParameters )
+{
+	( void ) pvParameters;
+
+//	for( ; ; )
+//	{
+	    /* 1. Fill the registers stored as part of task context with known values.*/
+	    __asm("reg1_loop:                    \n"                       \
+	          " movl xar2, #0xFFFF           \n"                       \
+              " movl xar3, #0xF0F0           \n"                       \
+              " movl xar4, #0x1010           \n"                       \
+              " movl xar5, #0x0101           \n"                       \
+              " movl xar6, #0x1111           \n"                       \
+              " movl xar7, #0x2222           \n"                       \
+	         );
+
+		/* 2. Force a context switch. */
+	    vTaskDelay(0);
+	    /* 3. Verify that all the registers contain expected values.*/
+	    /* 4. If all the register contain expected values, increment ulRegisterTest1Counter.*/
+        __asm(" mov acc, #0xFFFF           \n"                        \
+              " cmpl acc,@xar2              \n"                       \
+              " sb reg1_error_loop,neq      \n"                       \
+              " mov acc, #0xF0F0           \n"                        \
+              " cmpl acc,@xar3              \n"                        \
+              " sb reg1_error_loop,neq      \n"                        \
+              " mov acc, #0x1010           \n"                        \
+              " cmpl acc,@xar4              \n"                        \
+              " sb reg1_error_loop,neq      \n"                        \
+              " mov acc, #0x0101           \n"                        \
+              " cmpl acc,@xar5              \n"                        \
+              " sb reg1_error_loop,neq      \n"                        \
+              " mov acc, #0x1111           \n"                        \
+              " cmpl acc,@xar6              \n"                        \
+              " sb reg1_error_loop,neq      \n"                        \
+              " mov acc, #0x2222           \n"                        \
+              " cmpl acc,@xar7              \n"                        \
+              " sb reg1_error_loop,neq      \n"                        \
+              "* Increment the loop counter to indicate this test is still functioning \n" \
+              " movl xar0, #ulRegisterTest1Counter  \n"                \
+              " mov acc, *xar0                      \n"                \
+              " add acc, #1                         \n"                \
+              " movl *xar0,acc                      \n"                \
+              " sb reg1_loop,unc                    \n"                \
+              "reg1_error_loop:                     \n"                \
+              "* If this line is hit then there was an error in a core register value.   \n" \
+              "*This loop ensures the loop counter variable stops incrementing.          \n" \
+              " sb reg1_error_loop,unc                   \n"
+             );
+//	}
+}
+/*-----------------------------------------------------------*/
+
+static void prvRegisterTest2Task( void *pvParameters )
+{
+	( void ) pvParameters;
+
+//	for( ; ; )
+//	{
+	    /* 1. Fill the registers stored as part of task context with known values.*/
+        __asm("reg2_loop:                    \n"                       \
+              " movl xar2, #0x3333           \n"                       \
+              " movl xar3, #0x4444           \n"                       \
+              " movl xar4, #0x5555           \n"                       \
+              " movl xar5, #0x6666           \n"                       \
+              " movl xar6, #0x7777           \n"                       \
+              " movl xar7, #0x8888           \n"                       \
+             );
+
+        /* 2. Force a context switch. */
+        vTaskDelay(0);
+        /* 3. Verify that all the registers contain expected values.*/
+        /* 4. If all the register contain expected values, increment ulRegisterTest1Counter.*/
+        __asm(" mov acc, #0x3333            \n"                        \
+              " cmpl acc,@xar2              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              " mov acc, #0x4444            \n"                        \
+              " cmpl acc,@xar3              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              " mov acc, #0x5555            \n"                        \
+              " cmpl acc,@xar4              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              " mov acc, #0x6666            \n"                        \
+              " cmpl acc,@xar5              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              " mov acc, #0x7777            \n"                        \
+              " cmpl acc,@xar6              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              " mov acc, #0x8888            \n"                        \
+              " cmpl acc,@xar7              \n"                        \
+              " sb reg2_error_loop,neq      \n"                        \
+              "* Increment the loop counter to indicate this test is still functioning \n" \
+              " movl xar0, #ulRegisterTest2Counter  \n"                \
+              " mov acc, *xar0                      \n"                \
+              " add acc, #1                         \n"                \
+              " movl *xar0,acc                      \n"                \
+              " sb reg2_loop,unc                    \n"                \
+              "reg2_error_loop:                     \n"                \
+              "* If this line is hit then there was an error in a core register value.   \n" \
+              "*This loop ensures the loop counter variable stops incrementing.          \n" \
+              " sb reg2_error_loop,unc              \n"
+             );
+//	}
+}
+/*-----------------------------------------------------------*/
+
+static void prvRegisterTest3Task( void *pvParameters )
+{
+	( void ) pvParameters;
+
+//	for( ; ; )
+//	{
+	    /* 1. Fill the registers stored as part of task context with known values.*/
+        __asm("reg3_loop:                    \n"                       \
+              " movl xar2, #0x1111           \n"                       \
+              " movl xar3, #0x2222           \n"                       \
+              " movl xar4, #0x3333           \n"                       \
+              " movl xar5, #0xAAAA           \n"                       \
+              " movl xar6, #0xBBBB           \n"                       \
+              " movl xar7, #0xCCCC           \n"                       \
+             );
+
+        /* 2. Force a context switch. */
+        vTaskDelay(0);
+        /* 3. Verify that all the registers contain expected values.*/
+        /* 4. If all the register contain expected values, increment ulRegisterTest3Counter.*/
+        __asm(" mov acc, #0x1111            \n"                        \
+              " cmpl acc,@xar2              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              " mov acc, #0x2222            \n"                        \
+              " cmpl acc,@xar3              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              " mov acc, #0x3333            \n"                        \
+              " cmpl acc,@xar4              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              " mov acc, #0xAAAA            \n"                        \
+              " cmpl acc,@xar5              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              " mov acc, #0xBBBB            \n"                        \
+              " cmpl acc,@xar6              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              " mov acc, #0xCCCC            \n"                        \
+              " cmpl acc,@xar7              \n"                        \
+              " sb reg3_error_loop,neq      \n"                        \
+              "* Increment the loop counter to indicate this test is still functioning \n" \
+              " movl xar0, #ulRegisterTest3Counter  \n"                \
+              " mov acc, *xar0                      \n"                \
+              " add acc, #1                         \n"                \
+              " movl *xar0,acc                      \n"                \
+              " sb reg3_loop,unc                    \n"                \
+              "reg3_error_loop:                     \n"                \
+              "* If this line is hit then there was an error in a core register value.   \n" \
+              "*This loop ensures the loop counter variable stops incrementing.          \n" \
+              " sb reg3_error_loop,unc                   \n"
+             );
+//	}
+}
+/*-----------------------------------------------------------*/
+
+static void prvRegisterTest4Task( void *pvParameters )
+{
+	( void ) pvParameters;
+
+//	for( ; ; )
+//	{
+	    /* 1. Fill the registers stored as part of task context with known values.*/
+        __asm("reg4_loop:                    \n"                       \
+              " movl xar2, #0xDDDD           \n"                       \
+              " movl xar3, #0xEEEE           \n"                       \
+              " movl xar4, #0xFFFF           \n"                       \
+              " movl xar5, #0x9999           \n"                       \
+              " movl xar6, #0x8888           \n"                       \
+              " movl xar7, #0x7777           \n"                       \
+             );
+
+        /* 2. Force a context switch. */
+        vTaskDelay(0);
+        /* 3. Verify that all the registers contain expected values.*/
+        /* 4. If all the register contain expected values, increment ulRegisterTest1Counter.*/
+        __asm(" mov acc, #0xDDDD            \n"                        \
+              " cmpl acc,@xar2              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              " mov acc, #0xEEEE            \n"                        \
+              " cmpl acc,@xar3              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              " mov acc, #0xFFFF            \n"                        \
+              " cmpl acc,@xar4              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              " mov acc, #0x9999            \n"                        \
+              " cmpl acc,@xar5              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              " mov acc, #0x8888            \n"                        \
+              " cmpl acc,@xar6              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              " mov acc, #0x7777            \n"                        \
+              " cmpl acc,@xar7              \n"                        \
+              " sb reg4_error_loop,neq      \n"                        \
+              "* Increment the loop counter to indicate this test is still functioning \n" \
+              " movl xar0, #ulRegisterTest4Counter  \n"                \
+              " mov acc, *xar0                      \n"                \
+              " add acc, #1                         \n"                \
+              " movl *xar0,acc                      \n"                \
+              " sb reg4_loop,unc                    \n"                \
+              "reg4_error_loop:                     \n"                \
+              "* If this line is hit then there was an error in a core register value.   \n" \
+              "*This loop ensures the loop counter variable stops incrementing.          \n" \
+              " sb reg4_error_loop,unc                   \n"
+             );
+//	}
+}
+/*-----------------------------------------------------------*/
+
+void vStartRegisterTasks( UBaseType_t uxPriority )
+{
+	BaseType_t ret;
+
+	ret = xTaskCreate( prvRegisterTest1Task, "RegTest1", configMINIMAL_STACK_SIZE, NULL, uxPriority, NULL );
+	configASSERT( ret == pdPASS );
+
+	ret = xTaskCreate( prvRegisterTest2Task, "RegTest2", configMINIMAL_STACK_SIZE, NULL, uxPriority, NULL );
+	configASSERT( ret == pdPASS );
+
+	ret = xTaskCreate( prvRegisterTest3Task, "RegTest3", configMINIMAL_STACK_SIZE, NULL, uxPriority, NULL );
+	configASSERT( ret == pdPASS );
+
+	ret = xTaskCreate( prvRegisterTest4Task, "RegTest4", configMINIMAL_STACK_SIZE, NULL, uxPriority, NULL );
+	configASSERT( ret == pdPASS );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xAreRegisterTasksStillRunning( void )
+{
+static uint32_t ulLastRegisterTest1Counter = 0, ulLastRegisterTest2Counter = 0;
+static uint32_t ulLastRegisterTest3Counter = 0, ulLastRegisterTest4Counter = 0;
+
+	/* If the register test task is still running then we expect the loop
+	 * counters to have incremented since this function was last called. */
+	if( ulLastRegisterTest1Counter == ulRegisterTest1Counter )
+	{
+		xErrorDetected = pdTRUE;
+	}
+
+	if( ulLastRegisterTest2Counter == ulRegisterTest2Counter )
+	{
+		xErrorDetected = pdTRUE;
+	}
+
+	if( ulLastRegisterTest3Counter == ulRegisterTest3Counter )
+	{
+		xErrorDetected = pdTRUE;
+	}
+
+	if( ulLastRegisterTest4Counter == ulRegisterTest4Counter )
+	{
+		xErrorDetected = pdTRUE;
+	}
+
+	ulLastRegisterTest1Counter = ulRegisterTest1Counter;
+	ulLastRegisterTest2Counter = ulRegisterTest2Counter;
+	ulLastRegisterTest3Counter = ulRegisterTest3Counter;
+	ulLastRegisterTest4Counter = ulRegisterTest4Counter;
+
+	/* Errors detected in the task itself will have latched xErrorDetected
+	 * to true. */
+	return ( BaseType_t ) !xErrorDetected;
+}
+/*-----------------------------------------------------------*/

--- a/C2000_F2838x_C28x_CCS/port_validation/RegTests.h
+++ b/C2000_F2838x_C28x_CCS/port_validation/RegTests.h
@@ -1,0 +1,33 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+#ifndef REG_TEST_H
+#define REG_TEST_H
+
+void vStartRegisterTasks( UBaseType_t uxPriority );
+BaseType_t xAreRegisterTasksStillRunning( void );
+
+#endif /* REG_TEST_H */

--- a/C2000_F2838x_C28x_CCS/port_validation/TestRunner.c
+++ b/C2000_F2838x_C28x_CCS/port_validation/TestRunner.c
@@ -1,0 +1,687 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/* Standard includes. */
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "timers.h"
+#include "semphr.h"
+
+/* Various test includes. */
+#include "BlockQ.h"
+#include "integer.h"
+#include "semtest.h"
+#include "PollQ.h"
+#include "GenQTest.h"
+#include "QPeek.h"
+#include "recmutex.h"
+#include "flop.h"
+#include "TimerDemo.h"
+#include "countsem.h"
+#include "death.h"
+#include "QueueSet.h"
+#include "QueueOverwrite.h"
+#include "EventGroupsDemo.h"
+#include "IntSemTest.h"
+#include "IntQueue.h"
+#include "TaskNotify.h"
+#include "TaskNotifyArray.h"
+#include "QueueSetPolling.h"
+#include "StaticAllocation.h"
+#include "blocktim.h"
+#include "AbortDelay.h"
+#include "MessageBufferDemo.h"
+#include "StreamBufferDemo.h"
+#include "StreamBufferInterrupt.h"
+#include "RegTests.h"
+
+#include "sci.h"
+#include <string.h>
+
+/*
+ * Check free heap size
+ */
+size_t freeHeapVar = 0, freeHeapMinVar = 0;
+
+/*
+ * Toggles the LED built onto the Launchpad hardware.
+ */
+extern void vMainToggleLED( void );
+
+/**
+ * Priorities at which the tasks are created.
+ */
+#define testrunnerCHECK_TASK_PRIORITY			( configMAX_PRIORITIES - 2 )
+#define testrunnerQUEUE_POLL_PRIORITY			( tskIDLE_PRIORITY + 1 )
+#define testrunnerSEM_TEST_PRIORITY				( tskIDLE_PRIORITY + 1 )
+#define testrunnerBLOCK_Q_PRIORITY				( tskIDLE_PRIORITY + 2 )
+#define testrunnerCREATOR_TASK_PRIORITY			( tskIDLE_PRIORITY + 3 )
+#define testrunnerFLASH_TASK_PRIORITY			( tskIDLE_PRIORITY + 1 )
+#define testrunnerINTEGER_TASK_PRIORITY			( tskIDLE_PRIORITY )
+#define testrunnerGEN_QUEUE_TASK_PRIORITY		( tskIDLE_PRIORITY )
+#define testrunnerFLOP_TASK_PRIORITY			( tskIDLE_PRIORITY )
+#define testrunnerQUEUE_OVERWRITE_PRIORITY		( tskIDLE_PRIORITY )
+#define testrunnerREGISTER_TEST_PRIORITY		( tskIDLE_PRIORITY )
+
+/**
+ * Period used in timer tests.
+ */
+#define testrunnerTIMER_TEST_PERIOD				( 50 )
+/*-----------------------------------------------------------*/
+
+/**
+ * The variable into which error messages are latched.
+ */
+static char *pcStatusMessage = "No errors";
+/*-----------------------------------------------------------*/
+
+/**
+ * The task that periodically checks that all the standard demo tasks are
+ * still executing and error free.
+ */
+static void prvCheckTask( void *pvParameters );
+/*-----------------------------------------------------------*/
+
+void vStartTests( void )
+{
+	BaseType_t xResult;
+
+	xResult = xTaskCreate( prvCheckTask,
+						  "Check",
+						  configMINIMAL_STACK_SIZE,
+						  NULL,
+						  testrunnerCHECK_TASK_PRIORITY,
+						  NULL );
+
+	if( xResult == pdPASS )
+	{
+		#if( configSTART_TASK_NOTIFY_TESTS == 1 )
+		{
+			vStartTaskNotifyTask();
+		}
+		#endif /* configSTART_TASK_NOTIFY_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_TASK_NOTIFY_ARRAY_TESTS == 1 )
+		{
+			vStartTaskNotifyArrayTask();
+		}
+		#endif /* configSTART_TASK_NOTIFY_ARRAY_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_BLOCKING_QUEUE_TESTS == 1 )
+		{
+			vStartBlockingQueueTasks( testrunnerBLOCK_Q_PRIORITY );
+		}
+		#endif /* configSTART_BLOCKING_QUEUE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_SEMAPHORE_TESTS == 1 )
+		{
+			vStartSemaphoreTasks( testrunnerSEM_TEST_PRIORITY );
+		}
+		#endif /* configSTART_SEMAPHORE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_POLLED_QUEUE_TESTS == 1 )
+		{
+			vStartPolledQueueTasks( testrunnerQUEUE_POLL_PRIORITY );
+		}
+		#endif /* configSTART_POLLED_QUEUE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_INTEGER_MATH_TESTS == 1 )
+		{
+			vStartIntegerMathTasks( testrunnerINTEGER_TASK_PRIORITY );
+		}
+		#endif /* configSTART_INTEGER_MATH_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_GENERIC_QUEUE_TESTS == 1 )
+		{
+			vStartGenericQueueTasks( testrunnerGEN_QUEUE_TASK_PRIORITY );
+		}
+		#endif /* configSTART_GENERIC_QUEUE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_PEEK_QUEUE_TESTS == 1 )
+		{
+			vStartQueuePeekTasks();
+		}
+		#endif /* configSTART_PEEK_QUEUE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_MATH_TESTS == 1 )
+		{
+			vStartMathTasks( testrunnerFLOP_TASK_PRIORITY );
+		}
+		#endif /* configSTART_MATH_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_RECURSIVE_MUTEX_TESTS == 1 )
+		{
+			vStartRecursiveMutexTasks();
+		}
+		#endif /* configSTART_RECURSIVE_MUTEX_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_COUNTING_SEMAPHORE_TESTS == 1 )
+		{
+			vStartCountingSemaphoreTasks();
+		}
+		#endif /* configSTART_COUNTING_SEMAPHORE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_QUEUE_SET_TESTS == 1 )
+		{
+			vStartQueueSetTasks();
+		}
+		#endif /* configSTART_QUEUE_SET_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_QUEUE_OVERWRITE_TESTS == 1 )
+		{
+			vStartQueueOverwriteTask( testrunnerQUEUE_OVERWRITE_PRIORITY );
+		}
+		#endif /* configSTART_QUEUE_OVERWRITE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_EVENT_GROUP_TESTS == 1 )
+		{
+			vStartEventGroupTasks();
+		}
+		#endif /* configSTART_EVENT_GROUP_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_INTERRUPT_SEMAPHORE_TESTS == 1 )
+		{
+			vStartInterruptSemaphoreTasks();
+		}
+		#endif /* configSTART_INTERRUPT_SEMAPHORE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_QUEUE_SET_POLLING_TESTS == 1 )
+		{
+			vStartQueueSetPollingTask();
+		}
+		#endif /* configSTART_QUEUE_SET_POLLING_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_BLOCK_TIME_TESTS == 1 )
+		{
+			vCreateBlockTimeTasks();
+		}
+		#endif /* configSTART_BLOCK_TIME_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_ABORT_DELAY_TESTS == 1 )
+		{
+			vCreateAbortDelayTasks();
+		}
+		#endif /* configSTART_ABORT_DELAY_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_MESSAGE_BUFFER_TESTS == 1 )
+		{
+			vStartMessageBufferTasks( configMINIMAL_STACK_SIZE );
+		}
+		#endif /* configSTART_MESSAGE_BUFFER_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if(configSTART_STREAM_BUFFER_TESTS  == 1 )
+		{
+			vStartStreamBufferTasks();
+		}
+		#endif /* configSTART_STREAM_BUFFER_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_STREAM_BUFFER_INTERRUPT_TESTS == 1 )
+		{
+			vStartStreamBufferInterruptDemo();
+		}
+		#endif /* configSTART_STREAM_BUFFER_INTERRUPT_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) )
+		{
+			/* Don't expect these tasks to pass when preemption is not used. */
+			vStartTimerDemoTask( testrunnerTIMER_TEST_PERIOD );
+		}
+		#endif /* ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_INTERRUPT_QUEUE_TESTS == 1 )
+		{
+			vStartInterruptQueueTasks();
+		}
+		#endif /* configSTART_INTERRUPT_QUEUE_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_REGISTER_TESTS == 1 )
+		{
+			vStartRegisterTasks( testrunnerREGISTER_TEST_PRIORITY );
+		}
+		#endif /* configSTART_REGISTER_TESTS */
+
+		freeHeapVar = xPortGetFreeHeapSize();
+
+		#if( configSTART_DELETE_SELF_TESTS == 1 )
+		{
+			/* The suicide tasks must be created last as they need to know how many
+			* tasks were running prior to their creation.  This then allows them to
+			* ascertain whether or not the correct/expected number of tasks are
+			* running at any given time. */
+			vCreateSuicidalTasks( testrunnerCREATOR_TASK_PRIORITY );
+		}
+		#endif /* configSTART_DELETE_SELF_TESTS */
+	}
+
+	freeHeapVar = xPortGetFreeHeapSize();
+	freeHeapMinVar = xPortGetMinimumEverFreeHeapSize();
+
+
+	vTaskStartScheduler();
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationTickHook( void )
+{
+	#if( configSTART_TASK_NOTIFY_TESTS == 1 )
+	{
+		xNotifyTaskFromISR();
+	}
+	#endif /* configSTART_TASK_NOTIFY_TESTS */
+
+	#if( configSTART_TASK_NOTIFY_ARRAY_TESTS == 1 )
+	{
+		xNotifyArrayTaskFromISR();
+	}
+	#endif /* configSTART_TASK_NOTIFY_ARRAY_TESTS */
+
+	#if( configSTART_QUEUE_SET_TESTS == 1 )
+	{
+		vQueueSetAccessQueueSetFromISR();
+	}
+	#endif /* configSTART_QUEUE_SET_TESTS */
+
+	#if( configSTART_QUEUE_OVERWRITE_TESTS == 1 )
+	{
+		vQueueOverwritePeriodicISRDemo();
+	}
+	#endif /* configSTART_QUEUE_OVERWRITE_TESTS */
+
+	#if( configSTART_EVENT_GROUP_TESTS == 1 )
+	{
+		vPeriodicEventGroupsProcessing();
+	}
+	#endif /* configSTART_EVENT_GROUP_TESTS */
+
+	#if( configSTART_INTERRUPT_SEMAPHORE_TESTS == 1 )
+	{
+		vInterruptSemaphorePeriodicTest();
+	}
+	#endif /* configSTART_INTERRUPT_SEMAPHORE_TESTS */
+
+	#if( configSTART_QUEUE_SET_POLLING_TESTS == 1 )
+	{
+		vQueueSetPollingInterruptAccess();
+	}
+	#endif /* configSTART_QUEUE_SET_POLLING_TESTS */
+
+	#if( configSTART_STREAM_BUFFER_TESTS == 1 )
+	{
+		vPeriodicStreamBufferProcessing();
+	}
+	#endif /* configSTART_STREAM_BUFFER_TESTS */
+
+	#if( configSTART_STREAM_BUFFER_INTERRUPT_TESTS == 1 )
+	{
+		vBasicStreamBufferSendFromISR();
+	}
+	#endif /* configSTART_STREAM_BUFFER_INTERRUPT_TESTS */
+
+	#if( ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) )
+	{
+		/* Only created when preemption is used. */
+		vTimerPeriodicISRTests();
+	}
+	#endif /* ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) */
+
+	#if( configSTART_INTERRUPT_QUEUE_TESTS == 1 )
+	{
+		portYIELD_FROM_ISR( xFirstTimerHandler() );
+	}
+	#endif /* configSTART_INTERRUPT_QUEUE_TESTS */
+}
+/*-----------------------------------------------------------*/
+
+static void prvCheckTask( void *pvParameters )
+{
+TickType_t xNextWakeTime;
+const TickType_t xCycleFrequency = pdMS_TO_TICKS( 5000UL );
+
+	/* Silence compiler warnings about unused variables. */
+	( void ) pvParameters;
+
+	/* Initialise xNextWakeTime - this only needs to be done once. */
+	xNextWakeTime = xTaskGetTickCount();
+
+	for( ;; )
+	{
+		/* Place this task in the blocked state until it is time to run again. */
+		vTaskDelayUntil( &xNextWakeTime, xCycleFrequency );
+
+		#if( configSTART_TASK_NOTIFY_TESTS == 1 )
+		{
+			if( xAreTaskNotificationTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error:  Notification";
+				printf("Error:  Notification \r\n");
+			}
+		}
+		#endif /* configSTART_TASK_NOTIFY_TESTS */
+
+		#if( configSTART_TASK_NOTIFY_ARRAY_TESTS == 1 )
+		{
+			if( xAreTaskNotificationArrayTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error:  Notification Array";
+				printf("Error:  Notification Array \r\n");
+			}
+		}
+		#endif /* configSTART_TASK_NOTIFY_ARRAY_TESTS */
+
+		#if( configSTART_BLOCKING_QUEUE_TESTS == 1 )
+		{
+			if( xAreBlockingQueuesStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: BlockQueue";
+				printf("Error: BlockQueue \r\n");
+			}
+		}
+		#endif /* configSTART_BLOCKING_QUEUE_TESTS */
+
+		#if( configSTART_SEMAPHORE_TESTS == 1 )
+		{
+			if( xAreSemaphoreTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: SemTest";
+				printf("Error: SemTest \r\n");
+			}
+		}
+		#endif /* configSTART_SEMAPHORE_TESTS */
+
+		#if( configSTART_POLLED_QUEUE_TESTS == 1 )
+		{
+			if( xArePollingQueuesStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: PollQueue";
+				printf("Error: PollQueue \r\n");
+			}
+		}
+		#endif /* configSTART_POLLED_QUEUE_TESTS */
+
+		#if( configSTART_INTEGER_MATH_TESTS == 1 )
+		{
+			if( xAreIntegerMathsTaskStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: IntMath";
+				printf("Error: IntMath \r\n");
+			}
+		}
+		#endif /* configSTART_INTEGER_MATH_TESTS */
+
+		#if( configSTART_GENERIC_QUEUE_TESTS == 1 )
+		{
+			if( xAreGenericQueueTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: GenQueue";
+				printf("Error: GenQueue \r\n");
+			}
+		}
+		#endif /* configSTART_GENERIC_QUEUE_TESTS */
+
+		#if( configSTART_PEEK_QUEUE_TESTS == 1 )
+		{
+			if( xAreQueuePeekTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: QueuePeek";
+				printf("Error: QueuePeek \r\n");
+			}
+		}
+		#endif /* configSTART_PEEK_QUEUE_TESTS */
+
+		#if( configSTART_MATH_TESTS == 1 )
+		{
+			if( xAreMathsTaskStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Flop";
+				printf("Error: Flop \r\n");
+			}
+		}
+		#endif /* configSTART_MATH_TESTS */
+
+		#if( configSTART_RECURSIVE_MUTEX_TESTS == 1 )
+		{
+			if( xAreRecursiveMutexTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: RecMutex";
+				printf("Error: RecMutex \r\n");
+			}
+		}
+		#endif /* configSTART_RECURSIVE_MUTEX_TESTS */
+
+		#if( configSTART_COUNTING_SEMAPHORE_TESTS == 1 )
+		{
+			if( xAreCountingSemaphoreTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: CountSem";
+				printf("Error: CountSem \r\n");
+			}
+		}
+		#endif /* configSTART_COUNTING_SEMAPHORE_TESTS */
+
+		#if( configSTART_QUEUE_SET_TESTS == 1 )
+		{
+			if( xAreQueueSetTasksStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Queue set";
+				printf("Error: Queue set \r\n");
+			}
+		}
+		#endif /* configSTART_QUEUE_SET_TESTS */
+
+		#if( configSTART_QUEUE_OVERWRITE_TESTS == 1 )
+		{
+			if( xIsQueueOverwriteTaskStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Queue overwrite";
+				printf("Error: Queue overwrite \r\n");
+			}
+		}
+		#endif /* configSTART_QUEUE_OVERWRITE_TESTS */
+
+		#if( configSTART_EVENT_GROUP_TESTS == 1 )
+		{
+			if( xAreEventGroupTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: EventGroup";
+				printf("Error: EventGroup \r\n");
+			}
+		}
+		#endif /* configSTART_EVENT_GROUP_TESTS */
+
+		#if( configSTART_INTERRUPT_SEMAPHORE_TESTS == 1 )
+		{
+			if( xAreInterruptSemaphoreTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: IntSem";
+				printf("Error: IntSem \r\n");
+			}
+		}
+		#endif /* configSTART_INTERRUPT_SEMAPHORE_TESTS */
+
+		#if( configSTART_QUEUE_SET_POLLING_TESTS == 1 )
+		{
+			if( xAreQueueSetPollTasksStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Queue set polling";
+				printf("Error: Queue set polling \r\n");
+			}
+		}
+		#endif /* configSTART_QUEUE_SET_POLLING_TESTS */
+
+		#if( configSTART_BLOCK_TIME_TESTS == 1 )
+		{
+			if( xAreBlockTimeTestTasksStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Block time";
+				printf("Error: Block time \r\n");
+			}
+		}
+		#endif /* configSTART_BLOCK_TIME_TESTS */
+
+		#if( configSTART_ABORT_DELAY_TESTS == 1 )
+		{
+			if( xAreAbortDelayTestTasksStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Abort delay";
+				printf("Error: Abort delay \r\n");
+			}
+		}
+		#endif /* configSTART_ABORT_DELAY_TESTS */
+
+		#if( configSTART_MESSAGE_BUFFER_TESTS == 1 )
+		{
+			if( xAreMessageBufferTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error:  MessageBuffer";
+				printf("Error:  MessageBuffer \r\n");
+			}
+		}
+		#endif /* configSTART_MESSAGE_BUFFER_TESTS */
+
+		#if( configSTART_STREAM_BUFFER_TESTS == 1 )
+		{
+			if( xAreStreamBufferTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error:  StreamBuffer";
+				printf("Error:  StreamBuffer \r\n");
+			}
+		}
+		#endif /* configSTART_STREAM_BUFFER_TESTS */
+
+		#if( configSTART_STREAM_BUFFER_INTERRUPT_TESTS == 1 )
+		{
+			if( xIsInterruptStreamBufferDemoStillRunning() != pdPASS )
+			{
+				pcStatusMessage = "Error: Stream buffer interrupt";
+				printf("Error: Stream buffer interrupt \r\n");
+			}
+		}
+		#endif /* configSTART_STREAM_BUFFER_INTERRUPT_TESTS */
+
+		#if( ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) )
+		{
+			if( xAreTimerDemoTasksStillRunning( xCycleFrequency ) != pdTRUE )
+			{
+				pcStatusMessage = "Error: TimerDemo";
+				printf("Error: TimerDemo \r\n");
+			}
+		}
+		#endif /* ( configSTART_TIMER_TESTS == 1 ) && ( configUSE_PREEMPTION != 0 ) */
+
+		#if( configSTART_INTERRUPT_QUEUE_TESTS == 1 )
+		{
+			if( xAreIntQueueTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: IntQueue";
+				printf("Error: IntQueue \r\n");
+			}
+		}
+		#endif /* configSTART_INTERRUPT_QUEUE_TESTS */
+
+		#if( configSTART_REGISTER_TESTS == 1 )
+		{
+			if( xAreRegisterTasksStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: RegTests";
+				printf("Error: RegTests \r\n");
+			}
+		}
+		#endif /* configSTART_REGISTER_TESTS */
+
+		#if( configSTART_DELETE_SELF_TESTS == 1 )
+		{
+			if( xIsCreateTaskStillRunning() != pdTRUE )
+			{
+				pcStatusMessage = "Error: Death";
+				printf("Error: Death \r\n");
+			}
+		}
+		#endif /* configSTART_DELETE_SELF_TESTS */
+
+		if(strcmp("No errors", pcStatusMessage) == 0)
+		{
+		    printf("No errors \r\n");
+		}
+//		configPRINTF( ( "%s \r\n", pcStatusMessage ) );
+
+		/* Toggle the check LED to give an indication of the system status.  If
+        the LED toggles every mainNO_ERROR_CHECK_TASK_PERIOD milliseconds then
+        everything is ok.  A faster toggle indicates an error. */
+        vMainToggleLED();
+	}
+}
+/*-----------------------------------------------------------*/

--- a/C2000_F2838x_C28x_CCS/port_validation/TestRunner.h
+++ b/C2000_F2838x_C28x_CCS/port_validation/TestRunner.h
@@ -1,0 +1,37 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+#ifndef TEST_RUNNER_H
+#define TEST_RUNNER_H
+
+/**
+ * Start all the tests.
+ *
+ * Note that this function starts the scheduler and therefore, never returns.
+ */
+void vStartTests( void );
+
+#endif /* TEST_RUNNER_H */

--- a/C2000_F2838x_C28x_CCS/print_support/printf-stdarg.c
+++ b/C2000_F2838x_C28x_CCS/print_support/printf-stdarg.c
@@ -1,0 +1,313 @@
+/*
+	Copyright 2001, 2002 Georges Menie (www.menie.org)
+	stdarg version contributed by Christian Ettinger
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+/*
+	putchar is the only external dependency for this file,
+	if you have a working putchar, leave it commented out.
+	If not, uncomment the define below and
+	replace outbyte(c) by your own function call.
+
+*/
+#define TEST_PRINTF
+#include "sci.h"
+#define putchar(c) UartPutChar(c)
+extern void UartPutChar(uint16_t charToWrite);
+#include <stdarg.h>
+
+static int tiny_print( char **out, const char *format, va_list args, unsigned int buflen );
+
+static void printchar(char **str, int c, char *buflimit)
+{
+	//extern int putchar(int c);
+
+	if (str) {
+		if( buflimit == ( char * ) 0 ) {
+			/* Limit of buffer not known, write charater to buffer. */
+			**str = (char)c;
+			++(*str);
+		}
+		else if( ( ( unsigned long ) *str ) < ( ( unsigned long ) buflimit ) ) {
+			/* Withing known limit of buffer, write character. */
+			**str = (char)c;
+			++(*str);
+		}
+	}
+	else
+	{
+		(void)putchar(c);
+	}
+}
+
+#define PAD_RIGHT 1
+#define PAD_ZERO 2
+
+static int prints(char **out, const char *string, int width, int pad, char *buflimit)
+{
+	register int pc = 0, padchar = ' ';
+
+	if (width > 0) {
+		register int len = 0;
+		register const char *ptr;
+		for (ptr = string; *ptr; ++ptr) ++len;
+		if (len >= width) width = 0;
+		else width -= len;
+		if (pad & PAD_ZERO) padchar = '0';
+	}
+	if (!(pad & PAD_RIGHT)) {
+		for ( ; width > 0; --width) {
+			printchar (out, padchar, buflimit);
+			++pc;
+		}
+	}
+	for ( ; *string ; ++string) {
+		printchar (out, *string, buflimit);
+		++pc;
+	}
+	for ( ; width > 0; --width) {
+		printchar (out, padchar, buflimit);
+		++pc;
+	}
+
+	return pc;
+}
+
+/* the following should be enough for 32 bit int */
+#define PRINT_BUF_LEN 12
+
+static int printi(char **out, int i, int b, int sg, int width, int pad, int letbase, char *buflimit)
+{
+	char print_buf[PRINT_BUF_LEN];
+	register char *s;
+	register int t, neg = 0, pc = 0;
+	register unsigned int u = (unsigned int)i;
+
+	if (i == 0) {
+		print_buf[0] = '0';
+		print_buf[1] = '\0';
+		return prints (out, print_buf, width, pad, buflimit);
+	}
+
+	if (sg && b == 10 && i < 0) {
+		neg = 1;
+		u = (unsigned int)-i;
+	}
+
+	s = print_buf + PRINT_BUF_LEN-1;
+	*s = '\0';
+
+	while (u) {
+		t = (unsigned int)u % b;
+		if( t >= 10 )
+			t += letbase - '0' - 10;
+		*--s = (char)(t + '0');
+		u /= b;
+	}
+
+	if (neg) {
+		if( width && (pad & PAD_ZERO) ) {
+			printchar (out, '-', buflimit);
+			++pc;
+			--width;
+		}
+		else {
+			*--s = '-';
+		}
+	}
+
+	return pc + prints (out, s, width, pad, buflimit);
+}
+
+static int tiny_print( char **out, const char *format, va_list args, unsigned int buflen )
+{
+	register int width, pad;
+	register int pc = 0;
+	char scr[2], *buflimit;
+
+	if( buflen == 0 ){
+		buflimit = ( char * ) 0;
+	}
+	else {
+		/* Calculate the last valid buffer space, leaving space for the NULL
+		terminator. */
+		buflimit = ( *out ) + ( buflen - 1 );
+	}
+
+	for (; *format != 0; ++format) {
+		if (*format == '%') {
+			++format;
+			width = pad = 0;
+			if (*format == '\0') break;
+			if (*format == '%') goto out;
+			if (*format == '-') {
+				++format;
+				pad = PAD_RIGHT;
+			}
+			while (*format == '0') {
+				++format;
+				pad |= PAD_ZERO;
+			}
+			for ( ; *format >= '0' && *format <= '9'; ++format) {
+				width *= 10;
+				width += *format - '0';
+			}
+			if( *format == 's' ) {
+				register char *s = (char *)va_arg( args, int );
+				pc += prints (out, s?s:"(null)", width, pad, buflimit);
+				continue;
+			}
+			if( *format == 'd' ) {
+				pc += printi (out, va_arg( args, int ), 10, 1, width, pad, 'a', buflimit);
+				continue;
+			}
+			if( *format == 'x' ) {
+				pc += printi (out, va_arg( args, int ), 16, 0, width, pad, 'a', buflimit);
+				continue;
+			}
+			if( *format == 'X' ) {
+				pc += printi (out, va_arg( args, int ), 16, 0, width, pad, 'A', buflimit);
+				continue;
+			}
+			if( *format == 'u' ) {
+				pc += printi (out, va_arg( args, int ), 10, 0, width, pad, 'a', buflimit);
+				continue;
+			}
+			if( *format == 'c' ) {
+				/* char are converted to int then pushed on the stack */
+				scr[0] = (char)va_arg( args, int );
+				scr[1] = '\0';
+				pc += prints (out, scr, width, pad, buflimit);
+				continue;
+			}
+		}
+		else {
+		out:
+			printchar (out, *format, buflimit);
+			++pc;
+		}
+	}
+	if (out) **out = '\0';
+	va_end( args );
+	return pc;
+}
+
+int printf(const char *format, ...)
+{
+        va_list args;
+
+        va_start( args, format );
+        return tiny_print( 0, format, args, 0 );
+}
+
+int sprintf(char *out, const char *format, ...)
+{
+        va_list args;
+
+        va_start( args, format );
+        return tiny_print( &out, format, args, 0 );
+}
+
+
+int snprintf( char *buf, unsigned int count, const char *format, ... )
+{
+        va_list args;
+
+        ( void ) count;
+
+        va_start( args, format );
+        return tiny_print( &buf, format, args, count );
+}
+
+
+#ifdef TEST_PRINTF
+int checkPrintf(void)
+{
+	char *ptr = "Hello world!";
+	char *np = 0;
+	int i = 5;
+	unsigned int bs = sizeof(int)*8;
+	int mi;
+	char buf[80];
+
+	mi = (1 << (bs-1)) + 1;
+	printf("Ptr string = %s \r\n", ptr);
+	printf("printf test\r\n");
+	printf("%s is null pointer\r\n", np);
+	printf("%d = 5\r\n", i);
+	printf("%d = - max int\r\n", mi);
+	printf("char %c = 'a'\r\n", 'a');
+	printf("hex %x = ff\r\n", 0xff);
+	printf("hex %02x = 00\r\n", 0);
+	printf("signed %d = unsigned %u = hex %x\r\n", -3, -3, -3);
+	printf("%d %s(s)%", 0, "message");
+	printf("\r\n");
+	printf("%d %s(s) with %%\r\n", 0, "message");
+	sprintf(buf, "justif: \"%-10s\"\r\n", "left"); printf("%s", buf);
+	sprintf(buf, "justif: \"%10s\"\r\n", "right"); printf("%s", buf);
+	sprintf(buf, " 3: %04d zero padded\r\n", 3); printf("%s", buf);
+	sprintf(buf, " 3: %-4d left justif.\r\n", 3); printf("%s", buf);
+	sprintf(buf, " 3: %4d right justif.\r\n", 3); printf("%s", buf);
+	sprintf(buf, "-3: %04d zero padded\r\n", -3); printf("%s", buf);
+	sprintf(buf, "-3: %-4d left justif.\r\n", -3); printf("%s", buf);
+	sprintf(buf, "-3: %4d right justif.\r\n", -3); printf("%s", buf);
+
+	return 0;
+}
+
+/*
+ * if you compile this file with
+ *   gcc -Wall $(YOUR_C_OPTIONS) -DTEST_PRINTF -c printf.c
+ * you will get a normal warning:
+ *   printf.c:214: warning: spurious trailing `%' in format
+ * this line is testing an invalid % at the end of the format string.
+ *
+ * this should display (on 32bit int machine) :
+ *
+ * Hello world!
+ * printf test
+ * (null) is null pointer
+ * 5 = 5
+ * -2147483647 = - max int
+ * char a = 'a'
+ * hex ff = ff
+ * hex 00 = 00
+ * signed -3 = unsigned 4294967293 = hex fffffffd
+ * 0 message(s)
+ * 0 message(s) with %
+ * justif: "left      "
+ * justif: "     right"
+ *  3: 0003 zero padded
+ *  3: 3    left justif.
+ *  3:    3 right justif.
+ * -3: -003 zero padded
+ * -3: -3   left justif.
+ * -3:   -3 right justif.
+ */
+
+#endif
+
+
+/* To keep linker happy. */
+int	write( int i, char* c, int n)
+{
+	(void)i;
+	(void)n;
+	(void)c;
+	return 0;
+}
+

--- a/C2000_F2838x_C28x_CCS/print_support/uart_drv.c
+++ b/C2000_F2838x_C28x_CCS/print_support/uart_drv.c
@@ -1,0 +1,144 @@
+/*****************************************************************************/
+/* UART_LOWLEV.C - Example user-defined device.                              */
+/*****************************************************************************/
+#include <file.h>
+#include "uart_drv.h"
+//#include "uart.h"
+
+extern void UartSetup();
+extern void UartPutChar(int charToWrite);
+
+/*****************************************************************************/
+/* This is a sample implementation of a user-defined device.  The device     */
+/* must define the seven basic functions (open, close, read, write, lseek,   */
+/* unlink, rename).  These are expected to behave just like the Unix         */
+/* functions of these names.  Some devices might not have a reasonable       */
+/* action to take for some functions; a UART or TTY device might not be      */
+/* lseek-able, but can still be opened and written to.  A device is added    */
+/* using the add_device() RTS function call (q.v.).                          */
+/*****************************************************************************/
+/* The low-level interface is based on file names and file descriptors.      */
+/* The file names don't need to be valid Unix file names, but must mean      */
+/* something to the device.  The device must keep track of its own file      */
+/* descriptors, which will be used by the calling functions to read and      */
+/* write to the device.  If there can only be one instance of a "file" on a  */
+/* device, the file descriptor doesn't matter much, so just pass a       */
+/* non-negative integer such as zero.                        */
+/*****************************************************************************/
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_open()                                                   */
+/*                                                                           */
+/*****************************************************************************/
+int UART_open(const char *path, unsigned flags, int llv_fd)
+{
+    /*-----------------------------------------------------------------------*/
+    /* Only one UART device exists (_SSA).  For an _SSA device, file names   */
+    /* are not meaningful, so ignore the file name.                          */
+    /*-----------------------------------------------------------------------*/
+
+    /*-----------------------------------------------------------------------*/
+    /* Don't allow attempts to open the UART device that aren't O_WRONLY.    */
+    /*-----------------------------------------------------------------------*/
+    if (!(flags & O_WRONLY)) return -1;
+
+    /*-----------------------------------------------------------------------*/
+    /* Set up the UART                                                       */
+    /*-----------------------------------------------------------------------*/
+    UartSetup();
+
+    /*-----------------------------------------------------------------------*/
+    /* Arbitrarily give it file descriptor 1.  File descriptors are          */
+    /* device-specific; this file descriptor 1 is not the same as HOST file  */
+    /* descriptor 1 (stdout).                                                */
+    /*-----------------------------------------------------------------------*/
+    return 1;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_close()                                                  */
+/*                                                                           */
+/*****************************************************************************/
+int UART_close(int dev_fd)
+{
+    /*-----------------------------------------------------------------------*/
+    /* Only one UART device exists, so we don't do anything upon close.      */
+    /*-----------------------------------------------------------------------*/
+    return 0;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_read() reads *at most* count bytes.                                  */
+/*                                                                           */
+/*****************************************************************************/
+int UART_read(int dev_fd, char *buf, unsigned count)
+{
+    /*-----------------------------------------------------------------------*/
+    /* Only one UART device exists, and it is write-only, so return error    */
+    /*-----------------------------------------------------------------------*/
+    return -1;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_write()                                                              */
+/*                                                                           */
+/*****************************************************************************/
+int UART_write(int dev_fd, const char *buf, unsigned count)
+{
+    unsigned i;
+
+    /*-----------------------------------------------------------------------*/
+    /* Output character-by-character                                         */
+    /*-----------------------------------------------------------------------*/
+    for (i=0; i < count; i++)
+        UartPutChar(buf[i]);
+
+    return count;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_lseek()                                                              */
+/*                                                                           */
+/*****************************************************************************/
+off_t UART_lseek(int dev_fd, off_t offset, int origin)
+{
+    /*-----------------------------------------------------------------------*/
+    /* lseek is not possible on UART.                                        */
+    /*-----------------------------------------------------------------------*/
+    return -1;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_unlink()                                                             */
+/*                                                                           */
+/*****************************************************************************/
+int UART_unlink(const char *path)
+{
+    /*-----------------------------------------------------------------------*/
+    /* unlink is not possible on UART                                        */
+    /*-----------------------------------------------------------------------*/
+    return -1;
+}
+
+/*****************************************************************************/
+/*                                                                           */
+/* UART_rename()                                                             */
+/*                                                                           */
+/*****************************************************************************/
+/* rename is unusual among the low-level functions in that it is also        */
+/* specified in the ISO C standard.  It has the same prototype and       */
+/* semantics, so it's not really an issue.                   */
+/*****************************************************************************/
+int UART_rename(const char *old_name, const char *new_name)
+{
+    /*-----------------------------------------------------------------------*/
+    /* rename is not possible on UART                                        */
+    /*-----------------------------------------------------------------------*/
+    return -1;
+}

--- a/C2000_F2838x_C28x_CCS/print_support/uart_drv.h
+++ b/C2000_F2838x_C28x_CCS/print_support/uart_drv.h
@@ -1,0 +1,12 @@
+/*****************************************************************************/
+/* Must include stdio.h before this file for the definition of fpos_t        */
+/*****************************************************************************/
+#include <stdio.h>
+
+int    UART_open(const char *path, unsigned flags, int llv_fd);
+int    UART_close(int dev_fd);
+int    UART_read(int dev_fd, char *buf, unsigned count);
+int    UART_write(int dev_fd, const char *buf, unsigned count);
+fpos_t UART_lseek(int dev_fd, fpos_t offset, int origin);
+int    UART_unlink(const char *path);
+int    UART_rename(const char *old_name, const char *new_name);


### PR DESCRIPTION
Adding demos for FreeRTOS port for c28x based microcontrollers

Description
-----------
This pull request consists of demo projects for TMS320F2838xD (C2000 compiler 20.2.1.LTS) for the TMDSCNCD28388D controlcard board.

Test Steps
-----------
To run the demos on TMDSCNCD28388D controlcard, the following steps are required:
 - Install Code Compser Studio(CCS): https://www.ti.com/tool/CCSTUDIO
 - Install latest C2000Ware package: https://www.ti.com/tool/C2000WARE
 - Update the C2000WARE_ROOT and FreeRTOS_ROOT path variable in the example projectspec files available at following location in the repo: FreeRTOS-Partner-Supported-Demos\C2000_F2838x_C28x_CCS\CCS
 - Import the example project file in CCS
 - Build and debug the project

Standard Test Demo Results
-----------
![image](https://user-images.githubusercontent.com/93313481/162381617-0fb0c63f-9778-4c16-99b0-677737551911.png)

Known Issues
-----------
Support for "fpu64" is not added yet to the port. The examples should specify "fpu32" as option for floating point.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
