### PR TITLE
cortex-m85: Add MPU PXN example

### DIFF
--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/CMakeLists.txt
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.15)
+
+add_library(cmsis_bsp INTERFACE)
+
+target_include_directories(cmsis_bsp
+    INTERFACE
+        include
+)
+
+target_compile_definitions(cmsis_bsp
+    INTERFACE
+        CORSTONE310_FVP
+        CMSIS_device_header="SSE310MPS3.h"
+)
+
+target_sources(cmsis_bsp
+INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/startup_SSE310MPS3.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/system_SSE310MPS3.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/bsp_serial.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/Driver_USART.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/uart_cmsdk_drv.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/device_definition.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/source/syscalls_stub.c
+)

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_Common.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_Common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        2. Feb 2017
+ * $Revision:    V2.0
+ *
+ * Project:      Common Driver definitions
+ */
+
+/* History:
+ *  Version 2.0
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *    Added General return codes definitions
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_COMMON_H_
+#define DRIVER_COMMON_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define ARM_DRIVER_VERSION_MAJOR_MINOR(major,minor) (((major) << 8) | (minor))
+
+/**
+\brief Driver Version
+*/
+typedef struct _ARM_DRIVER_VERSION {
+  uint16_t api;                         ///< API version
+  uint16_t drv;                         ///< Driver version
+} ARM_DRIVER_VERSION;
+
+/* General return codes */
+#define ARM_DRIVER_OK                 0 ///< Operation succeeded 
+#define ARM_DRIVER_ERROR             -1 ///< Unspecified error
+#define ARM_DRIVER_ERROR_BUSY        -2 ///< Driver is busy
+#define ARM_DRIVER_ERROR_TIMEOUT     -3 ///< Timeout occurred
+#define ARM_DRIVER_ERROR_UNSUPPORTED -4 ///< Operation not supported
+#define ARM_DRIVER_ERROR_PARAMETER   -5 ///< Parameter error
+#define ARM_DRIVER_ERROR_SPECIFIC    -6 ///< Start of driver specific errors 
+
+/**
+\brief General power states
+*/ 
+typedef enum _ARM_POWER_STATE {
+  ARM_POWER_OFF,                        ///< Power off: no operation possible
+  ARM_POWER_LOW,                        ///< Low Power mode: retain state, detect and signal wake-up events
+  ARM_POWER_FULL                        ///< Power on: full operation at maximum performance
+} ARM_POWER_STATE;
+
+#endif /* DRIVER_COMMON_H_ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * $Date:        31. March 2020
+ * $Revision:    V2.4
+ *
+ * Project:      USART (Universal Synchronous Asynchronous Receiver Transmitter)
+ *               Driver definitions
+ */
+
+/* History:
+ *  Version 2.4
+ *    Removed volatile from ARM_USART_STATUS and ARM_USART_MODEM_STATUS
+ *  Version 2.3
+ *    ARM_USART_STATUS and ARM_USART_MODEM_STATUS made volatile
+ *  Version 2.2
+ *    Corrected ARM_USART_CPOL_Pos and ARM_USART_CPHA_Pos definitions
+ *  Version 2.1
+ *    Removed optional argument parameter from Signal Event
+ *  Version 2.0
+ *    New simplified driver:
+ *      complexity moved to upper layer (especially data handling)
+ *      more unified API for different communication interfaces
+ *      renamed driver UART -> USART (Asynchronous & Synchronous)
+ *    Added modes:
+ *      Synchronous
+ *      Single-wire
+ *      IrDA
+ *      Smart Card
+ *    Changed prefix ARM_DRV -> ARM_DRIVER
+ *  Version 1.10
+ *    Namespace prefix ARM_ added
+ *  Version 1.01
+ *    Added events:
+ *      ARM_UART_EVENT_TX_EMPTY,     ARM_UART_EVENT_RX_TIMEOUT
+ *      ARM_UART_EVENT_TX_THRESHOLD, ARM_UART_EVENT_RX_THRESHOLD
+ *    Added functions: SetTxThreshold, SetRxThreshold
+ *    Added "rx_timeout_event" to capabilities
+ *  Version 1.00
+ *    Initial release
+ */
+
+#ifndef DRIVER_USART_H_
+#define DRIVER_USART_H_
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+#include "Driver_Common.h"
+
+#define ARM_USART_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,4)  /* API version */
+
+
+#define _ARM_Driver_USART_(n)      Driver_USART##n
+#define  ARM_Driver_USART_(n) _ARM_Driver_USART_(n)
+
+
+/****** USART Control Codes *****/
+
+#define ARM_USART_CONTROL_Pos                0
+#define ARM_USART_CONTROL_Msk               (0xFFUL << ARM_USART_CONTROL_Pos)
+
+/*----- USART Control Codes: Mode -----*/
+#define ARM_USART_MODE_ASYNCHRONOUS         (0x01UL << ARM_USART_CONTROL_Pos)   ///< UART (Asynchronous); arg = Baudrate
+#define ARM_USART_MODE_SYNCHRONOUS_MASTER   (0x02UL << ARM_USART_CONTROL_Pos)   ///< Synchronous Master (generates clock signal); arg = Baudrate
+#define ARM_USART_MODE_SYNCHRONOUS_SLAVE    (0x03UL << ARM_USART_CONTROL_Pos)   ///< Synchronous Slave (external clock signal)
+#define ARM_USART_MODE_SINGLE_WIRE          (0x04UL << ARM_USART_CONTROL_Pos)   ///< UART Single-wire (half-duplex); arg = Baudrate
+#define ARM_USART_MODE_IRDA                 (0x05UL << ARM_USART_CONTROL_Pos)   ///< UART IrDA; arg = Baudrate
+#define ARM_USART_MODE_SMART_CARD           (0x06UL << ARM_USART_CONTROL_Pos)   ///< UART Smart Card; arg = Baudrate
+
+/*----- USART Control Codes: Mode Parameters: Data Bits -----*/
+#define ARM_USART_DATA_BITS_Pos              8
+#define ARM_USART_DATA_BITS_Msk             (7UL << ARM_USART_DATA_BITS_Pos)
+#define ARM_USART_DATA_BITS_5               (5UL << ARM_USART_DATA_BITS_Pos)    ///< 5 Data bits
+#define ARM_USART_DATA_BITS_6               (6UL << ARM_USART_DATA_BITS_Pos)    ///< 6 Data bit
+#define ARM_USART_DATA_BITS_7               (7UL << ARM_USART_DATA_BITS_Pos)    ///< 7 Data bits
+#define ARM_USART_DATA_BITS_8               (0UL << ARM_USART_DATA_BITS_Pos)    ///< 8 Data bits (default)
+#define ARM_USART_DATA_BITS_9               (1UL << ARM_USART_DATA_BITS_Pos)    ///< 9 Data bits
+
+/*----- USART Control Codes: Mode Parameters: Parity -----*/
+#define ARM_USART_PARITY_Pos                 12
+#define ARM_USART_PARITY_Msk                (3UL << ARM_USART_PARITY_Pos)
+#define ARM_USART_PARITY_NONE               (0UL << ARM_USART_PARITY_Pos)       ///< No Parity (default)
+#define ARM_USART_PARITY_EVEN               (1UL << ARM_USART_PARITY_Pos)       ///< Even Parity
+#define ARM_USART_PARITY_ODD                (2UL << ARM_USART_PARITY_Pos)       ///< Odd Parity
+
+/*----- USART Control Codes: Mode Parameters: Stop Bits -----*/
+#define ARM_USART_STOP_BITS_Pos              14
+#define ARM_USART_STOP_BITS_Msk             (3UL << ARM_USART_STOP_BITS_Pos)
+#define ARM_USART_STOP_BITS_1               (0UL << ARM_USART_STOP_BITS_Pos)    ///< 1 Stop bit (default)
+#define ARM_USART_STOP_BITS_2               (1UL << ARM_USART_STOP_BITS_Pos)    ///< 2 Stop bits
+#define ARM_USART_STOP_BITS_1_5             (2UL << ARM_USART_STOP_BITS_Pos)    ///< 1.5 Stop bits
+#define ARM_USART_STOP_BITS_0_5             (3UL << ARM_USART_STOP_BITS_Pos)    ///< 0.5 Stop bits
+
+/*----- USART Control Codes: Mode Parameters: Flow Control -----*/
+#define ARM_USART_FLOW_CONTROL_Pos           16
+#define ARM_USART_FLOW_CONTROL_Msk          (3UL << ARM_USART_FLOW_CONTROL_Pos)
+#define ARM_USART_FLOW_CONTROL_NONE         (0UL << ARM_USART_FLOW_CONTROL_Pos) ///< No Flow Control (default)
+#define ARM_USART_FLOW_CONTROL_RTS          (1UL << ARM_USART_FLOW_CONTROL_Pos) ///< RTS Flow Control
+#define ARM_USART_FLOW_CONTROL_CTS          (2UL << ARM_USART_FLOW_CONTROL_Pos) ///< CTS Flow Control
+#define ARM_USART_FLOW_CONTROL_RTS_CTS      (3UL << ARM_USART_FLOW_CONTROL_Pos) ///< RTS/CTS Flow Control
+
+/*----- USART Control Codes: Mode Parameters: Clock Polarity (Synchronous mode) -----*/
+#define ARM_USART_CPOL_Pos                   18
+#define ARM_USART_CPOL_Msk                  (1UL << ARM_USART_CPOL_Pos)
+#define ARM_USART_CPOL0                     (0UL << ARM_USART_CPOL_Pos)         ///< CPOL = 0 (default)
+#define ARM_USART_CPOL1                     (1UL << ARM_USART_CPOL_Pos)         ///< CPOL = 1
+
+/*----- USART Control Codes: Mode Parameters: Clock Phase (Synchronous mode) -----*/
+#define ARM_USART_CPHA_Pos                   19
+#define ARM_USART_CPHA_Msk                  (1UL << ARM_USART_CPHA_Pos)
+#define ARM_USART_CPHA0                     (0UL << ARM_USART_CPHA_Pos)         ///< CPHA = 0 (default)
+#define ARM_USART_CPHA1                     (1UL << ARM_USART_CPHA_Pos)         ///< CPHA = 1
+
+
+/*----- USART Control Codes: Miscellaneous Controls  -----*/
+#define ARM_USART_SET_DEFAULT_TX_VALUE      (0x10UL << ARM_USART_CONTROL_Pos)   ///< Set default Transmit value (Synchronous Receive only); arg = value
+#define ARM_USART_SET_IRDA_PULSE            (0x11UL << ARM_USART_CONTROL_Pos)   ///< Set IrDA Pulse in ns; arg: 0=3/16 of bit period
+#define ARM_USART_SET_SMART_CARD_GUARD_TIME (0x12UL << ARM_USART_CONTROL_Pos)   ///< Set Smart Card Guard Time; arg = number of bit periods
+#define ARM_USART_SET_SMART_CARD_CLOCK      (0x13UL << ARM_USART_CONTROL_Pos)   ///< Set Smart Card Clock in Hz; arg: 0=Clock not generated
+#define ARM_USART_CONTROL_SMART_CARD_NACK   (0x14UL << ARM_USART_CONTROL_Pos)   ///< Smart Card NACK generation; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_TX                (0x15UL << ARM_USART_CONTROL_Pos)   ///< Transmitter; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_RX                (0x16UL << ARM_USART_CONTROL_Pos)   ///< Receiver; arg: 0=disabled, 1=enabled
+#define ARM_USART_CONTROL_BREAK             (0x17UL << ARM_USART_CONTROL_Pos)   ///< Continuous Break transmission; arg: 0=disabled, 1=enabled
+#define ARM_USART_ABORT_SEND                (0x18UL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Send
+#define ARM_USART_ABORT_RECEIVE             (0x19UL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Receive
+#define ARM_USART_ABORT_TRANSFER            (0x1AUL << ARM_USART_CONTROL_Pos)   ///< Abort \ref ARM_USART_Transfer
+
+
+
+/****** USART specific error codes *****/
+#define ARM_USART_ERROR_MODE                (ARM_DRIVER_ERROR_SPECIFIC - 1)     ///< Specified Mode not supported
+#define ARM_USART_ERROR_BAUDRATE            (ARM_DRIVER_ERROR_SPECIFIC - 2)     ///< Specified baudrate not supported
+#define ARM_USART_ERROR_DATA_BITS           (ARM_DRIVER_ERROR_SPECIFIC - 3)     ///< Specified number of Data bits not supported
+#define ARM_USART_ERROR_PARITY              (ARM_DRIVER_ERROR_SPECIFIC - 4)     ///< Specified Parity not supported
+#define ARM_USART_ERROR_STOP_BITS           (ARM_DRIVER_ERROR_SPECIFIC - 5)     ///< Specified number of Stop bits not supported
+#define ARM_USART_ERROR_FLOW_CONTROL        (ARM_DRIVER_ERROR_SPECIFIC - 6)     ///< Specified Flow Control not supported
+#define ARM_USART_ERROR_CPOL                (ARM_DRIVER_ERROR_SPECIFIC - 7)     ///< Specified Clock Polarity not supported
+#define ARM_USART_ERROR_CPHA                (ARM_DRIVER_ERROR_SPECIFIC - 8)     ///< Specified Clock Phase not supported
+
+
+/**
+\brief USART Status
+*/
+typedef struct _ARM_USART_STATUS {
+  uint32_t tx_busy          : 1;        ///< Transmitter busy flag
+  uint32_t rx_busy          : 1;        ///< Receiver busy flag
+  uint32_t tx_underflow     : 1;        ///< Transmit data underflow detected (cleared on start of next send operation)
+  uint32_t rx_overflow      : 1;        ///< Receive data overflow detected (cleared on start of next receive operation)
+  uint32_t rx_break         : 1;        ///< Break detected on receive (cleared on start of next receive operation)
+  uint32_t rx_framing_error : 1;        ///< Framing error detected on receive (cleared on start of next receive operation)
+  uint32_t rx_parity_error  : 1;        ///< Parity error detected on receive (cleared on start of next receive operation)
+  uint32_t reserved         : 25;
+} ARM_USART_STATUS;
+
+/**
+\brief USART Modem Control
+*/
+typedef enum _ARM_USART_MODEM_CONTROL {
+  ARM_USART_RTS_CLEAR,                  ///< Deactivate RTS
+  ARM_USART_RTS_SET,                    ///< Activate RTS
+  ARM_USART_DTR_CLEAR,                  ///< Deactivate DTR
+  ARM_USART_DTR_SET                     ///< Activate DTR
+} ARM_USART_MODEM_CONTROL;
+
+/**
+\brief USART Modem Status
+*/
+typedef struct _ARM_USART_MODEM_STATUS {
+  uint32_t cts      : 1;                ///< CTS state: 1=Active, 0=Inactive
+  uint32_t dsr      : 1;                ///< DSR state: 1=Active, 0=Inactive
+  uint32_t dcd      : 1;                ///< DCD state: 1=Active, 0=Inactive
+  uint32_t ri       : 1;                ///< RI  state: 1=Active, 0=Inactive
+  uint32_t reserved : 28;
+} ARM_USART_MODEM_STATUS;
+
+
+/****** USART Event *****/
+#define ARM_USART_EVENT_SEND_COMPLETE       (1UL << 0)  ///< Send completed; however USART may still transmit data
+#define ARM_USART_EVENT_RECEIVE_COMPLETE    (1UL << 1)  ///< Receive completed
+#define ARM_USART_EVENT_TRANSFER_COMPLETE   (1UL << 2)  ///< Transfer completed
+#define ARM_USART_EVENT_TX_COMPLETE         (1UL << 3)  ///< Transmit completed (optional)
+#define ARM_USART_EVENT_TX_UNDERFLOW        (1UL << 4)  ///< Transmit data not available (Synchronous Slave)
+#define ARM_USART_EVENT_RX_OVERFLOW         (1UL << 5)  ///< Receive data overflow
+#define ARM_USART_EVENT_RX_TIMEOUT          (1UL << 6)  ///< Receive character timeout (optional)
+#define ARM_USART_EVENT_RX_BREAK            (1UL << 7)  ///< Break detected on receive
+#define ARM_USART_EVENT_RX_FRAMING_ERROR    (1UL << 8)  ///< Framing error detected on receive
+#define ARM_USART_EVENT_RX_PARITY_ERROR     (1UL << 9)  ///< Parity error detected on receive
+#define ARM_USART_EVENT_CTS                 (1UL << 10) ///< CTS state changed (optional)
+#define ARM_USART_EVENT_DSR                 (1UL << 11) ///< DSR state changed (optional)
+#define ARM_USART_EVENT_DCD                 (1UL << 12) ///< DCD state changed (optional)
+#define ARM_USART_EVENT_RI                  (1UL << 13) ///< RI  state changed (optional)
+
+
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_USART_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+
+  \fn          ARM_USART_CAPABILITIES ARM_USART_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_USART_CAPABILITIES
+
+  \fn          int32_t ARM_USART_Initialize (ARM_USART_SignalEvent_t cb_event)
+  \brief       Initialize USART Interface.
+  \param[in]   cb_event  Pointer to \ref ARM_USART_SignalEvent
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Uninitialize (void)
+  \brief       De-initialize USART Interface.
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_PowerControl (ARM_POWER_STATE state)
+  \brief       Control USART Interface Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Send (const void *data, uint32_t num)
+  \brief       Start sending data to USART transmitter.
+  \param[in]   data  Pointer to buffer with data to send to USART transmitter
+  \param[in]   num   Number of data items to send
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Receive (void *data, uint32_t num)
+  \brief       Start receiving data from USART receiver.
+  \param[out]  data  Pointer to buffer for data to receive from USART receiver
+  \param[in]   num   Number of data items to receive
+  \return      \ref execution_status
+
+  \fn          int32_t ARM_USART_Transfer (const void *data_out,
+                                                 void *data_in,
+                                           uint32_t    num)
+  \brief       Start sending/receiving data to/from USART transmitter/receiver.
+  \param[in]   data_out  Pointer to buffer with data to send to USART transmitter
+  \param[out]  data_in   Pointer to buffer for data to receive from USART receiver
+  \param[in]   num       Number of data items to transfer
+  \return      \ref execution_status
+
+  \fn          uint32_t ARM_USART_GetTxCount (void)
+  \brief       Get transmitted data count.
+  \return      number of data items transmitted
+
+  \fn          uint32_t ARM_USART_GetRxCount (void)
+  \brief       Get received data count.
+  \return      number of data items received
+
+  \fn          int32_t ARM_USART_Control (uint32_t control, uint32_t arg)
+  \brief       Control USART Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      common \ref execution_status and driver specific \ref usart_execution_status
+
+  \fn          ARM_USART_STATUS ARM_USART_GetStatus (void)
+  \brief       Get USART status.
+  \return      USART status \ref ARM_USART_STATUS
+
+  \fn          int32_t ARM_USART_SetModemControl (ARM_USART_MODEM_CONTROL control)
+  \brief       Set USART Modem Control line state.
+  \param[in]   control  \ref ARM_USART_MODEM_CONTROL
+  \return      \ref execution_status
+
+  \fn          ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus (void)
+  \brief       Get USART Modem Status lines state.
+  \return      modem status \ref ARM_USART_MODEM_STATUS
+
+  \fn          void ARM_USART_SignalEvent (uint32_t event)
+  \brief       Signal USART Events.
+  \param[in]   event  \ref USART_events notification mask
+*/
+
+typedef void (*ARM_USART_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_USART_SignalEvent : Signal USART Event.
+
+
+/**
+\brief USART Device Driver Capabilities.
+*/
+typedef struct _ARM_USART_CAPABILITIES {
+  uint32_t asynchronous       : 1;      ///< supports UART (Asynchronous) mode
+  uint32_t synchronous_master : 1;      ///< supports Synchronous Master mode
+  uint32_t synchronous_slave  : 1;      ///< supports Synchronous Slave mode
+  uint32_t single_wire        : 1;      ///< supports UART Single-wire mode
+  uint32_t irda               : 1;      ///< supports UART IrDA mode
+  uint32_t smart_card         : 1;      ///< supports UART Smart Card mode
+  uint32_t smart_card_clock   : 1;      ///< Smart Card Clock generator available
+  uint32_t flow_control_rts   : 1;      ///< RTS Flow Control available
+  uint32_t flow_control_cts   : 1;      ///< CTS Flow Control available
+  uint32_t event_tx_complete  : 1;      ///< Transmit completed event: \ref ARM_USART_EVENT_TX_COMPLETE
+  uint32_t event_rx_timeout   : 1;      ///< Signal receive character timeout event: \ref ARM_USART_EVENT_RX_TIMEOUT
+  uint32_t rts                : 1;      ///< RTS Line: 0=not available, 1=available
+  uint32_t cts                : 1;      ///< CTS Line: 0=not available, 1=available
+  uint32_t dtr                : 1;      ///< DTR Line: 0=not available, 1=available
+  uint32_t dsr                : 1;      ///< DSR Line: 0=not available, 1=available
+  uint32_t dcd                : 1;      ///< DCD Line: 0=not available, 1=available
+  uint32_t ri                 : 1;      ///< RI Line: 0=not available, 1=available
+  uint32_t event_cts          : 1;      ///< Signal CTS change event: \ref ARM_USART_EVENT_CTS
+  uint32_t event_dsr          : 1;      ///< Signal DSR change event: \ref ARM_USART_EVENT_DSR
+  uint32_t event_dcd          : 1;      ///< Signal DCD change event: \ref ARM_USART_EVENT_DCD
+  uint32_t event_ri           : 1;      ///< Signal RI change event: \ref ARM_USART_EVENT_RI
+  uint32_t reserved           : 11;     ///< Reserved (must be zero)
+} ARM_USART_CAPABILITIES;
+
+
+/**
+\brief Access structure of the USART Driver.
+*/
+typedef struct _ARM_DRIVER_USART {
+  ARM_DRIVER_VERSION     (*GetVersion)      (void);                              ///< Pointer to \ref ARM_USART_GetVersion : Get driver version.
+  ARM_USART_CAPABILITIES (*GetCapabilities) (void);                              ///< Pointer to \ref ARM_USART_GetCapabilities : Get driver capabilities.
+  int32_t                (*Initialize)      (ARM_USART_SignalEvent_t cb_event);  ///< Pointer to \ref ARM_USART_Initialize : Initialize USART Interface.
+  int32_t                (*Uninitialize)    (void);                              ///< Pointer to \ref ARM_USART_Uninitialize : De-initialize USART Interface.
+  int32_t                (*PowerControl)    (ARM_POWER_STATE state);             ///< Pointer to \ref ARM_USART_PowerControl : Control USART Interface Power.
+  int32_t                (*Send)            (const void *data, uint32_t num);    ///< Pointer to \ref ARM_USART_Send : Start sending data to USART transmitter.
+  int32_t                (*Receive)         (      void *data, uint32_t num);    ///< Pointer to \ref ARM_USART_Receive : Start receiving data from USART receiver.
+  int32_t                (*Transfer)        (const void *data_out,
+                                                   void *data_in,
+                                             uint32_t    num);                   ///< Pointer to \ref ARM_USART_Transfer : Start sending/receiving data to/from USART.
+  uint32_t               (*GetTxCount)      (void);                              ///< Pointer to \ref ARM_USART_GetTxCount : Get transmitted data count.
+  uint32_t               (*GetRxCount)      (void);                              ///< Pointer to \ref ARM_USART_GetRxCount : Get received data count.
+  int32_t                (*Control)         (uint32_t control, uint32_t arg);    ///< Pointer to \ref ARM_USART_Control : Control USART Interface.
+  ARM_USART_STATUS       (*GetStatus)       (void);                              ///< Pointer to \ref ARM_USART_GetStatus : Get USART status.
+  int32_t                (*SetModemControl) (ARM_USART_MODEM_CONTROL control);   ///< Pointer to \ref ARM_USART_SetModemControl : Set USART Modem Control line state.
+  ARM_USART_MODEM_STATUS (*GetModemStatus)  (void);                              ///< Pointer to \ref ARM_USART_GetModemStatus : Get USART Modem Status lines state.
+} const ARM_DRIVER_USART;
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif /* DRIVER_USART_H_ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART_CMSDK.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART_CMSDK.h
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DRIVER_USART_CMSDK_H__
+#define __DRIVER_USART_CMSDK_H__
+
+#include "Driver_USART_Common.h"
+#include "uart_cmsdk_drv.h"
+
+#ifndef CMSIS_device_header
+/* CMSIS pack default header, containing the CMSIS_device_header definition */
+#include "RTE_Components.h"
+#endif
+#include CMSIS_device_header
+
+extern uint32_t PeripheralClock;
+
+/* Driver Capabilities */
+static const ARM_USART_CAPABILITIES DriverCapabilities = {
+    1, /* supports UART (Asynchronous) mode */
+    0, /* supports Synchronous Master mode */
+    0, /* supports Synchronous Slave mode */
+    0, /* supports UART Single-wire mode */
+    0, /* supports UART IrDA mode */
+    0, /* supports UART Smart Card mode */
+    0, /* Smart Card Clock generator available */
+    0, /* RTS Flow Control available */
+    0, /* CTS Flow Control available */
+    0, /* Transmit completed event: \ref ARM_USARTx_EVENT_TX_COMPLETE */
+    0, /* Signal receive character timeout event: \ref ARM_USARTx_EVENT_RX_TIMEOUT */
+    0, /* RTS Line: 0=not available, 1=available */
+    0, /* CTS Line: 0=not available, 1=available */
+    0, /* DTR Line: 0=not available, 1=available */
+    0, /* DSR Line: 0=not available, 1=available */
+    0, /* DCD Line: 0=not available, 1=available */
+    0, /* RI Line: 0=not available, 1=available */
+    0, /* Signal CTS change event: \ref ARM_USARTx_EVENT_CTS */
+    0, /* Signal DSR change event: \ref ARM_USARTx_EVENT_DSR */
+    0, /* Signal DCD change event: \ref ARM_USARTx_EVENT_DCD */
+    0, /* Signal RI change event: \ref ARM_USARTx_EVENT_RI */
+    0  /* Reserved */
+};
+
+typedef struct {
+    struct uart_cmsdk_dev_t *dev;     /* UART device structure */
+    ARM_USART_SignalEvent_t cb_event; /* Callback function for events */
+    IRQn_Type rx_irq_number;          /* Num of the peripheral's rx IRQ line */
+    IRQn_Type tx_irq_number;          /* Num of the peripheral's tx IRQ line */
+    ARM_POWER_STATE state;            /* Active power state */
+    uint8_t initialized;              /* Is the peripheral initialized */
+
+    /* Databits can only be 8, so always use uint8_t for the buffers */
+    const uint8_t *tx_buffer;   /* TX buffer, it's allocated by the caller */
+    uint32_t tx_size;           /* Number of data items to transfer */
+    uint32_t tx_nbr_bytes;      /* Number of data items transfered */
+    uint8_t *rx_buffer;         /* RX buffer, it's allocated by the caller */
+    uint32_t rx_size;           /* Number of data items to receive */
+    uint32_t rx_nbr_bytes;      /* Number of data items recevied */
+} UARTx_Resources;
+
+static inline ARM_USART_CAPABILITIES ARM_USART_GetCapabilities(void);
+static inline int32_t ARM_USARTx_Initialize(UARTx_Resources *uart_dev, ARM_USART_SignalEvent_t cb_event);
+static inline int32_t ARM_USARTx_Uninitialize(UARTx_Resources *uart_dev);
+static inline int32_t ARM_USARTx_PowerControl(UARTx_Resources *uart_dev, ARM_POWER_STATE state);
+static inline int32_t ARM_USARTx_Send(UARTx_Resources *uart_dev, const void *data, uint32_t num);
+static inline int32_t ARM_USARTx_Receive(UARTx_Resources *uart_dev, void *data, uint32_t num);
+static inline uint32_t ARM_USARTx_GetTxCount(UARTx_Resources *uart_dev);
+static inline uint32_t ARM_USARTx_GetRxCount(UARTx_Resources *uart_dev);
+static ARM_USART_STATUS ARM_USARTx_GetStatus(UARTx_Resources *uart_dev);
+static inline int32_t ARM_USARTx_Control(UARTx_Resources *uart_dev, uint32_t control, uint32_t arg);
+
+static inline ARM_USART_CAPABILITIES ARM_USART_GetCapabilities(void)
+{
+    return DriverCapabilities;
+}
+
+static inline int32_t ARM_USARTx_Initialize(UARTx_Resources *uart_dev, ARM_USART_SignalEvent_t cb_event)
+{
+    uart_dev->cb_event = cb_event;
+    uart_dev->initialized = 1;
+
+    return ARM_DRIVER_OK;
+}
+
+static inline int32_t ARM_USARTx_Uninitialize(UARTx_Resources *uart_dev)
+{
+    ARM_USARTx_PowerControl(uart_dev, ARM_POWER_OFF);
+
+    /* Remove the callback so it won't be called
+     * if an interrupt happens */
+    uart_dev->cb_event = NULL;
+    uart_dev->initialized = 0;
+
+    return ARM_DRIVER_OK;
+}
+
+static inline int32_t ARM_USARTx_PowerControl(UARTx_Resources *uart_dev, ARM_POWER_STATE state)
+{
+    if (uart_dev->initialized != 1) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    switch (state) {
+        case ARM_POWER_OFF:
+            uart_cmsdk_irq_rx_disable(uart_dev->dev);
+            uart_cmsdk_irq_tx_disable(uart_dev->dev);
+
+            uart_cmsdk_rx_disable(uart_dev->dev);
+            uart_cmsdk_tx_disable(uart_dev->dev);
+
+            NVIC_DisableIRQ(uart_dev->rx_irq_number);
+            NVIC_DisableIRQ(uart_dev->tx_irq_number);
+
+            uart_dev->state = ARM_POWER_OFF;
+            return ARM_DRIVER_OK;
+        case ARM_POWER_LOW:
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+        case ARM_POWER_FULL:
+            if (uart_dev->state == ARM_POWER_FULL) {
+                return ARM_DRIVER_OK;
+            }
+
+            /* Initializes generic UART driver */
+            uart_cmsdk_init(uart_dev->dev, PeripheralClock);
+
+            /* Clear pending IRQs, if they were set before */
+            NVIC_ClearPendingIRQ(uart_dev->rx_irq_number);
+            NVIC_ClearPendingIRQ(uart_dev->tx_irq_number);
+
+            NVIC_EnableIRQ(uart_dev->rx_irq_number);
+            NVIC_EnableIRQ(uart_dev->tx_irq_number);
+
+            uart_cmsdk_irq_rx_enable(uart_dev->dev);
+            uart_cmsdk_irq_tx_enable(uart_dev->dev);
+
+            uart_dev->state = ARM_POWER_FULL;
+            return ARM_DRIVER_OK;
+
+            /* default:  The default is not defined intentionally to force the
+             *           compiler to check that all the enumeration values are
+             *           covered in the switch.*/
+    }
+
+    /* Invalid state requested */
+    return ARM_DRIVER_ERROR;
+}
+
+static inline int32_t ARM_USARTx_Send(UARTx_Resources *uart_dev, const void *data, uint32_t num)
+{
+    if (uart_dev->initialized != 1) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (uart_dev->state != ARM_POWER_FULL) {
+        return ARM_DRIVER_ERROR;
+    }
+    if ((data == NULL) || (num == 0U)) {
+        /* Invalid parameters */
+        return ARM_DRIVER_ERROR_PARAMETER;
+    }
+
+    /* Data buffer must stay allocated during the transfer, it's the caller's
+     * responsibility */
+    uart_dev->tx_buffer = (const uint8_t *)data;
+    uart_dev->tx_size = num;
+    uart_dev->tx_nbr_bytes = 0;
+
+    /* Only trigger the transaction. The rest of the logic will be in the IRQ handler:
+     * the CMSDK UART generates an IRQ after each sent bytes */
+    /* The caller has to make sure that the peripheral is ready */
+    if (UART_CMSDK_ERR_NONE != uart_cmsdk_write(uart_dev->dev, *uart_dev->tx_buffer)) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    return ARM_DRIVER_OK;
+}
+
+static inline int32_t ARM_USARTx_Receive(UARTx_Resources *uart_dev, void *data, uint32_t num)
+{
+    uint8_t placeholder_data;
+
+    if (uart_dev->initialized != 1) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (uart_dev->state != ARM_POWER_FULL) {
+        return ARM_DRIVER_ERROR;
+    }
+    if ((data == NULL) || (num == 0U)) {
+        /* Invalid parameters */
+        return ARM_DRIVER_ERROR_PARAMETER;
+    }
+
+    /* Read out any unread data from fifo */
+    placeholder_data = 0;
+    while (uart_cmsdk_rx_ready(uart_dev->dev) == 1) {
+        uart_cmsdk_read(uart_dev->dev, &placeholder_data);
+    }
+
+    /* Resets previous RX transaction values */
+    /* Data buffer must stay allocated during the transfer, it's the caller's
+     * responsibility */
+    uart_dev->rx_buffer = (uint8_t *)data;
+    uart_dev->rx_size = num;
+    uart_dev->rx_nbr_bytes = 0;
+
+    /* The rest of the logic is in the IRQ handler: the CMSDK UART
+     * generates an IRQ after each received bytes */
+
+    return ARM_DRIVER_OK;
+}
+
+static inline int32_t ARM_USARTx_Transfer(UARTx_Resources *uart_dev, const void *data_out, void *data_in, uint32_t num)
+{
+    ARG_UNUSED(data_out);
+    ARG_UNUSED(data_in);
+    ARG_UNUSED(num);
+
+    if (uart_dev->initialized != 1) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (uart_dev->state != ARM_POWER_FULL) {
+        return ARM_DRIVER_ERROR;
+    }
+    return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+static inline uint32_t ARM_USARTx_GetTxCount(UARTx_Resources *uart_dev)
+{
+    return uart_dev->tx_nbr_bytes;
+}
+
+static inline uint32_t ARM_USARTx_GetRxCount(UARTx_Resources *uart_dev)
+{
+    return uart_dev->rx_nbr_bytes;
+}
+
+static ARM_USART_STATUS ARM_USARTx_GetStatus(UARTx_Resources *uart_dev)
+{
+    ARM_USART_STATUS status = {0};
+
+    /* The RX and TX buffers are only set when the operation is
+     * ongoing */
+    status.tx_busy = uart_dev->tx_buffer == NULL ? 0 : 1;
+    status.rx_busy = uart_dev->rx_buffer == NULL ? 0 : 1;
+
+    return status;
+}
+
+static inline int32_t ARM_USARTx_Control(UARTx_Resources *uart_dev, uint32_t control, uint32_t arg)
+{
+    if (uart_dev->initialized != 1) {
+        return ARM_DRIVER_ERROR;
+    }
+    if (uart_dev->state != ARM_POWER_FULL) {
+        return ARM_DRIVER_ERROR;
+    }
+
+    switch (control & ARM_USART_CONTROL_Msk) {
+        case ARM_USART_CONTROL_TX:
+            if (arg == 0) {
+                uart_cmsdk_tx_disable(uart_dev->dev);
+            } else if (arg == 1) {
+                if (uart_cmsdk_tx_enable(uart_dev->dev) != UART_CMSDK_ERR_NONE) {
+                    return ARM_DRIVER_ERROR;
+                }
+            } else {
+                return ARM_DRIVER_ERROR_PARAMETER;
+            }
+            break;
+        case ARM_USART_CONTROL_RX:
+            if (arg == 0) {
+                uart_cmsdk_rx_disable(uart_dev->dev);
+            } else if (arg == 1) {
+                if (uart_cmsdk_rx_enable(uart_dev->dev) != UART_CMSDK_ERR_NONE) {
+                    return ARM_DRIVER_ERROR;
+                }
+            } else {
+                return ARM_DRIVER_ERROR_PARAMETER;
+            }
+            break;
+        case ARM_USART_MODE_ASYNCHRONOUS:
+            if (uart_cmsdk_set_baudrate(uart_dev->dev, arg) != UART_CMSDK_ERR_NONE) {
+                return ARM_USART_ERROR_BAUDRATE;
+            }
+            break;
+        case ARM_USART_ABORT_SEND:
+            uart_dev->tx_buffer = NULL;
+            uart_dev->tx_nbr_bytes = 0;
+            uart_dev->tx_size = 0;
+            break;
+        case ARM_USART_ABORT_RECEIVE:
+            uart_dev->rx_buffer = NULL;
+            uart_dev->rx_nbr_bytes = 0;
+            uart_dev->rx_size = 0;
+            break;
+        /* Unsupported command */
+        default:
+            return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+
+    /* UART Data bits */
+    if (control & ARM_USART_DATA_BITS_Msk) {
+        /* Data bit is not configurable */
+        return ARM_DRIVER_ERROR_UNSUPPORTED;
+    }
+
+    /* UART Parity */
+    if (control & ARM_USART_PARITY_Msk) {
+        /* Parity is not configurable */
+        return ARM_USART_ERROR_PARITY;
+    }
+
+    /* USART Stop bits */
+    if (control & ARM_USART_STOP_BITS_Msk) {
+        /* Stop bit is not configurable */
+        return ARM_USART_ERROR_STOP_BITS;
+    }
+
+    return ARM_DRIVER_OK;
+}
+
+/*
+ * \brief Macro for USART CMSDK Driver
+ *
+ * \param[in]  USART_DEV          Native driver device
+ *                                \ref uart_cmsdk_dev_t
+ * \param[out] USART_DRIVER_NAME  Resulting Driver name
+ */
+#define ARM_DRIVER_USART_CMSDK(USART_DEV, USART_DRIVER_NAME, RX_IRQ_HANDLER, TX_IRQ_HANDLER, RX_IRQ_NUM, TX_IRQ_NUM) \
+                                                                                                                     \
+    static UARTx_Resources USART_DRIVER_NAME##_DEV = {                                                               \
+        .dev = &USART_DEV,                                                                                           \
+        .tx_nbr_bytes = 0,                                                                                           \
+        .rx_nbr_bytes = 0,                                                                                           \
+        .cb_event = NULL,                                                                                            \
+        .rx_irq_number = RX_IRQ_NUM,                                                                                 \
+        .tx_irq_number = TX_IRQ_NUM,                                                                                 \
+    };                                                                                                               \
+                                                                                                                     \
+    void RX_IRQ_HANDLER(void);                                                                                       \
+    void TX_IRQ_HANDLER(void);                                                                                       \
+                                                                                                                     \
+    void RX_IRQ_HANDLER(void)                                                                                        \
+    {                                                                                                                \
+        uart_cmsdk_clear_interrupt(USART_DRIVER_NAME##_DEV.dev, UART_CMSDK_IRQ_RX);                                  \
+                                                                                                                     \
+        /* If RX buffer is NULL then there's no active Receive operation,                                            \
+         * just flush the input fifo. */                                                                             \
+        if (USART_DRIVER_NAME##_DEV.rx_buffer == NULL) {                                                             \
+            uint8_t placeholder_data;                                                                                \
+            uart_cmsdk_read(USART_DRIVER_NAME##_DEV.dev, &placeholder_data);                                         \
+            return;                                                                                                  \
+        }                                                                                                            \
+                                                                                                                     \
+        /* The return value is ignored because the RX FIFO has to be full if the interrupt happend */                \
+        uart_cmsdk_read(USART_DRIVER_NAME##_DEV.dev,                                                                 \
+                        &USART_DRIVER_NAME##_DEV.rx_buffer[USART_DRIVER_NAME##_DEV.rx_nbr_bytes]);                   \
+        USART_DRIVER_NAME##_DEV.rx_nbr_bytes++;                                                                      \
+                                                                                                                     \
+        if (USART_DRIVER_NAME##_DEV.rx_nbr_bytes == USART_DRIVER_NAME##_DEV.rx_size) {                               \
+            USART_DRIVER_NAME##_DEV.rx_buffer = NULL;                                                                \
+            if (USART_DRIVER_NAME##_DEV.cb_event != NULL) {                                                          \
+                USART_DRIVER_NAME##_DEV.cb_event(ARM_USART_EVENT_RECEIVE_COMPLETE);                                  \
+            }                                                                                                        \
+        }                                                                                                            \
+    }                                                                                                                \
+                                                                                                                     \
+    void TX_IRQ_HANDLER(void)                                                                                        \
+    {                                                                                                                \
+        uart_cmsdk_clear_interrupt(USART_DRIVER_NAME##_DEV.dev, UART_CMSDK_IRQ_TX);                                  \
+                                                                                                                     \
+        /* If TX buffer is NULL then there's no active Send operation */                                             \
+        if (USART_DRIVER_NAME##_DEV.tx_buffer == NULL) {                                                             \
+            return;                                                                                                  \
+        }                                                                                                            \
+                                                                                                                     \
+        USART_DRIVER_NAME##_DEV.tx_nbr_bytes++;                                                                      \
+                                                                                                                     \
+        if (USART_DRIVER_NAME##_DEV.tx_nbr_bytes == USART_DRIVER_NAME##_DEV.tx_size) {                               \
+            USART_DRIVER_NAME##_DEV.tx_buffer = NULL;                                                                \
+            if (USART_DRIVER_NAME##_DEV.cb_event != NULL) {                                                          \
+                USART_DRIVER_NAME##_DEV.cb_event(ARM_USART_EVENT_SEND_COMPLETE);                                     \
+            }                                                                                                        \
+        } else {                                                                                                     \
+            /* The return value is ignored because the TX FIFO has to be empty if the interrupt happend */           \
+            uart_cmsdk_write(USART_DRIVER_NAME##_DEV.dev,                                                            \
+                             USART_DRIVER_NAME##_DEV.tx_buffer[USART_DRIVER_NAME##_DEV.tx_nbr_bytes]);               \
+        }                                                                                                            \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_Initialize(ARM_USART_SignalEvent_t cb_event)                                  \
+    {                                                                                                                \
+        return ARM_USARTx_Initialize(&USART_DRIVER_NAME##_DEV, cb_event);                                            \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_Uninitialize(void)                                                            \
+    {                                                                                                                \
+        return ARM_USARTx_Uninitialize(&USART_DRIVER_NAME##_DEV);                                                    \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_PowerControl(ARM_POWER_STATE state)                                           \
+    {                                                                                                                \
+        return ARM_USARTx_PowerControl(&USART_DRIVER_NAME##_DEV, state);                                             \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_Send(const void *data, uint32_t num)                                          \
+    {                                                                                                                \
+        return ARM_USARTx_Send(&USART_DRIVER_NAME##_DEV, data, num);                                                 \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_Receive(void *data, uint32_t num)                                             \
+    {                                                                                                                \
+        return ARM_USARTx_Receive(&USART_DRIVER_NAME##_DEV, data, num);                                              \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_Transfer(const void *data_out, void *data_in, uint32_t num)                   \
+    {                                                                                                                \
+        return ARM_USARTx_Transfer(&USART_DRIVER_NAME##_DEV, data_out, data_in, num);                                \
+    }                                                                                                                \
+                                                                                                                     \
+    static uint32_t USART_DRIVER_NAME##_GetTxCount(void)                                                             \
+    {                                                                                                                \
+        return ARM_USARTx_GetTxCount(&USART_DRIVER_NAME##_DEV);                                                      \
+    }                                                                                                                \
+                                                                                                                     \
+    static uint32_t USART_DRIVER_NAME##_GetRxCount(void)                                                             \
+    {                                                                                                                \
+        return ARM_USARTx_GetRxCount(&USART_DRIVER_NAME##_DEV);                                                      \
+    }                                                                                                                \
+    static int32_t USART_DRIVER_NAME##_Control(uint32_t control, uint32_t arg)                                       \
+    {                                                                                                                \
+        return ARM_USARTx_Control(&USART_DRIVER_NAME##_DEV, control, arg);                                           \
+    }                                                                                                                \
+                                                                                                                     \
+    static ARM_USART_STATUS USART_DRIVER_NAME##_GetStatus(void)                                                      \
+    {                                                                                                                \
+        return ARM_USARTx_GetStatus(&USART_DRIVER_NAME##_DEV);                                                       \
+    }                                                                                                                \
+                                                                                                                     \
+    static int32_t USART_DRIVER_NAME##_SetModemControl(ARM_USART_MODEM_CONTROL control)                              \
+    {                                                                                                                \
+        ARG_UNUSED(control);                                                                                         \
+        return ARM_DRIVER_ERROR_UNSUPPORTED;                                                                         \
+    }                                                                                                                \
+                                                                                                                     \
+    static ARM_USART_MODEM_STATUS USART_DRIVER_NAME##_GetModemStatus(void)                                           \
+    {                                                                                                                \
+        ARM_USART_MODEM_STATUS modem_status = {0, 0, 0, 0, 0};                                                       \
+        return modem_status;                                                                                         \
+    }                                                                                                                \
+                                                                                                                     \
+    extern ARM_DRIVER_USART USART_DRIVER_NAME;                                                                       \
+    ARM_DRIVER_USART USART_DRIVER_NAME = {ARM_USART_GetVersion,                                                      \
+                                          ARM_USART_GetCapabilities,                                                 \
+                                          USART_DRIVER_NAME##_Initialize,                                            \
+                                          USART_DRIVER_NAME##_Uninitialize,                                          \
+                                          USART_DRIVER_NAME##_PowerControl,                                          \
+                                          USART_DRIVER_NAME##_Send,                                                  \
+                                          USART_DRIVER_NAME##_Receive,                                               \
+                                          USART_DRIVER_NAME##_Transfer,                                              \
+                                          USART_DRIVER_NAME##_GetTxCount,                                            \
+                                          USART_DRIVER_NAME##_GetRxCount,                                            \
+                                          USART_DRIVER_NAME##_Control,                                               \
+                                          USART_DRIVER_NAME##_GetStatus,                                             \
+                                          USART_DRIVER_NAME##_SetModemControl,                                       \
+                                          USART_DRIVER_NAME##_GetModemStatus}
+
+#endif /* __DRIVER_USART_CMSDK_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART_Common.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/Driver_USART_Common.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DRIVER_USART_COMMON_H__
+#define __DRIVER_USART_COMMON_H__
+
+#include "Driver_USART.h"
+
+#ifndef ARG_UNUSED
+#define ARG_UNUSED(arg)  (void)arg
+#endif
+
+/* Driver version */
+#define ARM_USART_DRV_VERSION  ARM_DRIVER_VERSION_MAJOR_MINOR(3, 0)
+
+/* Driver Version */
+static const ARM_DRIVER_VERSION DriverVersion = {
+    ARM_USART_API_VERSION,
+    ARM_USART_DRV_VERSION
+};
+
+static inline ARM_DRIVER_VERSION ARM_USART_GetVersion(void)
+{
+    return DriverVersion;
+}
+
+#endif /* __DRIVER_USART_COMMON_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/RTE_Components.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/RTE_Components.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-2024 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*-------- <<< Use Configuration Wizard in Context Menu >>> -------------------- */
+
+#ifndef __RTE_COMPONENTS_H
+#define __RTE_COMPONENTS_H
+
+/* <q> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0] */
+/* <i> Configuration settings for Driver_USART0 in component ::Drivers:USART */
+#define   RTE_USART0    1
+
+/* <q> IO (Input- Output) [arm_mps3_io_drv] */
+/* <i> Configuration settings for ARM MPS3 IO SCC in component ::Native Driver:arm_mps3_io_drv */
+#define   RTE_MPS3_IO    1
+
+#endif /* __RTE_COMPONENTS_H */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/SSE310MPS3.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/SSE310MPS3.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021-2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CORSTONE310_H__
+#define __CORSTONE310_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ======================  Start of section using anonymous unions  ============== */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+
+/* ========  Configuration of Core Peripherals  ================================== */
+#define __CM85_REV                0x0002U   /* Core revision r0p2 */
+#define __SAUREGION_PRESENT       1U        /* SAU regions present */
+#define __MPU_PRESENT             1U        /* MPU present */
+#define __VTOR_PRESENT            1U        /* VTOR present */
+#define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             1U        /* FPU present */
+#define __FPU_DP                  1U        /* double precision FPU */
+#define __DSP_PRESENT             1U        /* DSP extension present */
+#define __PMU_PRESENT             1U        /* PMU present */
+#define __PMU_NUM_EVENTCNT        8U        /* Number of PMU event counters */
+#define __ICACHE_PRESENT          1U        /* Instruction Cache present */
+#define __DCACHE_PRESENT          1U        /* Data Cache present */
+
+#include "platform_irq.h"
+#include "core_cm85.h"                      /* Processor and core peripherals */
+#include "platform_base_address.h"
+#include "platform_regs.h"
+#include "platform_pins.h"
+#include "system_SSE310MPS3.h"
+
+/* =====================  End of section using anonymous unions  ================ */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORSTONE310_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/arm_mps3_io_drv.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/arm_mps3_io_drv.h
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2021 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file arm_mps3_io_drv.h
+ * \brief Generic driver for ARM MPS3 FPGAIO.
+    Features of ARM MPS3 FPGAIO driver:
+        1. Read/Write LED status
+        2. Read button status
+        3. Read switches status
+        4. Read/Write counter values
+        5. Enable/Disable SHIELD0, SHIELD1, ADC
+        6. Read/Write Misc control register
+*/
+
+#ifndef __ARM_MPS3_IO_DRV_H__
+#define __ARM_MPS3_IO_DRV_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ARM MPS3 IO enumeration types */
+enum arm_mps3_io_access_t {
+    ARM_MPS3_IO_ACCESS_PIN = 0,  /*!< Pin access to MPS3 IO */
+    ARM_MPS3_IO_ACCESS_PORT      /*!< Port access to MPS3 IO */
+};
+
+/* ARM MPS3 IO device configuration structure */
+struct arm_mps3_io_dev_cfg_t {
+    const uint32_t base;                 /*!< MPS3 IO base address */
+};
+
+/* ARM MPS3 IO device structure */
+struct arm_mps3_io_dev_t {
+    const struct arm_mps3_io_dev_cfg_t* const cfg; /*!< MPS3 IO configuration */
+};
+
+/**
+ * \brief  Writes to output LEDs.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] access   Access type \ref arm_mps3_io_access_t
+ * \param[in] pin_num  Pin number.
+ * \param[in] value    Value(s) to set.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_leds(struct arm_mps3_io_dev_t* dev,
+                            enum arm_mps3_io_access_t access,
+                            uint8_t pin_num,
+                            uint32_t value);
+
+/**
+ * \brief Reads the buttons status.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ * \param[in] access   Access type \ref arm_mps3_io_access_t
+ * \param[in] pin_num  Pin number.
+ *
+ * \return Returns bit value for Pin access or port value for port access.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_buttons(struct arm_mps3_io_dev_t* dev,
+                                  enum arm_mps3_io_access_t access,
+                                  uint8_t pin_num);
+
+/**
+ * \brief Reads the switches status.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ * \param[in] access   Access type \ref arm_mps3_io_access_t
+ * \param[in] pin_num  Pin number.
+ *
+ * \return Returns bit value for Pin access or port value for port access.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+ uint32_t arm_mps3_io_read_switches(struct arm_mps3_io_dev_t* dev,
+                                      enum arm_mps3_io_access_t access,
+                                      uint8_t pin_num);
+
+/**
+ * \brief Reads the LED status.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ * \param[in] access   Access type \ref arm_mps3_io_access_t
+ * \param[in] pin_num  Pin number.
+ *
+ * \return Returns bit value for Pin access or port value for port access.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_leds(struct arm_mps3_io_dev_t* dev,
+                               enum arm_mps3_io_access_t access,
+                               uint8_t pin_num);
+
+/**
+ * \brief Reads the 100hz up counter value.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns 100hz up counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_clk100hz(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Sets value for 100hz up counter.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] value    Counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_clk100hz(struct arm_mps3_io_dev_t* dev,
+                                   uint32_t value);
+
+/**
+ * \brief Reads the 1hz up counter value.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns 1hz up counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_clk1hz(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Sets value for 1hz up counter.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] value    Counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_clk1hz(struct arm_mps3_io_dev_t* dev,
+                                   uint32_t value);
+
+/**
+ * \brief Reads the Cycle Up Counter value.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns cycle up counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_counter(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Sets value for Cycle up counter.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] value    Counter value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_counter(struct arm_mps3_io_dev_t* dev,
+                                   uint32_t value);
+
+/**
+ * \brief Reads the Prescale counter value.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns current value of the pre-scaler counter.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_pscntr(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Reads reload value for prescale counter.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns reload value for prescale counter.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_prescale(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Sets reload value for prescale counter.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] value    Reload value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_prescale(struct arm_mps3_io_dev_t* dev,
+                                   uint32_t value);
+
+/**
+ * \brief Get MISC register value.
+ *
+ * \param[in] dev      MPS3 IO device where to read \ref arm_mps3_io_dev_t
+ *
+ * \return Returns MISC register value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t arm_mps3_io_read_misc(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Set MISC register value.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ * \param[in] value    Value to set for MISC register value
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_write_misc(struct arm_mps3_io_dev_t* dev,
+                                        uint32_t value);
+
+/**
+ * \brief Enable SHIELD0_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_enable_shield0_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Disable SHIELD0_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_disable_shield0_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Enable SHIELD1_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_enable_shield1_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Disable SHIELD1_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_disable_shield1_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Enable ADC_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_enable_adc_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+/**
+ * \brief Disable ADC_SPI_nCS.
+ *
+ * \param[in] dev      MPS3 IO device where to write \ref arm_mps3_io_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void arm_mps3_io_disable_adc_spi_ncs(struct arm_mps3_io_dev_t* dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARM_MPS3_IO_DRV_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/bsp_serial.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/bsp_serial.h
@@ -1,0 +1,22 @@
+/* Copyright 2017-2024 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __SERIAL_H__
+#define __SERIAL_H__
+
+
+#include <stddef.h>
+
+/**
+ * \brief Initializes default UART device
+ */
+void bsp_serial_init( void );
+
+/**
+ * \brief Prints a string through the default UART device
+ */
+void bsp_serial_print( char * str );
+
+#endif /* __SERIAL_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_compiler.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_compiler.h
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Compiler Generic Header File
+ */
+
+#ifndef __CMSIS_COMPILER_H
+#define __CMSIS_COMPILER_H
+
+#include <stdint.h>
+
+/*
+ * Arm Compiler above 6.10.1 (armclang)
+ */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6100100)
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "./a-profile/cmsis_armclang_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "./r-profile/cmsis_armclang_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "./m-profile/cmsis_armclang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+/*
+ * TI Arm Clang Compiler (tiarmclang)
+ */
+#elif defined (__ti__)
+  #if __ARM_ARCH_PROFILE == 'A'
+    #error "Core-A is not supported for this compiler"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #error "Core-R is not supported for this compiler"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_tiarmclang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * LLVM/Clang Compiler
+ */
+#elif defined ( __clang__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_clang_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_clang_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_clang_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * GNU Compiler
+ */
+#elif defined ( __GNUC__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_gcc_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_gcc_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_gcc_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * IAR Compiler
+ */
+#elif defined ( __ICCARM__ )
+  #if __ARM_ARCH_PROFILE == 'A'
+    #include "a-profile/cmsis_iccarm_a.h"
+  #elif __ARM_ARCH_PROFILE == 'R'
+    #include "r-profile/cmsis_iccarm_r.h"
+  #elif __ARM_ARCH_PROFILE == 'M'
+    #include "m-profile/cmsis_iccarm_m.h"
+  #else
+    #error "Unknown Arm architecture profile"
+  #endif
+
+
+/*
+ * TI Arm Compiler (armcl)
+ */
+#elif defined ( __TI_ARM__ )
+  #include <cmsis_ccs.h>
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __attribute__((packed))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void*)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)                           __attribute__((aligned(x)))
+  #endif
+  #ifndef   __RESTRICT
+    #define __RESTRICT                             __restrict
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+/*
+ * TASKING Compiler
+ */
+#elif defined ( __TASKING__ )
+  /*
+   * The CMSIS functions have been implemented as intrinsics in the compiler.
+   * Please use "carm -?i" to get an up to date list of all intrinsics,
+   * Including the CMSIS ones.
+   */
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __packed__
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __packed__
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __packed__
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)                           __align(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+/*
+ * COSMIC Compiler
+ */
+#elif defined ( __CSMC__ )
+   #include <cmsis_csm.h>
+
+ #ifndef   __ASM
+    #define __ASM                                  _asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __STATIC_FORCEINLINE
+    #define __STATIC_FORCEINLINE                   __STATIC_INLINE
+  #endif
+  #ifndef   __NO_RETURN
+    // NO RETURN is automatically detected hence no warning here
+    #define __NO_RETURN
+  #endif
+  #ifndef   __USED
+    #warning No compiler specific solution for __USED. __USED is ignored.
+    #define __USED
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __weak
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               @packed
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        @packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         @packed union
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #warning No compiler specific solution for __ALIGNED. __ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+  #ifndef   __COMPILER_BARRIER
+    #warning No compiler specific solution for __COMPILER_BARRIER. __COMPILER_BARRIER is ignored.
+    #define __COMPILER_BARRIER()                   (void)0
+  #endif
+  #ifndef __NO_INIT
+    #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #endif
+  #ifndef __ALIAS
+    #define __ALIAS(x)                             __attribute__ ((alias(x)))
+  #endif
+
+#else
+  #error Unknown compiler.
+#endif
+
+
+#endif /* __CMSIS_COMPILER_H */
+

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_driver_config.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_driver_config.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019-2024 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_DRIVER_CONFIG_H__
+#define __CMSIS_DRIVER_CONFIG_H__
+
+#include "device_cfg.h"
+#include "device_definition.h"
+#include "platform_base_address.h"
+#include "system_SSE310MPS3.h"
+
+#endif /* __CMSIS_DRIVER_CONFIG_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_version.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/cmsis_version.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2009-2023 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Core Version Definitions
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CMSIS_VERSION_H
+#define __CMSIS_VERSION_H
+
+/*  CMSIS-Core(M) Version definitions */
+#define __CM_CMSIS_VERSION_MAIN  ( 6U)                                    /*!< \brief [31:16] CMSIS-Core(M) main version */
+#define __CM_CMSIS_VERSION_SUB   ( 0U)                                    /*!< \brief [15:0]  CMSIS-Core(M) sub version */
+#define __CM_CMSIS_VERSION       ((__CM_CMSIS_VERSION_MAIN << 16U) | \
+                                   __CM_CMSIS_VERSION_SUB           )     /*!< \brief CMSIS Core(M) version number */
+
+/*  CMSIS-Core(A) Version definitions */
+#define __CA_CMSIS_VERSION_MAIN  ( 6U)                                    /*!< \brief [31:16] CMSIS-Core(A) main version */
+#define __CA_CMSIS_VERSION_SUB   ( 0U)                                    /*!< \brief [15:0]  CMSIS-Core(A) sub version */
+#define __CA_CMSIS_VERSION       ((__CA_CMSIS_VERSION_MAIN << 16U) | \
+                                   __CA_CMSIS_VERSION_SUB          )      /*!< \brief CMSIS-Core(A) version number */
+
+#endif

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/core_cm85.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/core_cm85.h
@@ -1,0 +1,4765 @@
+/*
+ * Copyright (c) 2022-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS Cortex-M85 Core Peripheral Access Layer Header File
+ */
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#endif
+
+#ifndef __CORE_CM85_H_GENERIC
+#define __CORE_CM85_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M85
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/* CMSIS CM85 definitions */
+
+#define __CORTEX_M                (85U)                               /*!< Cortex-M Core */
+
+#if defined ( __CC_ARM )
+  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined (__ARMVFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined (__TI_VFP_SUPPORT__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined (__FPU_VFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM85_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM85_H_DEPENDANT
+#define __CORE_CM85_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM85_REV
+    #define __CM85_REV               0x0001U
+    #warning "__CM85_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __FPU_PRESENT != 0U
+    #ifndef __FPU_DP
+      #define __FPU_DP             0U
+      #warning "__FPU_DP not defined in device header file; using default!"
+    #endif
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __PMU_PRESENT
+    #define __PMU_PRESENT             0U
+    #warning "__PMU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #if __PMU_PRESENT != 0U
+    #ifndef __PMU_NUM_EVENTCNT
+      #define __PMU_NUM_EVENTCNT      8U
+      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
+    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+    #endif
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M85 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core EWIC Register
+  - Core EWIC Interrupt Status Access Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core PMU Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/** \brief APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/** \brief IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:1;               /*!< bit:     20  Reserved */
+    uint32_t B:1;                        /*!< bit:     21  BTI active       (read 0) */
+    uint32_t _reserved2:2;               /*!< bit: 22..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/** \brief xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_B_Pos                         21U                                            /*!< xPSR: B Position */
+#define xPSR_B_Msk                         (1UL << xPSR_B_Pos)                            /*!< xPSR: B Mask */
+
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t BTI_EN:1;                   /*!< bit:      4  Privileged branch target identification enable */
+    uint32_t UBTI_EN:1;                  /*!< bit:      5  Unprivileged branch target identification enable */
+    uint32_t PAC_EN:1;                   /*!< bit:      6  Privileged pointer authentication enable */
+    uint32_t UPAC_EN:1;                  /*!< bit:      7  Unprivileged pointer authentication enable */
+    uint32_t _reserved1:24;              /*!< bit:  8..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/** \brief CONTROL Register Definitions */
+#define CONTROL_UPAC_EN_Pos                 7U                                            /*!< CONTROL: UPAC_EN Position */
+#define CONTROL_UPAC_EN_Msk                (1UL << CONTROL_UPAC_EN_Pos)                   /*!< CONTROL: UPAC_EN Mask */
+
+#define CONTROL_PAC_EN_Pos                  6U                                            /*!< CONTROL: PAC_EN Position */
+#define CONTROL_PAC_EN_Msk                 (1UL << CONTROL_PAC_EN_Pos)                    /*!< CONTROL: PAC_EN Mask */
+
+#define CONTROL_UBTI_EN_Pos                 5U                                            /*!< CONTROL: UBTI_EN Position */
+#define CONTROL_UBTI_EN_Msk                (1UL << CONTROL_UBTI_EN_Pos)                   /*!< CONTROL: UBTI_EN Mask */
+
+#define CONTROL_BTI_EN_Pos                  4U                                            /*!< CONTROL: BTI_EN Position */
+#define CONTROL_BTI_EN_Msk                 (1UL << CONTROL_BTI_EN_Pos)                    /*!< CONTROL: BTI_EN Mask */
+
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RESERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
+
+/** \brief NVIC Software Triggered Interrupt Register Definitions */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+        uint32_t RESERVED4[14U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
+
+/** \brief SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/** \brief SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+/** \brief SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+
+/** \brief SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
+#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
+
+#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
+#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/** \brief SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/** \brief SCB Configuration Control Register Definitions */
+#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
+#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
+
+#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
+#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
+
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/** \brief SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/** \brief SCB Configurable Fault Status Register Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/** \brief SCB MemManage Fault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+
+/** \brief SCB BusFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+
+/** \brief SCB UsageFault Status Register Definitions (part of SCB Configurable Fault Status Register) */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+
+/** \brief SCB Hard Fault Status Register Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/** \brief SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
+#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
+
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+
+/** \brief SCB Non-Secure Access Control Register Definitions */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+
+#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
+#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
+
+#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
+#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
+
+#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
+#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
+
+#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
+#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
+
+#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
+#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
+
+#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
+#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
+
+#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
+#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
+
+#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
+#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
+
+/** \brief SCB Debug Feature Register 0 Definitions */
+#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
+#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
+
+#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
+#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
+
+/** \brief SCB Cache Level ID Register Definitions */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+
+/** \brief SCB Cache Type Register Definitions */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+
+/** \brief SCB Cache Size ID Register Definitions */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+
+/** \brief SCB Cache Size Selection Register Definitions */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+
+/** \brief SCB Software Triggered Interrupt Register Definitions */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+
+/** \brief SCB RAS Fault Status Register Definitions */
+#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
+#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
+
+#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
+#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
+
+#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
+#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
+
+/** \brief SCB D-Cache Invalidate by Set-way Register Definitions */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+
+/** \brief SCB D-Cache Clean by Set-way Register Definitions */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+
+/** \brief SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+  \brief    Type definitions for the Implementation Control Block Register
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Implementation Control Block (ICB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} ICB_Type;
+
+/** \brief ICB Auxiliary Control Register Definitions */
+#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
+#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
+
+#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
+#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
+#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
+
+#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
+#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
+
+#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
+#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
+
+#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
+#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
+
+#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
+#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
+
+/** \brief ICB Interrupt Controller Type Register Definitions */
+#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
+#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
+
+/*@} end of group CMSIS_ICB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/** \brief SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/** \brief SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/** \brief SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/** \brief SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} ITM_Type;
+
+/** \brief ITM Stimulus Port Register Definitions */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (1UL << ITM_STIM_DISABLED_Pos)                 /*!< ITM STIM: DISABLED Mask */
+
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (1UL /*<< ITM_STIM_FIFOREADY_Pos*/)            /*!< ITM STIM: FIFOREADY Mask */
+
+/** \brief ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+
+/** \brief ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+
+/** \brief ITM Integration Read Register Definitions */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (1UL << ITM_ITREAD_AFVALID_Pos)                /*!< ITM ITREAD: AFVALID Mask */
+
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (1UL /*<< ITM_ITREAD_ATREADY_Pos*/)            /*!< ITM ITREAD: ATREADY Mask */
+
+/** \brief ITM Integration Write Register Definitions */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (1UL << ITM_ITWRITE_AFVALID_Pos)               /*!< ITM ITWRITE: AFVALID Mask */
+
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)           /*!< ITM ITWRITE: ATREADY Mask */
+
+/** \brief ITM Integration Mode Control Register Definitions */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (1UL /*<< ITM_ITCTRL_IME_Pos*/)                /*!< ITM ITCTRL: IME Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED14[968U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
+
+/** \brief DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (1UL << DWT_CTRL_NOTRCPKT_Pos)              /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (1UL << DWT_CTRL_NOEXTTRIG_Pos)             /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (1UL << DWT_CTRL_NOCYCCNT_Pos)              /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (1UL << DWT_CTRL_NOPRFCNT_Pos)              /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (1UL << DWT_CTRL_CYCDISS_Pos)               /*!< DWT CTRL: CYCDISS Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (1UL << DWT_CTRL_CYCEVTENA_Pos)             /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (1UL << DWT_CTRL_FOLDEVTENA_Pos)            /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (1UL << DWT_CTRL_LSUEVTENA_Pos)             /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (1UL << DWT_CTRL_SLEEPEVTENA_Pos)           /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (1UL << DWT_CTRL_EXCEVTENA_Pos)             /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (1UL << DWT_CTRL_CPIEVTENA_Pos)             /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (1UL << DWT_CTRL_EXCTRCENA_Pos)             /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (1UL << DWT_CTRL_PCSAMPLENA_Pos)            /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (1UL << DWT_CTRL_CYCTAP_Pos)                /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)         /*!< DWT CTRL: CYCCNTENA Mask */
+
+/** \brief DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+
+/** \brief DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+
+/** \brief DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/** \brief DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+
+/** \brief DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/** \brief DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (1UL << DWT_FUNCTION_MATCHED_Pos)           /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+  __IOM uint32_t PFCR;                   /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+        uint32_t RESERVED2[313U];
+  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+        uint32_t RESERVED3[2U];
+  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+        uint32_t RESERVED4[44U];
+  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+        uint32_t RESERVED5[2U];
+  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+} MemSysCtl_Type;
+
+/** \brief MemSysCtl Memory System Control Register Definitions */
+#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
+#define MEMSYSCTL_MSCR_CPWRDN_Msk          (1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)          /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+
+#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)         /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+
+#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)        /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)        /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)      /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+
+#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)      /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+
+#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+#define MEMSYSCTL_MSCR_FORCEWT_Msk         (1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)         /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+
+#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+#define MEMSYSCTL_MSCR_ECCEN_Msk           (1UL << MEMSYSCTL_MSCR_ECCEN_Pos)           /*!< MEMSYSCTL MSCR: ECCEN Mask */
+
+/** \brief MemSysCtl Prefetcher Control Register Definitions */
+#define MEMSYSCTL_PFCR_DIS_NLP_Pos          7U                                         /*!< MEMSYSCTL PFCR: DIS_NLP Position */
+#define MEMSYSCTL_PFCR_DIS_NLP_Msk         (1UL << MEMSYSCTL_PFCR_DIS_NLP_Pos)         /*!< MEMSYSCTL PFCR: DIS_NLP Mask */
+
+#define MEMSYSCTL_PFCR_ENABLE_Pos           0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
+#define MEMSYSCTL_PFCR_ENABLE_Msk          (1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/)      /*!< MEMSYSCTL PFCR: ENABLE Mask */
+
+/** \brief MemSysCtl ITCM Control Register Definitions */
+#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
+#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
+
+#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
+#define MEMSYSCTL_ITCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)        /*!< MEMSYSCTL ITCMCR: EN Mask */
+
+/** \brief MemSysCtl DTCM Control Register Definitions */
+#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
+#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
+
+#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
+#define MEMSYSCTL_DTCMCR_EN_Msk            (1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)        /*!< MEMSYSCTL DTCMCR: EN Mask */
+
+/** \brief MemSysCtl P-AHB Control Register Definitions */
+#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
+#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
+
+#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
+#define MEMSYSCTL_PAHBCR_EN_Msk            (1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)        /*!< MEMSYSCTL PAHBCR: EN Mask */
+
+/** \brief MemSysCtl ITGU Control Register Definitions */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl ITGU Configuration Register Definitions */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+
+/** \brief MemSysCtl DTGU Control Registers Definitions */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)      /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/)  /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+
+/** \brief MemSysCtl DTGU Configuration Register Definitions */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)     /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+
+/*@}*/ /* end of group MemSysCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PwrModCtl_Type     Power Mode Control Registers
+  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+ */
+typedef struct
+{
+  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+} PwrModCtl_Type;
+
+/** \brief PwrModCtl Core Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos   4U                                              /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
+
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+
+/** \brief PwrModCtl Debug Power Domain Low Power State Register Definitions */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+
+/*@}*/ /* end of group PwrModCtl_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+ */
+typedef struct
+{
+  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+        uint32_t RESERVED0[124U];
+  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+        uint32_t RESERVED1[112U];
+  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+        uint32_t RESERVED2[112U];
+  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+} EWIC_Type;
+
+/** \brief EWIC Control Register Definitions */
+#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
+#define EWIC_EWIC_CR_EN_Msk                (1UL /*<< EWIC_EWIC_CR_EN_Pos*/)            /*!< EWIC EWIC_CR: EN Mask */
+
+/** \brief EWIC Automatic Sequence Control Register Definitions */
+#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
+#define EWIC_EWIC_ASCR_ASPU_Msk            (1UL << EWIC_EWIC_ASCR_ASPU_Pos)            /*!< EWIC EWIC_ASCR: ASPU Mask */
+
+#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
+#define EWIC_EWIC_ASCR_ASPD_Msk            (1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)        /*!< EWIC EWIC_ASCR: ASPD Mask */
+
+/** \brief EWIC Event Number ID Register Definitions */
+#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
+#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
+
+/** \brief EWIC Mask A Register Definitions */
+#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)        /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+
+#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+#define EWIC_EWIC_MASKA_NMI_Msk            (1UL << EWIC_EWIC_MASKA_NMI_Pos)            /*!< EWIC EWIC_MASKA: NMI Mask */
+
+#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+#define EWIC_EWIC_MASKA_EVENT_Msk          (1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)      /*!< EWIC EWIC_MASKA: EVENT Mask */
+
+/** \brief EWIC Mask n Register Definitions */
+#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                         /*!< EWIC EWIC_MASKn: IRQ Position */
+#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
+
+/** \brief EWIC Pend A Register Definitions */
+#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)        /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+
+#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+#define EWIC_EWIC_PENDA_NMI_Msk            (1UL << EWIC_EWIC_PENDA_NMI_Pos)            /*!< EWIC EWIC_PENDA: NMI Mask */
+
+#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+#define EWIC_EWIC_PENDA_EVENT_Msk          (1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)      /*!< EWIC EWIC_PENDA: EVENT Mask */
+
+/** \brief EWIC Pend n Register Definitions */
+#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                         /*!< EWIC EWIC_PENDn: IRQ Position */
+#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
+
+/** \brief EWIC Pend Summary Register Definitions */
+#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
+#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
+
+#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
+#define EWIC_EWIC_PSR_NZA_Msk              (1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)          /*!< EWIC EWIC_PSR: NZA Mask */
+
+/*@}*/ /* end of group EWIC_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+ */
+typedef struct
+{
+  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+        uint32_t RESERVED0[31U];
+  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
+} EWIC_ISA_Type;
+
+/** \brief EWIC_ISA Event Set Pending Register Definitions */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)      /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
+#define EWIC_ISA_EVENTSPR_NMI_Msk          (1UL << EWIC_ISA_EVENTSPR_NMI_Pos)          /*!< EWIC_ISA EVENTSPR: NMI Mask */
+
+#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
+#define EWIC_ISA_EVENTSPR_EVENT_Msk        (1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)    /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask A Register Definitions */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+
+#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
+#define EWIC_ISA_EVENTMASKA_NMI_Msk        (1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)        /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+
+#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                         /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)  /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+
+/** \brief EWIC_ISA Event Mask n Register Definitions */
+#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                         /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+
+/*@}*/ /* end of group EWIC_ISA_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Error Banking Registers (ERRBNK)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Error Banking Registers (ERRBNK).
+ */
+typedef struct
+{
+  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+} ErrBnk_Type;
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 0 Definitions */
+#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
+#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
+
+#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
+#define ERRBNK_IEBR0_BANK_Msk              (1UL << ERRBNK_IEBR0_BANK_Pos)              /*!< ERRBNK IEBR0: BANK Mask */
+
+#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
+#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
+
+#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
+#define ERRBNK_IEBR0_LOCKED_Msk            (1UL << ERRBNK_IEBR0_LOCKED_Pos)            /*!< ERRBNK IEBR0: LOCKED Mask */
+
+#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
+#define ERRBNK_IEBR0_VALID_Msk             (1UL << /*ERRBNK_IEBR0_VALID_Pos*/)         /*!< ERRBNK IEBR0: VALID Mask */
+
+/** \brief ErrBnk Instruction Cache Error Bank Register 1 Definitions */
+#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
+#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
+
+#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
+#define ERRBNK_IEBR1_BANK_Msk              (1UL << ERRBNK_IEBR1_BANK_Pos)              /*!< ERRBNK IEBR1: BANK Mask */
+
+#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
+#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
+
+#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
+#define ERRBNK_IEBR1_LOCKED_Msk            (1UL << ERRBNK_IEBR1_LOCKED_Pos)            /*!< ERRBNK IEBR1: LOCKED Mask */
+
+#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
+#define ERRBNK_IEBR1_VALID_Msk             (1UL << /*ERRBNK_IEBR1_VALID_Pos*/)         /*!< ERRBNK IEBR1: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 0 Definitions */
+#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
+#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
+
+#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
+#define ERRBNK_DEBR0_TYPE_Msk              (1UL << ERRBNK_DEBR0_TYPE_Pos)              /*!< ERRBNK DEBR0: TYPE Mask */
+
+#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
+#define ERRBNK_DEBR0_BANK_Msk              (1UL << ERRBNK_DEBR0_BANK_Pos)              /*!< ERRBNK DEBR0: BANK Mask */
+
+#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
+#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
+
+#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
+#define ERRBNK_DEBR0_LOCKED_Msk            (1UL << ERRBNK_DEBR0_LOCKED_Pos)            /*!< ERRBNK DEBR0: LOCKED Mask */
+
+#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
+#define ERRBNK_DEBR0_VALID_Msk             (1UL << /*ERRBNK_DEBR0_VALID_Pos*/)         /*!< ERRBNK DEBR0: VALID Mask */
+
+/** \brief ErrBnk Data Cache Error Bank Register 1 Definitions */
+#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
+#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
+
+#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
+#define ERRBNK_DEBR1_TYPE_Msk              (1UL << ERRBNK_DEBR1_TYPE_Pos)              /*!< ERRBNK DEBR1: TYPE Mask */
+
+#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
+#define ERRBNK_DEBR1_BANK_Msk              (1UL << ERRBNK_DEBR1_BANK_Pos)              /*!< ERRBNK DEBR1: BANK Mask */
+
+#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
+#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
+
+#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
+#define ERRBNK_DEBR1_LOCKED_Msk            (1UL << ERRBNK_DEBR1_LOCKED_Pos)            /*!< ERRBNK DEBR1: LOCKED Mask */
+
+#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
+#define ERRBNK_DEBR1_VALID_Msk             (1UL << /*ERRBNK_DEBR1_VALID_Pos*/)         /*!< ERRBNK DEBR1: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 0 Definitions */
+#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
+
+#define ERRBNK_TEBR0_POISON_Pos            28U                                         /*!< ERRBNK TEBR0: POISON Position */
+#define ERRBNK_TEBR0_POISON_Msk            (1UL << ERRBNK_TEBR0_POISON_Pos)            /*!< ERRBNK TEBR0: POISON Mask */
+
+#define ERRBNK_TEBR0_TYPE_Pos              27U                                         /*!< ERRBNK TEBR0: TYPE Position */
+#define ERRBNK_TEBR0_TYPE_Msk              (1UL << ERRBNK_TEBR0_TYPE_Pos)              /*!< ERRBNK TEBR0: TYPE Mask */
+
+#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
+#define ERRBNK_TEBR0_BANK_Msk              (0x7UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
+
+#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
+#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
+
+#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
+#define ERRBNK_TEBR0_LOCKED_Msk            (1UL << ERRBNK_TEBR0_LOCKED_Pos)            /*!< ERRBNK TEBR0: LOCKED Mask */
+
+#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
+#define ERRBNK_TEBR0_VALID_Msk             (1UL << /*ERRBNK_TEBR0_VALID_Pos*/)         /*!< ERRBNK TEBR0: VALID Mask */
+
+/** \brief ErrBnk TCM Error Bank Register 1 Definitions */
+#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
+
+#define ERRBNK_TEBR1_POISON_Pos            28U                                         /*!< ERRBNK TEBR1: POISON Position */
+#define ERRBNK_TEBR1_POISON_Msk            (1UL << ERRBNK_TEBR1_POISON_Pos)            /*!< ERRBNK TEBR1: POISON Mask */
+
+#define ERRBNK_TEBR1_TYPE_Pos              27U                                         /*!< ERRBNK TEBR1: TYPE Position */
+#define ERRBNK_TEBR1_TYPE_Msk              (1UL << ERRBNK_TEBR1_TYPE_Pos)              /*!< ERRBNK TEBR1: TYPE Mask */
+
+#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
+#define ERRBNK_TEBR1_BANK_Msk              (0x7UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
+
+#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
+#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
+
+#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
+#define ERRBNK_TEBR1_LOCKED_Msk            (1UL << ERRBNK_TEBR1_LOCKED_Pos)            /*!< ERRBNK TEBR1: LOCKED Mask */
+
+#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
+#define ERRBNK_TEBR1_VALID_Msk             (1UL << /*ERRBNK_TEBR1_VALID_Pos*/)         /*!< ERRBNK TEBR1: VALID Mask */
+
+/*@}*/ /* end of group ErrBnk_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+ */
+typedef struct
+{
+  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+} PrcCfgInf_Type;
+
+/** \brief PrcCfgInf Processor Configuration Information Selection Register Definitions */
+
+/** \brief PrcCfgInf Processor Configuration Information Read Data Register Definitions */
+
+/*@}*/ /* end of group PrcCfgInf_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup STL_Type     Software Test Library Observation Registers
+  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+ */
+typedef struct
+{
+  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+  __IM  uint32_t STLD0MPUOR;             /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
+  __IM  uint32_t STLD1MPUOR;             /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
+  __IM  uint32_t STLD2MPUOR;             /*!< Offset: 0x020 (R/ )  MPU Memory Attributes Register 2 */
+  __IM  uint32_t STLD3MPUOR;             /*!< Offset: 0x024 (R/ )  MPU Memory Attributes Register 3 */
+  __IOM uint32_t STLSTBSLOTSR;           /*!< Offset: 0x028 (R/W)  STB Control Register */
+  __IOM uint32_t STLLFDENTRYSR;          /*!< Offset: 0x02C (R/W)  LFD Control Register */
+} STL_Type;
+
+/** \brief STL NVIC Pending Priority Tree Register Definitions */
+#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
+#define STL_STLNVICPENDOR_VALID_Msk        (1UL << STL_STLNVICPENDOR_VALID_Pos)        /*!< STL STLNVICPENDOR: VALID Mask */
+
+#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
+#define STL_STLNVICPENDOR_TARGET_Msk       (1UL << STL_STLNVICPENDOR_TARGET_Pos)       /*!< STL STLNVICPENDOR: TARGET Mask */
+
+#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
+#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
+
+#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
+#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
+
+/** \brief STL NVIC Active Priority Tree Register Definitions */
+#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
+#define STL_STLNVICACTVOR_VALID_Msk        (1UL << STL_STLNVICACTVOR_VALID_Pos)        /*!< STL STLNVICACTVOR: VALID Mask */
+
+#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
+#define STL_STLNVICACTVOR_TARGET_Msk       (1UL << STL_STLNVICACTVOR_TARGET_Pos)       /*!< STL STLNVICACTVOR: TARGET Mask */
+
+#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
+#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
+
+#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
+#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
+
+/** \brief STL MPU Sample Register Definitions */
+#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
+
+#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+#define STL_STLIDMPUSR_INSTR_Msk           (1UL << STL_STLIDMPUSR_INSTR_Pos)           /*!< STL STLIDMPUSR: INSTR Mask */
+
+#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
+#define STL_STLIDMPUSR_DATA_Msk            (1UL << STL_STLIDMPUSR_DATA_Pos)            /*!< STL STLIDMPUSR: DATA Mask */
+
+/** \brief STL MPU Region Hit Register Definitions */
+#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
+#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
+
+#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
+#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 0 Definitions */
+#define STL_STLD0MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
+#define STL_STLD0MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD0MPUOR_HITREGION_Pos)    /*!< STL STLD0MPUOR: HITREGION Mask */
+
+#define STL_STLD0MPUOR_ATTR_Pos             0U                                         /*!< STL STLD0MPUOR: ATTR Position */
+#define STL_STLD0MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/)    /*!< STL STLD0MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 1 Definitions */
+#define STL_STLD1MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
+#define STL_STLD1MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD1MPUOR_HITREGION_Pos)    /*!< STL STLD1MPUOR: HITREGION Mask */
+
+#define STL_STLD1MPUOR_ATTR_Pos             0U                                         /*!< STL STLD1MPUOR: ATTR Position */
+#define STL_STLD1MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/)    /*!< STL STLD1MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 2 Definitions */
+#define STL_STLD2MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD2MPUOR: HITREGION Position */
+#define STL_STLD2MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD2MPUOR_HITREGION_Pos)    /*!< STL STLD2MPUOR: HITREGION Mask */
+
+#define STL_STLD2MPUOR_ATTR_Pos             0U                                         /*!< STL STLD2MPUOR: ATTR Position */
+#define STL_STLD2MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD2MPUOR_ATTR_Pos*/)    /*!< STL STLD2MPUOR: ATTR Mask */
+
+/** \brief STL MPU Memory Attributes Register 3 Definitions */
+#define STL_STLD3MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD3MPUOR: HITREGION Position */
+#define STL_STLD3MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD3MPUOR_HITREGION_Pos)    /*!< STL STLD3MPUOR: HITREGION Mask */
+
+#define STL_STLD3MPUOR_ATTR_Pos             0U                                         /*!< STL STLD3MPUOR: ATTR Position */
+#define STL_STLD3MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD3MPUOR_ATTR_Pos*/)    /*!< STL STLD3MPUOR: ATTR Mask */
+
+/** \brief STL STB Control Register Definitions */
+#define STL_STLSTBSLOTSR_VALID_Pos          4U                                         /*!< STL STLSTBSLOTSR: VALID Position */
+#define STL_STLSTBSLOTSR_VALID_Msk         (1UL << STL_STLSTBSLOTSR_VALID_Pos)         /*!< STL STLSTBSLOTSR: VALID Mask */
+
+#define STL_STLSTBSLOTSR_STBSLOTNUM_Pos     0U                                         /*!< STL STLSTBSLOTSR: STBSLOTNUM Position */
+#define STL_STLSTBSLOTSR_STBSLOTNUM_Msk    (0xFUL /*<< STL_STLSTBSLOTSR_STBSLOTNUM_Pos*/) /*!< STL STLSTBSLOTSR: STBSLOTNUM Mask */
+
+/** \brief STL LFD Control Register Definitions */
+#define STL_STLLFDENTRYSR_VALID_Pos         4U                                         /*!< STL STLLFDENTRYSR: VALID Position */
+#define STL_STLLFDENTRYSR_VALID_Msk        (1UL << STL_STLLFDENTRYSR_VALID_Pos)        /*!< STL STLLFDENTRYSR: VALID Mask */
+
+#define STL_STLLFDENTRYSR_LFDENTRYNUM_Pos   0U                                         /*!< STL STLLFDENTRYSR: LFDENTRYNUM Position */
+#define STL_STLLFDENTRYSR_LFDENTRYNUM_Msk  (0xFUL /*<< STL_STLLFDENTRYSR_LFDENTRYNUM_Pos*/) /*!< STL STLLFDENTRYSR: LFDENTRYNUM Mask */
+/*@}*/ /* end of group STL_Type */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPIU    Trace Port Interface Unit (TPIU)
+  \brief    Type definitions for the Trace Port Interface Unit (TPIU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Unit Register (TPIU).
+ */
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER Register */
+  __IM  uint32_t ITFTTD0;                /*!< Offset: 0xEEC (R/ )  Integration Test FIFO Test Data 0 Register */
+  __IOM uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/W)  Integration Test ATB Control Register 2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  Integration Test ATB Control Register 0 */
+  __IM  uint32_t ITFTTD1;                /*!< Offset: 0xEFC (R/ )  Integration Test FIFO Test Data 1 Register */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  Device Configuration Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} TPIU_Type;
+
+/** \brief TPIU Asynchronous Clock Prescaler Register Definitions */
+#define TPIU_ACPR_PRESCALER_Pos             0U                                         /*!< TPIU ACPR: PRESCALER Position */
+#define TPIU_ACPR_PRESCALER_Msk            (0x1FFFUL /*<< TPIU_ACPR_PRESCALER_Pos*/)   /*!< TPIU ACPR: PRESCALER Mask */
+
+/** \brief TPIU Selected Pin Protocol Register Definitions */
+#define TPIU_SPPR_TXMODE_Pos                0U                                         /*!< TPIU SPPR: TXMODE Position */
+#define TPIU_SPPR_TXMODE_Msk               (0x3UL /*<< TPIU_SPPR_TXMODE_Pos*/)         /*!< TPIU SPPR: TXMODE Mask */
+
+/** \brief TPIU Formatter and Flush Status Register Definitions */
+#define TPIU_FFSR_FtNonStop_Pos             3U                                         /*!< TPIU FFSR: FtNonStop Position */
+#define TPIU_FFSR_FtNonStop_Msk            (1UL << TPIU_FFSR_FtNonStop_Pos)            /*!< TPIU FFSR: FtNonStop Mask */
+
+#define TPIU_FFSR_TCPresent_Pos             2U                                         /*!< TPIU FFSR: TCPresent Position */
+#define TPIU_FFSR_TCPresent_Msk            (1UL << TPIU_FFSR_TCPresent_Pos)            /*!< TPIU FFSR: TCPresent Mask */
+
+#define TPIU_FFSR_FtStopped_Pos             1U                                         /*!< TPIU FFSR: FtStopped Position */
+#define TPIU_FFSR_FtStopped_Msk            (1UL << TPIU_FFSR_FtStopped_Pos)            /*!< TPIU FFSR: FtStopped Mask */
+
+#define TPIU_FFSR_FlInProg_Pos              0U                                         /*!< TPIU FFSR: FlInProg Position */
+#define TPIU_FFSR_FlInProg_Msk             (1UL /*<< TPIU_FFSR_FlInProg_Pos*/)         /*!< TPIU FFSR: FlInProg Mask */
+
+/** \brief TPIU Formatter and Flush Control Register Definitions */
+#define TPIU_FFCR_TrigIn_Pos                8U                                         /*!< TPIU FFCR: TrigIn Position */
+#define TPIU_FFCR_TrigIn_Msk               (1UL << TPIU_FFCR_TrigIn_Pos)               /*!< TPIU FFCR: TrigIn Mask */
+
+#define TPIU_FFCR_FOnMan_Pos                6U                                         /*!< TPIU FFCR: FOnMan Position */
+#define TPIU_FFCR_FOnMan_Msk               (1UL << TPIU_FFCR_FOnMan_Pos)               /*!< TPIU FFCR: FOnMan Mask */
+
+#define TPIU_FFCR_EnFCont_Pos               1U                                         /*!< TPIU FFCR: EnFCont Position */
+#define TPIU_FFCR_EnFCont_Msk              (1UL << TPIU_FFCR_EnFCont_Pos)              /*!< TPIU FFCR: EnFCont Mask */
+
+/** \brief TPIU Periodic Synchronization Control Register Definitions */
+#define TPIU_PSCR_PSCount_Pos               0U                                         /*!< TPIU PSCR: PSCount Position */
+#define TPIU_PSCR_PSCount_Msk              (0x1FUL /*<< TPIU_PSCR_PSCount_Pos*/)       /*!< TPIU PSCR: TPSCount Mask */
+
+/** \brief TPIU TRIGGER Register Definitions */
+#define TPIU_TRIGGER_TRIGGER_Pos            0U                                         /*!< TPIU TRIGGER: TRIGGER Position */
+#define TPIU_TRIGGER_TRIGGER_Msk           (1UL /*<< TPIU_TRIGGER_TRIGGER_Pos*/)       /*!< TPIU TRIGGER: TRIGGER Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 0 Register Definitions */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD0: ATB Interface 2 ATVALIDPosition */
+#define TPIU_ITFTTD0_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD0: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD0_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD0_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD0: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD0_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD0_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD0: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data2_Pos     16U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data2 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data2_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data2 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data1_Pos      8U                                         /*!< TPIU ITFTTD0: ATB Interface 1 data1 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data1_Msk     (0xFFUL << TPIU_ITFTTD0_ATB_IF1_data1_Pos)  /*!< TPIU ITFTTD0: ATB Interface 1 data1 Mask */
+
+#define TPIU_ITFTTD0_ATB_IF1_data0_Pos      0U                                          /*!< TPIU ITFTTD0: ATB Interface 1 data0 Position */
+#define TPIU_ITFTTD0_ATB_IF1_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD0_ATB_IF1_data0_Pos*/) /*!< TPIU ITFTTD0: ATB Interface 1 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 2 Register Definitions */
+#define TPIU_ITATBCTR2_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID2S Position */
+#define TPIU_ITATBCTR2_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID2S_Pos)       /*!< TPIU ITATBCTR2: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR2_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR2: AFVALID1S Position */
+#define TPIU_ITATBCTR2_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR2_AFVALID1S_Pos)       /*!< TPIU ITATBCTR2: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR2_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY2S Position */
+#define TPIU_ITATBCTR2_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR2_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR2: ATREADY1S Position */
+#define TPIU_ITATBCTR2_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR2_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR2: ATREADY1S Mask */
+
+/** \brief TPIU Integration Test FIFO Test Data 1 Register Definitions */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos   29U                                         /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF2_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF2_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Pos 27U                                         /*!< TPIU ITFTTD1: ATB Interface 2 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF2_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF2_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 2 byte count Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos   26U                                         /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Position */
+#define TPIU_ITFTTD1_ATB_IF1_ATVALID_Msk   (0x3UL << TPIU_ITFTTD1_ATB_IF1_ATVALID_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 ATVALID Mask */
+
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Pos 24U                                         /*!< TPIU ITFTTD1: ATB Interface 1 byte count Position */
+#define TPIU_ITFTTD1_ATB_IF1_bytecount_Msk (0x3UL << TPIU_ITFTTD1_ATB_IF1_bytecount_Pos) /*!< TPIU ITFTTD1: ATB Interface 1 byte countt Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data2_Pos     16U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data2 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data2_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data2 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data1_Pos      8U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data1 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data1_Msk     (0xFFUL << TPIU_ITFTTD1_ATB_IF2_data1_Pos)  /*!< TPIU ITFTTD1: ATB Interface 2 data1 Mask */
+
+#define TPIU_ITFTTD1_ATB_IF2_data0_Pos      0U                                         /*!< TPIU ITFTTD1: ATB Interface 2 data0 Position */
+#define TPIU_ITFTTD1_ATB_IF2_data0_Msk     (0xFFUL /*<< TPIU_ITFTTD1_ATB_IF2_data0_Pos*/) /*!< TPIU ITFTTD1: ATB Interface 2 data0 Mask */
+
+/** \brief TPIU Integration Test ATB Control Register 0 Definitions */
+#define TPIU_ITATBCTR0_AFVALID2S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID2S Position */
+#define TPIU_ITATBCTR0_AFVALID2S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID2S_Pos)       /*!< TPIU ITATBCTR0: AFVALID2SS Mask */
+
+#define TPIU_ITATBCTR0_AFVALID1S_Pos        1U                                         /*!< TPIU ITATBCTR0: AFVALID1S Position */
+#define TPIU_ITATBCTR0_AFVALID1S_Msk       (1UL << TPIU_ITATBCTR0_AFVALID1S_Pos)       /*!< TPIU ITATBCTR0: AFVALID1SS Mask */
+
+#define TPIU_ITATBCTR0_ATREADY2S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY2S Position */
+#define TPIU_ITATBCTR0_ATREADY2S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY2S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY2S Mask */
+
+#define TPIU_ITATBCTR0_ATREADY1S_Pos        0U                                         /*!< TPIU ITATBCTR0: ATREADY1S Position */
+#define TPIU_ITATBCTR0_ATREADY1S_Msk       (1UL /*<< TPIU_ITATBCTR0_ATREADY1S_Pos*/)   /*!< TPIU ITATBCTR0: ATREADY1S Mask */
+
+/** \brief TPIU Integration Mode Control Register Definitions */
+#define TPIU_ITCTRL_Mode_Pos                0U                                         /*!< TPIU ITCTRL: Mode Position */
+#define TPIU_ITCTRL_Mode_Msk               (0x3UL /*<< TPIU_ITCTRL_Mode_Pos*/)         /*!< TPIU ITCTRL: Mode Mask */
+
+/** \brief TPIU Claim Tag Set Register Definitions */
+#define TPIU_CLAIMSET_SET_Pos               0U                                         /*!< TPIU CLAIMSET: SET Position */
+#define TPIU_CLAIMSET_SET_Msk              (0xFUL /*<< TPIU_CLAIMSET_SET_Pos*/)        /*!< TPIU CLAIMSET: SET Mask */
+
+/** \brief TPIU Claim Tag Clear Register Definitions */
+#define TPIU_CLAIMCLR_CLR_Pos               0U                                         /*!< TPIU CLAIMCLR: CLR Position */
+#define TPIU_CLAIMCLR_CLR_Msk              (0xFUL /*<< TPIU_CLAIMCLR_CLR_Pos*/)        /*!< TPIU CLAIMCLR: CLR Mask */
+
+/** \brief TPIU DEVID Register Definitions */
+#define TPIU_DEVID_NRZVALID_Pos            11U                                         /*!< TPIU DEVID: NRZVALID Position */
+#define TPIU_DEVID_NRZVALID_Msk            (1UL << TPIU_DEVID_NRZVALID_Pos)            /*!< TPIU DEVID: NRZVALID Mask */
+
+#define TPIU_DEVID_MANCVALID_Pos           10U                                         /*!< TPIU DEVID: MANCVALID Position */
+#define TPIU_DEVID_MANCVALID_Msk           (1UL << TPIU_DEVID_MANCVALID_Pos)           /*!< TPIU DEVID: MANCVALID Mask */
+
+#define TPIU_DEVID_PTINVALID_Pos            9U                                         /*!< TPIU DEVID: PTINVALID Position */
+#define TPIU_DEVID_PTINVALID_Msk           (1UL << TPIU_DEVID_PTINVALID_Pos)           /*!< TPIU DEVID: PTINVALID Mask */
+
+#define TPIU_DEVID_FIFOSZ_Pos               6U                                         /*!< TPIU DEVID: FIFOSZ Position */
+#define TPIU_DEVID_FIFOSZ_Msk              (0x7UL << TPIU_DEVID_FIFOSZ_Pos)            /*!< TPIU DEVID: FIFOSZ Mask */
+
+#define TPIU_DEVID_NrTraceInput_Pos         0U                                         /*!< TPIU DEVID: NrTraceInput Position */
+#define TPIU_DEVID_NrTraceInput_Msk        (0x3FUL /*<< TPIU_DEVID_NrTraceInput_Pos*/) /*!< TPIU DEVID: NrTraceInput Mask */
+
+/** \brief TPIU DEVTYPE Register Definitions */
+#define TPIU_DEVTYPE_SubType_Pos            4U                                         /*!< TPIU DEVTYPE: SubType Position */
+#define TPIU_DEVTYPE_SubType_Msk           (0xFUL /*<< TPIU_DEVTYPE_SubType_Pos*/)     /*!< TPIU DEVTYPE: SubType Mask */
+
+#define TPIU_DEVTYPE_MajorType_Pos          0U                                         /*!< TPIU DEVTYPE: MajorType Position */
+#define TPIU_DEVTYPE_MajorType_Msk         (0xFUL << TPIU_DEVTYPE_MajorType_Pos)       /*!< TPIU DEVTYPE: MajorType Mask */
+
+/*@}*/ /* end of group CMSIS_TPIU */
+
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+  \brief    Type definitions for the Performance Monitoring Unit (PMU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Performance Monitoring Unit (PMU).
+ */
+typedef struct
+{
+  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    Event Counter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   Cycle Counter Register */
+        uint32_t RESERVED1[224];
+  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  Event Type and Filter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  Cycle Counter Filter Register */
+        uint32_t RESERVED3[480];
+  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  Count Enable Set Register */
+        uint32_t RESERVED4[7];
+  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  Count Enable Clear Register */
+        uint32_t RESERVED5[7];
+  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  Interrupt Enable Set Register */
+        uint32_t RESERVED6[7];
+  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  Interrupt Enable Clear Register */
+        uint32_t RESERVED7[7];
+  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  Overflow Flag Status Clear Register */
+        uint32_t RESERVED8[7];
+  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  Software Increment Register */
+        uint32_t RESERVED9[7];
+  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  Overflow Flag Status Set Register */
+        uint32_t RESERVED10[79];
+  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  Type Register */
+  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  Control Register */
+        uint32_t RESERVED11[108];
+  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  Authentication Status Register */
+  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  Device Architecture Register */
+        uint32_t RESERVED12[3];
+  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  Device Type Register */
+} PMU_Type;
+
+/** \brief PMU Event Counter Registers (0-30) Definitions  */
+#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
+#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
+
+/** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
+#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
+#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
+
+/** \brief PMU Count Enable Set Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+
+#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+
+#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+
+/** \brief PMU Count Enable Clear Register Definitions */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+
+#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+
+#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+
+/** \brief PMU Interrupt Enable Set Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+
+#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+
+/** \brief PMU Interrupt Enable Clear Register Definitions */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+
+#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+
+#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+
+/** \brief PMU Overflow Flag Status Set Register Definitions */
+#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+
+#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+
+#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+
+/** \brief PMU Overflow Flag Status Clear Register Definitions */
+#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+
+#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+
+#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+
+/** \brief PMU Software Increment Counter */
+#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+
+#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+
+#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+
+#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+
+#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+
+#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+
+#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+
+#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+
+#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+
+#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+
+#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+
+#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+
+#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+
+#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+
+#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+
+#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+
+#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+
+#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+
+#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+
+#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+
+#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+
+#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+
+#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+
+#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+
+#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+
+#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+
+#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+
+#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+
+#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+
+#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+
+#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+
+/** \brief PMU Control Register Definitions */
+#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
+#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
+
+#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
+#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
+#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
+
+#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
+#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
+
+#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
+#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
+
+#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
+#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
+
+/** \brief PMU Type Register Definitions */
+#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
+#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
+
+#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
+#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
+
+#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
+#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
+
+#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
+
+/** \brief PMU Authentication Status Register Definitions */
+#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+
+#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+
+/*@} end of group CMSIS_PMU */
+#endif
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
+
+#define MPU_TYPE_RALIASES                  4U
+
+/** \brief MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/** \brief MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/** \brief MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/** \brief MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/** \brief MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/** \brief MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
+
+/** \brief SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/** \brief SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/** \brief SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/** \brief SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/** \brief SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/** \brief SAU Secure Fault Status Register Definitions */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Floating Point Unit (FPU).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
+
+/** \brief FPU Floating-Point Context Control Register Definitions */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+
+/** \brief FPU Floating-Point Context Address Register Definitions */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+
+/** \brief FPU Floating-Point Default Status Control Register Definitions */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+
+#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
+#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
+
+#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
+
+/** \brief FPU Media and VFP Feature Register 0 Definitions */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: Rounding modes bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: Rounding modes bits Mask */
+
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: Square root bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                /*!< MVFR0: Square root bits Mask */
+
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: Divide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: Double-precision bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: Double-precision bits Mask */
+
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: Single-precision bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: Single-precision bits Mask */
+
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMD registers bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMD registers bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 1 Definitions */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: Fused MAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: Fused MAC bits Mask */
+
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FP HPFP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FP HPFP bits Mask */
+
+#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
+#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
+
+#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
+#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
+
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: D_NaN mode bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: D_NaN mode bits Mask */
+
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FtZ mode bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FtZ mode bits Mask */
+
+/** \brief FPU Media and VFP Feature Register 2 Definitions */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: VFP Misc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: VFP Misc bits Mask */
+
+/*@} end of group CMSIS_FPU */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
+
+/** \brief DCB Debug Halting Control and Status Register Definitions */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (1UL << DCB_DHCSR_S_RESTART_ST_Pos)            /*!< DCB DHCSR: Restart sticky status Mask */
+
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (1UL << DCB_DHCSR_S_RESET_ST_Pos)              /*!< DCB DHCSR: Reset sticky status Mask */
+
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (1UL << DCB_DHCSR_S_RETIRE_ST_Pos)             /*!< DCB DHCSR: Retire sticky status Mask */
+
+#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+#define DCB_DHCSR_S_FPD_Msk                (1UL << DCB_DHCSR_S_FPD_Pos)                   /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+
+#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_SUIDE_Msk              (1UL << DCB_DHCSR_S_SUIDE_Pos)                 /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_NSUIDE_Msk             (1UL << DCB_DHCSR_S_NSUIDE_Pos)                /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (1UL << DCB_DHCSR_S_SDE_Pos)                   /*!< DCB DHCSR: Secure debug enabled Mask */
+
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (1UL << DCB_DHCSR_S_LOCKUP_Pos)                /*!< DCB DHCSR: Lockup status Mask */
+
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (1UL << DCB_DHCSR_S_SLEEP_Pos)                 /*!< DCB DHCSR: Sleeping status Mask */
+
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (1UL << DCB_DHCSR_S_HALT_Pos)                  /*!< DCB DHCSR: Halted status Mask */
+
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (1UL << DCB_DHCSR_S_REGRDY_Pos)                /*!< DCB DHCSR: Register ready status Mask */
+
+#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
+#define DCB_DHCSR_C_PMOV_Msk               (1UL << DCB_DHCSR_C_PMOV_Pos)                  /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (1UL << DCB_DHCSR_C_SNAPSTALL_Pos)             /*!< DCB DHCSR: Snap stall control Mask */
+
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (1UL << DCB_DHCSR_C_MASKINTS_Pos)              /*!< DCB DHCSR: Mask interrupts control Mask */
+
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (1UL << DCB_DHCSR_C_STEP_Pos)                  /*!< DCB DHCSR: Step control Mask */
+
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (1UL << DCB_DHCSR_C_HALT_Pos)                  /*!< DCB DHCSR: Halt control Mask */
+
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)           /*!< DCB DHCSR: Debug enable control Mask */
+
+/** \brief DCB Debug Core Register Selector Register Definitions */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (1UL << DCB_DCRSR_REGWnR_Pos)                  /*!< DCB DCRSR: Register write/not-read Mask */
+
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+
+/** \brief DCB Debug Core Register Data Register Definitions */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+
+/** \brief DCB Debug Exception and Monitor Control Register Definitions */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (1UL << DCB_DEMCR_TRCENA_Pos)                  /*!< DCB DEMCR: Trace enable Mask */
+
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (1UL << DCB_DEMCR_MONPRKEY_Pos)                /*!< DCB DEMCR: Monitor pend req key Mask */
+
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (1UL << DCB_DEMCR_UMON_EN_Pos)                 /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (1UL << DCB_DEMCR_SDME_Pos)                    /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (1UL << DCB_DEMCR_MON_REQ_Pos)                 /*!< DCB DEMCR: Monitor request Mask */
+
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (1UL << DCB_DEMCR_MON_STEP_Pos)                /*!< DCB DEMCR: Monitor step Mask */
+
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (1UL << DCB_DEMCR_MON_PEND_Pos)                /*!< DCB DEMCR: Monitor pend Mask */
+
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (1UL << DCB_DEMCR_MON_EN_Pos)                  /*!< DCB DEMCR: Monitor enable Mask */
+
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (1UL << DCB_DEMCR_VC_SFERR_Pos)                /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (1UL << DCB_DEMCR_VC_HARDERR_Pos)              /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (1UL << DCB_DEMCR_VC_INTERR_Pos)               /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (1UL << DCB_DEMCR_VC_BUSERR_Pos)               /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (1UL << DCB_DEMCR_VC_STATERR_Pos)              /*!< DCB DEMCR: Vector Catch state errors Mask */
+
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (1UL << DCB_DEMCR_VC_CHKERR_Pos)               /*!< DCB DEMCR: Vector Catch check errors Mask */
+
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (1UL << DCB_DEMCR_VC_NOCPERR_Pos)              /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (1UL << DCB_DEMCR_VC_MMERR_Pos)                /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)        /*!< DCB DEMCR: Vector Catch Core reset Mask */
+
+/** \brief DCB Debug Set Clear Exception and Monitor Control Register Definitions */
+#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
+#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)           /*!< DCB DSCEMCR: Clear monitor request Mask */
+
+#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
+#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)          /*!< DCB DSCEMCR: Clear monitor pend Mask */
+
+#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
+#define DCB_DSCEMCR_SET_MON_REQ_Msk        (1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)           /*!< DCB DSCEMCR: Set monitor request Mask */
+
+#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
+#define DCB_DSCEMCR_SET_MON_PEND_Msk       (1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)          /*!< DCB DSCEMCR: Set monitor pend Mask */
+
+/** \brief DCB Debug Authentication Control Register Definitions */
+#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+#define DCB_DAUTHCTRL_UIDEN_Msk            (1UL << DCB_DAUTHCTRL_UIDEN_Pos)               /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+
+#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+#define DCB_DAUTHCTRL_UIDAPEN_Msk          (1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+
+#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+#define DCB_DAUTHCTRL_FSDMA_Msk            (1UL << DCB_DAUTHCTRL_FSDMA_Pos)               /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)          /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)          /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)       /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+
+/** \brief DCB Debug Security Control and Status Register Definitions */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (1UL << DCB_DSCSR_CDSKEY_Pos)                  /*!< DCB DSCSR: CDS write-enable key Mask */
+
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (1UL << DCB_DSCSR_CDS_Pos)                     /*!< DCB DSCSR: Current domain Secure Mask */
+
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (1UL << DCB_DSCSR_SBRSEL_Pos)                  /*!< DCB DSCSR: Secure banked register select Mask */
+
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)            /*!< DCB DSCSR: Secure banked register select enable Mask */
+
+/*@} end of group CMSIS_DCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ */
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+        uint32_t RESERVED1[3U];
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+} DIB_Type;
+
+/** \brief DIB Debug Authentication Status Register Definitions */
+#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+
+#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+
+/** \brief DIB SCS Device Architecture Register Definitions */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+
+/** \brief DIB SCS Device Type Register Definitions */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+
+/*@} end of group CMSIS_DIB */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
+  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
+  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
+  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
+  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
+  #define TPIU_BASE           (0xE0040000UL)                             /*!< TPIU Base Address */
+  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPIU                ((TPIU_Type      *)     TPIU_BASE        ) /*!< TPIU configuration struct */
+  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
+  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
+  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
+  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
+  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
+  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
+  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
+    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
+ */
+
+/*@} */
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
+
+/* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+
+/* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+
+/* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
+
+
+/**
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ */
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
+
+
+/**
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ */
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *) ((uintptr_t) SCB->VTOR);
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
+
+
+/**
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
+
+
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/* ##########################  MPU functions  #################################### */
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+
+  #include "m-profile/armv8m_mpu.h"
+
+#endif
+
+/* ##########################  PMU functions and events  #################################### */
+
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+
+#include "m-profile/armv8m_pmu.h"
+
+/**
+  \brief   Cortex-M85 PMU events
+  \note    Architectural PMU events can be found in armv8m_pmu.h
+*/
+
+#define ARMCM85_PMU_ECC_ERR                          0xC000             /*!< One or more Error Correcting Code (ECC) errors detected */
+#define ARMCM85_PMU_ECC_ERR_MBIT                     0xC001             /*!< One or more multi-bit ECC errors detected */
+#define ARMCM85_PMU_ECC_ERR_DCACHE                   0xC010             /*!< One or more ECC errors in the data cache */
+#define ARMCM85_PMU_ECC_ERR_ICACHE                   0xC011             /*!< One or more ECC errors in the instruction cache */
+#define ARMCM85_PMU_ECC_ERR_MBIT_DCACHE              0xC012             /*!< One or more multi-bit ECC errors in the data cache */
+#define ARMCM85_PMU_ECC_ERR_MBIT_ICACHE              0xC013             /*!< One or more multi-bit ECC errors in the instruction cache */
+#define ARMCM85_PMU_ECC_ERR_DTCM                     0xC020             /*!< One or more ECC errors in the Data Tightly Coupled Memory (DTCM) */
+#define ARMCM85_PMU_ECC_ERR_ITCM                     0xC021             /*!< One or more ECC errors in the Instruction Tightly Coupled Memory (ITCM) */
+#define ARMCM85_PMU_ECC_ERR_MBIT_DTCM                0xC022             /*!< One or more multi-bit ECC errors in the DTCM */
+#define ARMCM85_PMU_ECC_ERR_MBIT_ITCM                0xC023             /*!< One or more multi-bit ECC errors in the ITCM */
+#define ARMCM85_PMU_PF_LINEFILL                      0xC100             /*!< The prefetcher starts a line-fill */
+#define ARMCM85_PMU_PF_CANCEL                        0xC101             /*!< The prefetcher stops prefetching */
+#define ARMCM85_PMU_PF_DROP_LINEFILL                 0xC102             /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
+#define ARMCM85_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
+#define ARMCM85_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+#define ARMCM85_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
+#define ARMCM85_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access on the P-AHB write interface */
+#define ARMCM85_PMU_AXI_WRITE_ACCESS                 0xC302             /*!< Any beat access to M-AXI write interface */
+#define ARMCM85_PMU_AXI_READ_ACCESS                  0xC303             /*!< Any beat access to M-AXI read interface */
+#define ARMCM85_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+#define ARMCM85_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+#define ARMCM85_PMU_FUSED_INST_RETIRED               0xC500             /*!< Fused instructions architecturally executed */
+#define ARMCM85_PMU_BR_INDIRECT                      0xC501             /*!< Indirect branch instruction architecturally executed */
+#define ARMCM85_PMU_BTAC_HIT                         0xC502             /*!< BTAC branch predictor hit */
+#define ARMCM85_PMU_BTAC_HIT_RETURNS                 0xC503             /*!< Return branch hits BTAC */
+#define ARMCM85_PMU_BTAC_HIT_CALLS                   0xC504             /*!< Call branch hits BTAC */
+#define ARMCM85_PMU_BTAC_HIT_INDIRECT                0xC505             /*!< Indirect branch hits BTACT */
+#define ARMCM85_PMU_BTAC_NEW_ALLOC                   0xC506             /*!< New allocation to BTAC */
+#define ARMCM85_PMU_BR_IND_MIS_PRED                  0xC507             /*!< Indirect branch mis-predicted */
+#define ARMCM85_PMU_BR_RETURN_MIS_PRED               0xC508             /*!< Return branch mis-predicted */
+#define ARMCM85_PMU_BR_BTAC_OFFSET_OVERFLOW          0xC509             /*!< Branch does not allocate in BTAC due to offset overflow */
+#define ARMCM85_PMU_STB_FULL_STALL_AXI               0xC50A             /*!< STore Buffer (STB) full with AXI requests causing CPU to stall */
+#define ARMCM85_PMU_STB_FULL_STALL_TCM               0xC50B             /*!< STB full with TCM requests causing CPU to stall */
+#define ARMCM85_PMU_CPU_STALLED_AHBS                 0xC50C             /*!< CPU is stalled because TCM access through AHBS */
+#define ARMCM85_PMU_AHBS_STALLED_CPU                 0xC50D             /*!< AHBS is stalled due to TCM access by CPU */
+#define ARMCM85_PMU_BR_INTERSTATING_MIS_PRED         0xC50E             /*!< Inter-stating branch is mis-predicted. */
+#define ARMCM85_PMU_DWT_STALL                        0xC50F             /*!< Data Watchpoint and Trace (DWT) stall */
+#define ARMCM85_PMU_DWT_FLUSH                        0xC510             /*!< DWT flush */
+#define ARMCM85_PMU_ETM_STALL                        0xC511             /*!< Embedded Trace Macrocell (ETM) stall */
+#define ARMCM85_PMU_ETM_FLUSH                        0xC512             /*!< ETM flush */
+#define ARMCM85_PMU_ADDRESS_BANK_CONFLICT            0xC513             /*!< Bank conflict prevents memory instruction dual issue */
+#define ARMCM85_PMU_BLOCKED_DUAL_ISSUE               0xC514             /*!< Dual instruction issuing is prevented */
+#define ARMCM85_PMU_FP_CONTEXT_TRIGGER               0xC515             /*!< Floating Point Context is created */
+#define ARMCM85_PMU_TAIL_CHAIN                       0xC516             /*!< New exception is handled without first unstacking */
+#define ARMCM85_PMU_LATE_ARRIVAL                     0xC517             /*!< Late-arriving exception taken during exception entry */
+#define ARMCM85_PMU_INT_STALL_FAULT                  0xC518             /*!< Delayed exception entry due to ongoing fault processing */
+#define ARMCM85_PMU_INT_STALL_DEV                    0xC519             /*!< Delayed exception entry due to outstanding device access */
+#define ARMCM85_PMU_PAC_STALL                        0xC51A             /*!< Stall caused by authentication code computation */
+#define ARMCM85_PMU_PAC_RETIRED                      0xC51B             /*!< PAC instruction architecturally executed */
+#define ARMCM85_PMU_AUT_RETIRED                      0xC51C             /*!< AUT instruction architecturally executed */
+#define ARMCM85_PMU_BTI_RETIRED                      0xC51D             /*!< BTI instruction architecturally executed */
+#define ARMCM85_PMU_PF_NL_MODE                       0xC51E             /*!< Prefetch in next line mode */
+#define ARMCM85_PMU_PF_STREAM_MODE                   0xC51F             /*!< Prefetch in stream mode */
+#define ARMCM85_PMU_PF_BUFF_CACHE_HIT                0xC520             /*!< Prefetch request that hit in the cache */
+#define ARMCM85_PMU_PF_REQ_LFB_HIT                   0xC521             /*!< Prefetch request that hit in line fill buffers */
+#define ARMCM85_PMU_PF_BUFF_FULL                     0xC522             /*!< Number of times prefetch buffer is full */
+#define ARMCM85_PMU_PF_REQ_DCACHE_HIT                0xC523             /*!< Generated prefetch request address that hit in D-Cache */
+
+#endif
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
+
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+/* ##########################  MVE functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_MveFunctions MVE Functions
+  \brief    Function that provides MVE type.
+  @{
+ */
+
+/**
+  \brief   get MVE type
+  \details returns the MVE type
+  \returns
+   - \b  0: No Vector Extension (MVE)
+   - \b  1: Integer Vector Extension (MVE-I)
+   - \b  2: Floating-point Vector Extension (MVE-F)
+ */
+__STATIC_INLINE uint32_t SCB_GetMVEType(void)
+{
+  const uint32_t mvfr1 = FPU->MVFR1;
+  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
+  {
+    return 2U;
+  }
+  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
+  {
+    return 1U;
+  }
+  else
+  {
+    return 0U;
+  }
+}
+
+
+/*@} end of CMSIS_Core_MveFunctions */
+
+
+/* ##########################  Cache functions  #################################### */
+
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+  #include "m-profile/armv7m_cachel1.h"
+#endif
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+/* ###################  PAC Key functions  ########################### */
+
+#if (defined (__ARM_FEATURE_PAUTH) && (__ARM_FEATURE_PAUTH == 1))
+#include "m-profile/armv81m_pac.h"
+#endif
+
+
+/* ##################################    Debug Control function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
+ */
+
+
+/**
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
+ */
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
+
+/**
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
+ */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    Debug Identification function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
+ */
+
+
+/**
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
+ */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_DCBFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+/* ##################################### Debug In/Output function ########################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
+
+
+/**
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
+ */
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
+ */
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
+
+/*@} end of CMSIS_core_DebugFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM85_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/device_cfg.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/device_cfg.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2020-2024 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DEVICE_CFG_H__
+#define __DEVICE_CFG_H__
+
+#include "RTE_Components.h"
+
+/**
+ * \file device_cfg.h
+ * \brief Configuration file native driver re-targeting
+ *
+ * \details This file can be used to add native driver specific macro
+ *          definitions to select which peripherals are available in the build.
+ *
+ * This is a default device configuration file with all peripherals enabled.
+ */
+
+/* Secure only peripheral configuration */
+
+/* ARM MPS3 IO SCC */
+#ifdef RTE_MPS3_IO
+    #define MPS3_IO_NS
+    #define MPS3_IO_DEV    MPS3_IO_DEV_NS
+#endif
+
+/* I2C_SBCon */
+#ifdef RTE_I2C0
+    #define I2C0_SBCON_S
+    #define I2C0_SBCON_DEV    I2C0_SBCON_DEV_S
+#endif
+
+/* I2S */
+#ifdef RTE_I2S
+    #define MPS3_I2S_S
+    #define MPS3_I2S_DEV    MPS3_I2S_DEV_S
+#endif
+
+/* ARM UART Controller CMSDK */
+#ifdef RTE_USART0
+    #define UART0_CMSDK_S
+    #define UART0_CMSDK_DEV    UART0_CMSDK_DEV_S
+#endif
+#ifdef RTE_USART1
+    #define UART1_CMSDK_S
+    #define UART1_CMSDK_DEV      UART1_CMSDK_DEV_S
+#endif
+
+#define DEFAULT_UART_BAUDRATE    115200U
+
+/* To be used as CODE and DATA sram */
+#ifdef RTE_ISRAM0_MPC
+    #define MPC_ISRAM0_S
+    #define MPC_ISRAM0_DEV    MPC_ISRAM0_DEV_S
+#endif
+
+#ifdef RTE_ISRAM1_MPC
+    #define MPC_ISRAM1_S
+    #define MPC_ISRAM1_DEV    MPC_ISRAM0_DEV_S
+#endif
+
+#ifdef RTE_SRAM_MPC
+    #define MPC_SRAM_S
+    #define MPC_SRAM_DEV    MPC_SRAM_DEV_S
+#endif
+
+#ifdef RTE_QSPI_MPC
+    #define MPC_QSPI_S
+    #define MPC_QSPI_DEV    MPC_QSPI_DEV_S
+#endif
+
+/** System Counter Armv8-M */
+#ifdef RTE_SYSCOUNTER
+    #define SYSCOUNTER_CNTRL_ARMV8_M_S
+    #define SYSCOUNTER_CNTRL_ARMV8_M_DEV               SYSCOUNTER_CNTRL_ARMV8_M_DEV_S
+
+    #define SYSCOUNTER_READ_ARMV8_M_S
+    #define SYSCOUNTER_READ_ARMV8_M_DEV                SYSCOUNTER_READ_ARMV8_M_DEV_S
+
+/**
+ * Arbitrary scaling values for test purposes
+ */
+    #define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_INT      1u
+    #define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_FRACT    0u
+    #define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_INT      1u
+    #define SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_FRACT    0u
+#endif /* ifdef RTE_SYSCOUNTER */
+
+/* System timer */
+#ifdef RTE_TIMEOUT
+    #define SYSTIMER0_ARMV8_M_S
+    #define SYSTIMER0_ARMV8_M_DEV               SYSTIMER0_ARMV8_M_DEV_S
+    #define SYSTIMER1_ARMV8_M_S
+    #define SYSTIMER1_ARMV8_M_DEV               SYSTIMER1_ARMV8_M_DEV_S
+    #define SYSTIMER2_ARMV8_M_S
+    #define SYSTIMER2_ARMV8_M_DEV               SYSTIMER2_ARMV8_M_DEV_S
+    #define SYSTIMER3_ARMV8_M_S
+    #define SYSTIMER3_ARMV8_M_DEV               SYSTIMER3_ARMV8_M_DEV_S
+
+    #define SYSTIMER0_ARMV8M_DEFAULT_FREQ_HZ    ( 32000000ul )
+    #define SYSTIMER1_ARMV8M_DEFAULT_FREQ_HZ    ( 32000000ul )
+    #define SYSTIMER2_ARMV8M_DEFAULT_FREQ_HZ    ( 32000000ul )
+    #define SYSTIMER3_ARMV8M_DEFAULT_FREQ_HZ    ( 32000000ul )
+#endif /* ifdef RTE_TIMEOUT */
+
+/* CMSDK GPIO driver structures */
+#ifdef RTE_GPIO
+    #define GPIO0_CMSDK_S
+    #define GPIO0_CMSDK_DEV    GPIO0_CMSDK_DEV_S
+    #define GPIO1_CMSDK_S
+    #define GPIO1_CMSDK_DEV    GPIO1_CMSDK_DEV_S
+    #define GPIO2_CMSDK_S
+    #define GPIO2_CMSDK_DEV    GPIO2_CMSDK_DEV_S
+    #define GPIO3_CMSDK_S
+    #define GPIO3_CMSDK_DEV    GPIO3_CMSDK_DEV_S
+#endif
+
+/* System Watchdogs */
+#ifdef RTE_WATCHDOG
+    #define SYSWDOG_ARMV8_M_S
+    #define SYSWDOG_ARMV8_M_DEV    SYSWDOG_ARMV8_M_DEV_S
+#endif
+
+/* ARM MPC SIE 310 driver structures */
+#ifdef RTE_VM0_MPC
+    #define MPC_VM0_S
+    #define MPC_VM0_DEV    MPC_VM0_DEV_S
+#endif
+#ifdef RTE_VM1_MPC
+    #define MPC_VM1_S
+    #define MPC_VM1_DEV    MPC_VM1_DEV_S
+#endif
+#ifdef RTE_SSRAM2_MPC
+    #define MPC_SSRAM2_S
+    #define MPC_SSRAM2_DEV    MPC_SSRAM2_DEV_S
+#endif
+#ifdef RTE_SSRAM3_MPC
+    #define MPC_SSRAM3_S
+    #define MPC_SSRAM3_DEV    MPC_SSRAM3_DEV_S
+#endif
+
+/* ARM PPC driver structures */
+#ifdef RTE_MAIN0_PPC_CORSTONE310
+    #define PPC_CORSTONE310_MAIN0_S
+    #define PPC_CORSTONE310_MAIN0_DEV    PPC_CORSTONE310_MAIN0_DEV_S
+#endif
+#ifdef RTE_MAIN_EXP0_PPC_CORSTONE310
+    #define PPC_CORSTONE310_MAIN_EXP0_S
+    #define PPC_CORSTONE310_MAIN_EXP0_DEV    PPC_CORSTONE310_MAIN_EXP0_DEV_S
+#endif
+#ifdef RTE_MAIN_EXP1_PPC_CORSTONE310
+    #define PPC_CORSTONE310_MAIN_EXP1_S
+    #define PPC_CORSTONE310_MAIN_EXP1_DEV    PPC_CORSTONE310_MAIN_EXP1_DEV_S
+#endif
+#ifdef RTE_MAIN_EXP2_PPC_CORSTONE310
+    #define PPC_CORSTONE310_MAIN_EXP2_S
+    #define PPC_CORSTONE310_MAIN_EXP2_DEV    PPC_CORSTONE310_MAIN_EXP2_DEV_S
+#endif
+#ifdef RTE_MAIN_EXP3_PPC_CORSTONE310
+    #define PPC_CORSTONE310_MAIN_EXP3_S
+    #define PPC_CORSTONE310_MAIN_EXP3_DEV    PPC_CORSTONE310_MAIN_EXP3_DEV_S
+#endif
+#ifdef RTE_PERIPH0_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH0_S
+    #define PPC_CORSTONE310_PERIPH0_DEV    PPC_CORSTONE310_PERIPH0_DEV_S
+#endif
+#ifdef RTE_PERIPH1_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH1_S
+    #define PPC_CORSTONE310_PERIPH1_DEV    PPC_CORSTONE310_PERIPH1_DEV_S
+#endif
+#ifdef RTE_PERIPH_EXP0_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH_EXP0_S
+    #define PPC_CORSTONE310_PERIPH_EXP0_DEV    PPC_CORSTONE310_PERIPH_EXP0_DEV_S
+#endif
+#ifdef RTE_PERIPH_EXP1_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH_EXP1_S
+    #define PPC_CORSTONE310_PERIPH_EXP1_DEV    PPC_CORSTONE310_PERIPH_EXP1_DEV_S
+#endif
+#ifdef RTE_PERIPH_EXP2_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH_EXP2_S
+    #define PPC_CORSTONE310_PERIPH_EXP2_DEV    PPC_CORSTONE310_PERIPH_EXP2_DEV_S
+#endif
+#ifdef RTE_PERIPH_EXP3_PPC_CORSTONE310
+    #define PPC_CORSTONE310_PERIPH_EXP3_S
+    #define PPC_CORSTONE310_PERIPH_EXP3_DEV    PPC_CORSTONE310_PERIPH_EXP3_DEV_S
+#endif
+
+/* DMA350 */
+#ifdef RTE_DMA350
+    #define DMA350_DMA0_S
+    #define DMA350_DMA0_DEV    DMA350_DMA0_DEV_S
+
+    #define DMA350_CH0_S
+    #define DMA350_DMA0_CH0_S
+    #define DMA350_CH1_S
+    #define DMA350_DMA0_CH1_S
+#endif
+
+/* ARM SPI PL022 */
+/* Invalid device stubs are not defined */
+#define DEFAULT_SPI_SPEED_HZ    4000000U /* 4MHz */
+#ifdef RTE_SPI1
+    #define SPI1_PL022_S
+    #define SPI1_PL022_DEV      SPI1_PL022_DEV_S
+#endif
+
+#endif /* __DEVICE_CFG_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/device_definition.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/device_definition.h
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file device_definition.h
+ * \brief The structure definitions in this file are exported based on the
+ * peripheral definitions from device_cfg.h.
+ * This file is meant to be used as a helper for baremetal
+ * applications and/or as an example of how to configure the generic
+ * driver structures.
+ */
+
+#ifndef __DEVICE_DEFINITION_H__
+#define __DEVICE_DEFINITION_H__
+
+#include "device_cfg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ======= Defines peripheral configuration structures ======= */
+/* UART CMSDK driver structures */
+#ifdef UART0_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART0_CMSDK_DEV_S;
+#endif
+#ifdef UART0_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART0_CMSDK_DEV_NS;
+#endif
+
+#ifdef UART1_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART1_CMSDK_DEV_S;
+#endif
+#ifdef UART1_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART1_CMSDK_DEV_NS;
+#endif
+
+#ifdef UART2_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART2_CMSDK_DEV_S;
+#endif
+#ifdef UART2_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART2_CMSDK_DEV_NS;
+#endif
+
+#ifdef UART3_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART3_CMSDK_DEV_S;
+#endif
+#ifdef UART3_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART3_CMSDK_DEV_NS;
+#endif
+
+#ifdef UART4_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART4_CMSDK_DEV_S;
+#endif
+#ifdef UART4_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART4_CMSDK_DEV_NS;
+#endif
+
+#ifdef UART5_CMSDK_S
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART5_CMSDK_DEV_S;
+#endif
+#ifdef UART5_CMSDK_NS
+#include "uart_cmsdk_drv.h"
+extern struct uart_cmsdk_dev_t UART5_CMSDK_DEV_NS;
+#endif
+
+/* ARM PPC driver structures */
+#ifdef PPC_CORSTONE310_MAIN0_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN0_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP0_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP0_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP1_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP1_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP2_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP2_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP3_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP3_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH0_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH0_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH1_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH1_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP0_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP0_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP1_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP1_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP2_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP2_DEV_S;
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP3_S
+#include "ppc_corstone310_drv.h"
+extern struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP3_DEV_S;
+#endif
+
+/* System counters */
+#ifdef SYSCOUNTER_CNTRL_ARMV8_M_S
+#include "syscounter_armv8-m_cntrl_drv.h"
+extern struct syscounter_armv8_m_cntrl_dev_t SYSCOUNTER_CNTRL_ARMV8_M_DEV_S;
+#endif
+
+#ifdef SYSCOUNTER_READ_ARMV8_M_S
+#include "syscounter_armv8-m_read_drv.h"
+extern struct syscounter_armv8_m_read_dev_t SYSCOUNTER_READ_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSCOUNTER_READ_ARMV8_M_NS
+#include "syscounter_armv8-m_read_drv.h"
+extern struct syscounter_armv8_m_read_dev_t SYSCOUNTER_READ_ARMV8_M_DEV_NS;
+#endif
+
+/* System timers */
+#ifdef SYSTIMER0_ARMV8_M_S
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER0_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSTIMER0_ARMV8_M_NS
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER0_ARMV8_M_DEV_NS;
+#endif
+
+#ifdef SYSTIMER1_ARMV8_M_S
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER1_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSTIMER1_ARMV8_M_NS
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER1_ARMV8_M_DEV_NS;
+#endif
+
+#ifdef SYSTIMER2_ARMV8_M_S
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER2_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSTIMER2_ARMV8_M_NS
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER2_ARMV8_M_DEV_NS;
+#endif
+
+#ifdef SYSTIMER3_ARMV8_M_S
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER3_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSTIMER3_ARMV8_M_NS
+#include "systimer_armv8-m_drv.h"
+extern struct systimer_armv8_m_dev_t SYSTIMER3_ARMV8_M_DEV_NS;
+#endif
+
+/* System Watchdogs */
+#ifdef SYSWDOG_ARMV8_M_S
+#include "syswdog_armv8-m_drv.h"
+extern struct syswdog_armv8_m_dev_t SYSWDOG_ARMV8_M_DEV_S;
+#endif
+#ifdef SYSWDOG_ARMV8_M_NS
+#include "syswdog_armv8-m_drv.h"
+extern struct syswdog_armv8_m_dev_t SYSWDOG_ARMV8_M_DEV_NS;
+#endif
+
+/* ARM MPC SIE 300 driver structures */
+#ifdef MPC_SRAM_S
+#include "mpc_sie_drv.h"
+extern struct mpc_sie_dev_t MPC_SRAM_DEV_S;
+#endif
+
+#ifdef MPC_QSPI_S
+#include "mpc_sie_drv.h"
+extern struct mpc_sie_dev_t MPC_QSPI_DEV_S;
+#endif
+
+#ifdef MPC_DDR4_S
+#include "mpc_sie_drv.h"
+extern struct mpc_sie_dev_t MPC_DDR4_DEV_S;
+#endif
+
+#ifdef MPC_ISRAM0_S
+#include "mpc_sie_drv.h"
+extern struct mpc_sie_dev_t MPC_ISRAM0_DEV_S;
+#endif
+
+#ifdef MPC_ISRAM1_S
+#include "mpc_sie_drv.h"
+extern struct mpc_sie_dev_t MPC_ISRAM1_DEV_S;
+#endif
+
+#ifdef MPS3_IO_S
+#include "arm_mps3_io_drv.h"
+extern struct arm_mps3_io_dev_t MPS3_IO_DEV_S;
+#endif
+
+#ifdef MPS3_IO_NS
+#include "arm_mps3_io_drv.h"
+extern struct arm_mps3_io_dev_t MPS3_IO_DEV_NS;
+#endif
+
+#ifdef SMSC9220_ETH_S
+#include "smsc9220_eth_drv.h"
+extern struct smsc9220_eth_dev_t SMSC9220_ETH_DEV_S;
+#endif
+
+#ifdef SMSC9220_ETH_NS
+#include "smsc9220_eth_drv.h"
+extern struct smsc9220_eth_dev_t SMSC9220_ETH_DEV_NS;
+#endif
+
+/* CMSDK GPIO driver structures */
+#ifdef GPIO0_CMSDK_S
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO0_CMSDK_DEV_S;
+#endif
+
+#ifdef GPIO0_CMSDK_NS
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO0_CMSDK_DEV_NS;
+#endif
+
+#ifdef GPIO1_CMSDK_S
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO1_CMSDK_DEV_S;
+#endif
+
+#ifdef GPIO1_CMSDK_NS
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO1_CMSDK_DEV_NS;
+#endif
+
+#ifdef GPIO2_CMSDK_S
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO2_CMSDK_DEV_S;
+#endif
+
+#ifdef GPIO2_CMSDK_NS
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO2_CMSDK_DEV_NS;
+#endif
+
+#ifdef GPIO3_CMSDK_S
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO3_CMSDK_DEV_S;
+#endif
+
+#ifdef GPIO3_CMSDK_NS
+#include "gpio_cmsdk_drv.h"
+extern struct gpio_cmsdk_dev_t GPIO3_CMSDK_DEV_NS;
+#endif
+
+/* PL022 SPI driver structures */
+#ifdef SPI0_PL022_S
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI0_PL022_DEV_S;
+#endif
+
+#ifdef SPI0_PL022_NS
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI0_PL022_DEV_NS;
+#endif
+
+#ifdef SPI1_PL022_S
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI1_PL022_DEV_S;
+#endif
+
+#ifdef SPI1_PL022_NS
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI1_PL022_DEV_NS;
+#endif
+
+#ifdef SPI2_PL022_S
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI2_PL022_DEV_S;
+#endif
+
+#ifdef SPI2_PL022_NS
+#include "spi_pl022_drv.h"
+extern struct spi_pl022_dev_t SPI2_PL022_DEV_NS;
+#endif
+
+/* I2C_SBCon driver structures */
+#ifdef I2C0_SBCON_S
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C0_SBCON_DEV_S;
+#endif
+
+#ifdef I2C0_SBCON_NS
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C0_SBCON_DEV_NS;
+#endif
+
+#ifdef I2C1_SBCON_S
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C1_SBCON_DEV_S;
+#endif
+
+#ifdef I2C1_SBCON_NS
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C1_SBCON_DEV_NS;
+#endif
+
+#ifdef I2C2_SBCON_S
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C2_SBCON_DEV_S;
+#endif
+
+#ifdef I2C2_SBCON_NS
+#include "i2c_sbcon_drv.h"
+#include "timeout.h"
+extern struct i2c_sbcon_dev_t I2C2_SBCON_DEV_NS;
+#endif
+
+/* I2S driver structures */
+#ifdef MPS3_I2S_S
+#include "audio_i2s_mps3_drv.h"
+extern struct audio_i2s_mps3_dev_t MPS3_I2S_DEV_S;
+#endif
+
+#ifdef MPS3_I2S_NS
+#include "audio_i2s_mps3_drv.h"
+extern struct audio_i2s_mps3_dev_t MPS3_I2S_DEV_NS;
+#endif
+
+/* DMA350 driver structures */
+#ifdef DMA350_DMA0_S
+#include "dma350_ch_drv.h"
+#include "dma350_drv.h"
+extern struct dma350_dev_t DMA350_DMA0_DEV_S;
+
+#ifdef DMA350_DMA0_CH0_S
+extern struct dma350_ch_dev_t DMA350_DMA0_CH0_DEV_S;
+#endif
+
+#ifdef DMA350_DMA0_CH1_S
+extern struct dma350_ch_dev_t DMA350_DMA0_CH1_DEV_S;
+#endif
+
+#ifdef DMA350_DMA0_CH0_NS
+extern struct dma350_ch_dev_t DMA350_DMA0_CH0_DEV_NS;
+#endif
+
+#ifdef DMA350_DMA0_CH1_NS
+extern struct dma350_ch_dev_t DMA350_DMA0_CH1_DEV_NS;
+#endif
+
+#endif /* DMA350_DMA0_S */
+
+#if defined(DMA350_DMA0_S)
+#include "dma350_lib.h"
+extern const struct dma350_remap_list_t dma350_address_remap;
+#endif
+
+/* TGU driver structure */
+#ifdef TGU_ARMV8_M_ITCM_S
+#include "tgu_armv8_m_drv.h"
+extern struct tgu_armv8_m_dev_t TGU_ARMV8_M_ITCM_DEV_S;
+#endif
+
+#ifdef TGU_ARMV8_M_DTCM_S
+#include "tgu_armv8_m_drv.h"
+extern struct tgu_armv8_m_dev_t TGU_ARMV8_M_DTCM_DEV_S;
+#endif
+
+/* Color LCD driver structures */
+#ifdef MPS3_CLCD_S
+#include "clcd_mps3_drv.h"
+extern struct clcd_mps3_dev_t MPS3_CLCD_DEV_S;
+#endif
+
+#ifdef MPS3_CLCD_NS
+#include "clcd_mps3_drv.h"
+extern struct clcd_mps3_dev_t MPS3_CLCD_DEV_NS;
+#endif
+
+/* RTC driver structures */
+#ifdef RTC_PL031_S
+#include "rtc_pl031_drv.h"
+extern struct rtc_pl031_dev_t RTC_PL031_DEV_S;
+#endif
+
+#ifdef RTC_PL031_NS
+#include "rtc_pl031_drv.h"
+extern struct rtc_pl031_dev_t RTC_PL031_DEV_NS;
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __DEVICE_DEFINITION_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv7m_cachel1.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv7m_cachel1.h
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Level 1 Cache API for Armv7-M and later
+ */
+
+#ifndef ARM_ARMV7M_CACHEL1_H
+#define ARM_ARMV7M_CACHEL1_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_CacheFunctions Cache Functions
+  \brief    Functions that configure Instruction and Data cache.
+  @{
+ */
+
+/* Cache Size ID Register Macros */
+#define CCSIDR_WAYS(x)         (((x) & SCB_CCSIDR_ASSOCIATIVITY_Msk) >> SCB_CCSIDR_ASSOCIATIVITY_Pos)
+#define CCSIDR_SETS(x)         (((x) & SCB_CCSIDR_NUMSETS_Msk      ) >> SCB_CCSIDR_NUMSETS_Pos      )
+
+#ifndef __SCB_DCACHE_LINE_SIZE
+#define __SCB_DCACHE_LINE_SIZE  32U /*!< Cortex-M7 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+#endif
+
+#ifndef __SCB_ICACHE_LINE_SIZE
+#define __SCB_ICACHE_LINE_SIZE  32U /*!< Cortex-M7 cache line size is fixed to 32 bytes (8 words). See also register SCB_CCSIDR */
+#endif
+
+/**
+  \brief   Enable I-Cache
+  \details Turns on I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if (SCB->CCR & SCB_CCR_IC_Msk) return;  /* return if ICache is already enabled */
+
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+    SCB->CCR |=  (uint32_t)SCB_CCR_IC_Msk;  /* enable I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable I-Cache
+  \details Turns off I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->CCR &= ~(uint32_t)SCB_CCR_IC_Msk;  /* disable I-Cache */
+    SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate I-Cache
+  \details Invalidates I-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateICache (void)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    __DSB();
+    __ISB();
+    SCB->ICIALLU = 0UL;
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   I-Cache Invalidate by address
+  \details Invalidates I-Cache for the given address.
+           I-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           I-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   isize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateICache_by_Addr (volatile void *addr, int32_t isize)
+{
+  #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    if ( isize > 0 ) {
+       int32_t op_size = isize + (((uint32_t)addr) & (__SCB_ICACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_ICACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->ICIMVAU = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_ICACHE_LINE_SIZE;
+        op_size -= __SCB_ICACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   Enable D-Cache
+  \details Turns on D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_EnableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    if (SCB->CCR & SCB_CCR_DC_Msk) return;  /* return if DCache is already enabled */
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+    __DSB();
+
+    SCB->CCR |=  (uint32_t)SCB_CCR_DC_Msk;  /* enable D-Cache */
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Disable D-Cache
+  \details Turns off D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_DisableDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    struct {
+      uint32_t ccsidr;
+      uint32_t sets;
+      uint32_t ways;
+    } locals
+    #if ((defined(__GNUC__) || defined(__clang__)) && !defined(__OPTIMIZE__))
+       __ALIGNED(__SCB_DCACHE_LINE_SIZE)
+    #endif
+    ;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
+    __DSB();
+
+    #if !defined(__OPTIMIZE__)
+      /*
+       * For the endless loop issue with no optimization builds.
+       * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
+       *
+       * The issue only happens when local variables are in stack. If
+       * local variables are saved in general purpose register, then the function
+       * is OK.
+       *
+       * When local variables are in stack, after disabling the cache, flush the
+       * local variables cache line for data consistency.
+       */
+      /* Clean and invalidate the local variable cache. */
+    #if defined(__ICCARM__)
+    /* As we can't align the stack to the cache line size, invalidate each of the variables */
+      SCB->DCCIMVAC = (uint32_t)&locals.sets;
+      SCB->DCCIMVAC = (uint32_t)&locals.ways;
+      SCB->DCCIMVAC = (uint32_t)&locals.ccsidr;
+    #else
+      SCB->DCCIMVAC = (uint32_t)&locals;
+    #endif
+      __DSB();
+      __ISB();
+    #endif
+
+    locals.ccsidr = SCB->CCSIDR;
+                                            /* clean & invalidate D-Cache */
+    locals.sets = (uint32_t)(CCSIDR_SETS(locals.ccsidr));
+    do {
+      locals.ways = (uint32_t)(CCSIDR_WAYS(locals.ccsidr));
+      do {
+        SCB->DCCISW = (((locals.sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((locals.ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (locals.ways-- != 0U);
+    } while(locals.sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Invalidate D-Cache
+  \details Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_InvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCISW = (((sets << SCB_DCISW_SET_Pos) & SCB_DCISW_SET_Msk) |
+                      ((ways << SCB_DCISW_WAY_Pos) & SCB_DCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean D-Cache
+  \details Cleans D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCSW = (((sets << SCB_DCCSW_SET_Pos) & SCB_DCCSW_SET_Msk) |
+                      ((ways << SCB_DCCSW_WAY_Pos) & SCB_DCCSW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   Clean & Invalidate D-Cache
+  \details Cleans and Invalidates D-Cache
+  */
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache (void)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
+
+    SCB->CSSELR = 0U;                       /* select Level 1 data cache */
+    __DSB();
+
+    ccsidr = SCB->CCSIDR;
+
+                                            /* clean & invalidate D-Cache */
+    sets = (uint32_t)(CCSIDR_SETS(ccsidr));
+    do {
+      ways = (uint32_t)(CCSIDR_WAYS(ccsidr));
+      do {
+        SCB->DCCISW = (((sets << SCB_DCCISW_SET_Pos) & SCB_DCCISW_SET_Msk) |
+                       ((ways << SCB_DCCISW_WAY_Pos) & SCB_DCCISW_WAY_Msk)  );
+        #if defined ( __CC_ARM )
+          __schedule_barrier();
+        #endif
+      } while (ways-- != 0U);
+    } while(sets-- != 0U);
+
+    __DSB();
+    __ISB();
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Invalidate by address
+  \details Invalidates D-Cache for the given address.
+           D-Cache is invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are invalidated.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_InvalidateDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCIMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean by address
+  \details Cleans D-Cache for the given address
+           D-Cache is cleaned starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned.
+  \param[in]   addr    address
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCMVAC = op_addr;             /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr += __SCB_DCACHE_LINE_SIZE;
+        op_size -= __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+
+/**
+  \brief   D-Cache Clean and Invalidate by address
+  \details Cleans and invalidates D_Cache for the given address
+           D-Cache is cleaned and invalidated starting from a 32 byte aligned address in 32 byte granularity.
+           D-Cache memory blocks which are part of given address + given size are cleaned and invalidated.
+  \param[in]   addr    address (aligned to 32-byte boundary)
+  \param[in]   dsize   size of memory block (in number of bytes)
+*/
+__STATIC_FORCEINLINE void SCB_CleanInvalidateDCache_by_Addr (volatile void *addr, int32_t dsize)
+{
+  #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    if ( dsize > 0 ) {
+       int32_t op_size = dsize + (((uint32_t)addr) & (__SCB_DCACHE_LINE_SIZE - 1U));
+      uint32_t op_addr = (uint32_t)addr /* & ~(__SCB_DCACHE_LINE_SIZE - 1U) */;
+
+      __DSB();
+
+      do {
+        SCB->DCCIMVAC = op_addr;            /* register accepts only 32byte aligned values, only bits 31..5 are valid */
+        op_addr +=          __SCB_DCACHE_LINE_SIZE;
+        op_size -=          __SCB_DCACHE_LINE_SIZE;
+      } while ( op_size > 0 );
+
+      __DSB();
+      __ISB();
+    }
+  #endif
+}
+
+/*@} end of CMSIS_Core_CacheFunctions */
+
+#endif /* ARM_ARMV7M_CACHEL1_H */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv8m_mpu.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv8m_mpu.h
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2017-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) MPU API for Armv8-M and Armv8.1-M MPU
+ */
+
+#ifndef ARM_MPU_ARMV8_H
+#define ARM_MPU_ARMV8_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/** \brief Attribute for device memory (outer only) */
+#define ARM_MPU_ATTR_DEVICE                           ( 0U )
+
+/** \brief Attribute for non-cacheable, normal memory */
+#define ARM_MPU_ATTR_NON_CACHEABLE                    ( 4U )
+
+/** \brief Attribute for Normal memory, Outer and Inner cacheability.
+* \param NT Non-Transient: Set to 1 for Non-transient data. Set to 0 for Transient data.
+* \param WB Write-Back: Set to 1 to use a Write-Back policy. Set to 0 to use a Write-Through policy.
+* \param RA Read Allocation: Set to 1 to enable cache allocation on read miss. Set to 0 to disable cache allocation on read miss.
+* \param WA Write Allocation: Set to 1 to enable cache allocation on write miss. Set to 0 to disable cache allocation on write miss.
+*/
+#define ARM_MPU_ATTR_MEMORY_(NT, WB, RA, WA) \
+  ((((NT) & 1U) << 3U) | (((WB) & 1U) << 2U) | (((RA) & 1U) << 1U) | ((WA) & 1U))
+
+/** \brief Device memory type non Gathering, non Re-ordering, non Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGnRnE (0U)
+
+/** \brief Device memory type non Gathering, non Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGnRE  (1U)
+
+/** \brief Device memory type non Gathering, Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_nGRE   (2U)
+
+/** \brief Device memory type Gathering, Re-ordering, Early Write Acknowledgement */
+#define ARM_MPU_ATTR_DEVICE_GRE    (3U)
+
+/** \brief Normal memory outer-cacheable and inner-cacheable attributes
+* WT = Write Through, WB = Write Back, TR = Transient, RA = Read-Allocate, WA = Write Allocate
+*/
+#define MPU_ATTR_NORMAL_OUTER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_OUTER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_OUTER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_OUTER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_OUTER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_OUTER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_OUTER_WB_RA_WA      (0b1111)
+#define MPU_ATTR_NORMAL_INNER_NON_CACHEABLE (0b0100)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA      (0b0010)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_WA      (0b0001)
+#define MPU_ATTR_NORMAL_INNER_WT_TR_RA_WA   (0b0011)
+#define MPU_ATTR_NORMAL_INNER_WT_RA         (0b1010)
+#define MPU_ATTR_NORMAL_INNER_WT_WA         (0b1001)
+#define MPU_ATTR_NORMAL_INNER_WT_RA_WA      (0b1011)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA      (0b0101)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_WA      (0b0110)
+#define MPU_ATTR_NORMAL_INNER_WB_TR_RA_WA   (0b0111)
+#define MPU_ATTR_NORMAL_INNER_WB_RA         (0b1101)
+#define MPU_ATTR_NORMAL_INNER_WB_WA         (0b1110)
+#define MPU_ATTR_NORMAL_INNER_WB_RA_WA      (0b1111)
+
+/** \brief Memory Attribute
+* \param O Outer memory attributes
+* \param I O == ARM_MPU_ATTR_DEVICE: Device memory attributes, else: Inner memory attributes
+*/
+#define ARM_MPU_ATTR(O, I) ((((O) & 0xFU) << 4U) | ((((O) & 0xFU) != 0U) ? ((I) & 0xFU) : (((I) & 0x3U) << 2U)))
+
+/* \brief Specifies MAIR_ATTR number */
+#define MAIR_ATTR(x)       ((x > 7 || x < 0) ? 0 : x)
+
+/**
+ * Shareability
+ */
+/** \brief Normal memory, non-shareable  */
+#define ARM_MPU_SH_NON   (0U)
+
+/** \brief Normal memory, outer shareable  */
+#define ARM_MPU_SH_OUTER (2U)
+
+/** \brief Normal memory, inner shareable  */
+#define ARM_MPU_SH_INNER (3U)
+
+/**
+ * Access permissions
+ * AP = Access permission, RO = Read-only, RW = Read/Write, NP = Any privilege, PO = Privileged code only
+ */
+/** \brief Normal memory, read/write */
+#define ARM_MPU_AP_RW (0U)
+
+/** \brief Normal memory, read-only */
+#define ARM_MPU_AP_RO (1U)
+
+/** \brief Normal memory, any privilege level */
+#define ARM_MPU_AP_NP (1U)
+
+/** \brief Normal memory, privileged access only */
+#define ARM_MPU_AP_PO (0U)
+
+/*
+ * Execute-never
+ * XN = Execute-never, EX = Executable
+ */
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_XN (1U)
+
+/** \brief Normal memory, Execution only permitted if read permitted */
+#define ARM_MPU_EX (0U)
+
+/** \brief Memory access permissions
+* \param RO Read-Only: Set to 1 for read-only memory. Set to 0 for a read/write memory.
+* \param NP Non-Privileged: Set to 1 for non-privileged memory. Set to 0 for privileged memory.
+*/
+#define ARM_MPU_AP_(RO, NP) ((((RO) & 1U) << 1U) | ((NP) & 1U))
+
+/** \brief Region Base Address Register value
+* \param BASE The base address bits [31:5] of a memory region. The value is zero extended. Effective address gets 32 byte aligned.
+* \param SH Defines the Shareability domain for this memory region.
+* \param RO Read-Only: Set to 1 for a read-only memory region. Set to 0 for a read/write memory region.
+* \param NP Non-Privileged: Set to 1 for a non-privileged memory region. Set to 0 for privileged memory region.
+* \param XN eXecute Never: Set to 1 for a non-executable memory region. Set to 0 for an executable memory region.
+*/
+#define ARM_MPU_RBAR(BASE, SH, RO, NP, XN) \
+  (((BASE) & MPU_RBAR_BASE_Msk) | \
+  (((SH) << MPU_RBAR_SH_Pos) & MPU_RBAR_SH_Msk) | \
+  ((ARM_MPU_AP_(RO, NP) << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk) | \
+  (((XN) << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk))
+
+/** \brief Region Limit Address Register value
+* \param LIMIT The limit address bits [31:5] for this memory region. The value is one extended.
+* \param IDX The attribute index to be associated with this memory region.
+*/
+#define ARM_MPU_RLAR(LIMIT, IDX) \
+  (((LIMIT) & MPU_RLAR_LIMIT_Msk) | \
+  (((IDX) << MPU_RLAR_AttrIndx_Pos) & MPU_RLAR_AttrIndx_Msk) | \
+  (MPU_RLAR_EN_Msk))
+
+#if defined(MPU_RLAR_PXN_Pos)
+
+/** \brief Region Limit Address Register with PXN value
+* \param LIMIT The limit address bits [31:5] for this memory region. The value is one extended.
+* \param PXN Privileged execute never. Defines whether code can be executed from this privileged region.
+* \param IDX The attribute index to be associated with this memory region.
+*/
+#define ARM_MPU_RLAR_PXN(LIMIT, PXN, IDX) \
+  (((LIMIT) & MPU_RLAR_LIMIT_Msk) | \
+  (((PXN) << MPU_RLAR_PXN_Pos) & MPU_RLAR_PXN_Msk) | \
+  (((IDX) << MPU_RLAR_AttrIndx_Pos) & MPU_RLAR_AttrIndx_Msk) | \
+  (MPU_RLAR_EN_Msk))
+
+#endif
+
+/**
+* Struct for a single MPU Region
+*/
+typedef struct {
+  uint32_t RBAR;                   /*!< Region Base Address Register value */
+  uint32_t RLAR;                   /*!< Region Limit Address Register value */
+} ARM_MPU_Region_t;
+
+/**
+  \brief  Read MPU Type Register
+  \return Number of MPU regions
+*/
+__STATIC_INLINE uint32_t ARM_MPU_TYPE()
+{
+  return ((MPU->TYPE) >> 8);
+}
+
+/** Enable the MPU.
+* \param MPU_Control Default access permissions for unconfigured regions.
+*/
+__STATIC_INLINE void ARM_MPU_Enable(uint32_t MPU_Control)
+{
+  __DMB();
+  MPU->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  __DSB();
+  __ISB();
+}
+
+/** Disable the MPU.
+*/
+__STATIC_INLINE void ARM_MPU_Disable(void)
+{
+  __DMB();
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  __DSB();
+  __ISB();
+}
+
+#ifdef MPU_NS
+/** Enable the Non-secure MPU.
+* \param MPU_Control Default access permissions for unconfigured regions.
+*/
+__STATIC_INLINE void ARM_MPU_Enable_NS(uint32_t MPU_Control)
+{
+  __DMB();
+  MPU_NS->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB_NS->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  __DSB();
+  __ISB();
+}
+
+/** Disable the Non-secure MPU.
+*/
+__STATIC_INLINE void ARM_MPU_Disable_NS(void)
+{
+  __DMB();
+#ifdef SCB_SHCSR_MEMFAULTENA_Msk
+  SCB_NS->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+#endif
+  MPU_NS->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  __DSB();
+  __ISB();
+}
+#endif
+
+/** Set the memory attribute encoding to the given MPU.
+* \param mpu Pointer to the MPU to be configured.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttrEx(MPU_Type* mpu, uint8_t idx, uint8_t attr)
+{
+  const uint8_t reg = idx / 4U;
+  const uint32_t pos = ((idx % 4U) * 8U);
+  const uint32_t mask = 0xFFU << pos;
+
+  if (reg >= (sizeof(mpu->MAIR) / sizeof(mpu->MAIR[0]))) {
+    return; // invalid index
+  }
+
+  mpu->MAIR[reg] = ((mpu->MAIR[reg] & ~mask) | ((attr << pos) & mask));
+}
+
+/** Set the memory attribute encoding.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttr(uint8_t idx, uint8_t attr)
+{
+  ARM_MPU_SetMemAttrEx(MPU, idx, attr);
+}
+
+#ifdef MPU_NS
+/** Set the memory attribute encoding to the Non-secure MPU.
+* \param idx The attribute index to be set [0-7]
+* \param attr The attribute value to be set.
+*/
+__STATIC_INLINE void ARM_MPU_SetMemAttr_NS(uint8_t idx, uint8_t attr)
+{
+  ARM_MPU_SetMemAttrEx(MPU_NS, idx, attr);
+}
+#endif
+
+/** Clear and disable the given MPU region of the given MPU.
+* \param mpu Pointer to MPU to be used.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegionEx(MPU_Type* mpu, uint32_t rnr)
+{
+  mpu->RNR = rnr;
+  mpu->RLAR = 0U;
+}
+
+/** Clear and disable the given MPU region.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegion(uint32_t rnr)
+{
+  ARM_MPU_ClrRegionEx(MPU, rnr);
+}
+
+#ifdef MPU_NS
+/** Clear and disable the given Non-secure MPU region.
+* \param rnr Region number to be cleared.
+*/
+__STATIC_INLINE void ARM_MPU_ClrRegion_NS(uint32_t rnr)
+{
+  ARM_MPU_ClrRegionEx(MPU_NS, rnr);
+}
+#endif
+
+/** Configure the given MPU region of the given MPU.
+* \param mpu Pointer to MPU to be used.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegionEx(MPU_Type* mpu, uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  mpu->RNR = rnr;
+  mpu->RBAR = rbar;
+  mpu->RLAR = rlar;
+}
+
+/** Configure the given MPU region.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegion(uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  ARM_MPU_SetRegionEx(MPU, rnr, rbar, rlar);
+}
+
+#ifdef MPU_NS
+/** Configure the given Non-secure MPU region.
+* \param rnr Region number to be configured.
+* \param rbar Value for RBAR register.
+* \param rlar Value for RLAR register.
+*/
+__STATIC_INLINE void ARM_MPU_SetRegion_NS(uint32_t rnr, uint32_t rbar, uint32_t rlar)
+{
+  ARM_MPU_SetRegionEx(MPU_NS, rnr, rbar, rlar);
+}
+#endif
+
+/** Memcpy with strictly ordered memory access, e.g. used by code in ARM_MPU_LoadEx()
+* \param dst Destination data is copied to.
+* \param src Source data is copied from.
+* \param len Amount of data words to be copied.
+*/
+__STATIC_INLINE void ARM_MPU_OrderedMemcpy(volatile uint32_t* dst, const uint32_t* __RESTRICT src, uint32_t len)
+{
+  uint32_t i;
+  for (i = 0U; i < len; ++i)
+  {
+    dst[i] = src[i];
+  }
+}
+
+/** Load the given number of MPU regions from a table to the given MPU.
+* \param mpu Pointer to the MPU registers to be used.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_LoadEx(MPU_Type* mpu, uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  const uint32_t rowWordSize = sizeof(ARM_MPU_Region_t)/4U;
+  if (cnt == 1U) {
+    mpu->RNR = rnr;
+    ARM_MPU_OrderedMemcpy(&(mpu->RBAR), &(table->RBAR), rowWordSize);
+  } else {
+    uint32_t rnrBase   = rnr & ~(MPU_TYPE_RALIASES-1U);
+    uint32_t rnrOffset = rnr % MPU_TYPE_RALIASES;
+
+    mpu->RNR = rnrBase;
+    while ((rnrOffset + cnt) > MPU_TYPE_RALIASES) {
+      uint32_t c = MPU_TYPE_RALIASES - rnrOffset;
+      ARM_MPU_OrderedMemcpy(&(mpu->RBAR)+(rnrOffset*2U), &(table->RBAR), c*rowWordSize);
+      table += c;
+      cnt -= c;
+      rnrOffset = 0U;
+      rnrBase += MPU_TYPE_RALIASES;
+      mpu->RNR = rnrBase;
+    }
+
+    ARM_MPU_OrderedMemcpy(&(mpu->RBAR)+(rnrOffset*2U), &(table->RBAR), cnt*rowWordSize);
+  }
+}
+
+/** Load the given number of MPU regions from a table.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_Load(uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  ARM_MPU_LoadEx(MPU, rnr, table, cnt);
+}
+
+#ifdef MPU_NS
+/** Load the given number of MPU regions from a table to the Non-secure MPU.
+* \param rnr First region number to be configured.
+* \param table Pointer to the MPU configuration table.
+* \param cnt Amount of regions to be configured.
+*/
+__STATIC_INLINE void ARM_MPU_Load_NS(uint32_t rnr, ARM_MPU_Region_t const* table, uint32_t cnt)
+{
+  ARM_MPU_LoadEx(MPU_NS, rnr, table, cnt);
+}
+#endif
+
+#endif
+

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv8m_pmu.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/armv8m_pmu.h
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) PMU API for Armv8.1-M PMU
+ */
+
+#ifndef ARM_PMU_ARMV8_H
+#define ARM_PMU_ARMV8_H
+
+#if   defined ( __ICCARM__ )
+  #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header    /* treat file as system include file */
+#endif
+
+/**
+ * \brief PMU Events
+ * \note  See the Armv8.1-M Architecture Reference Manual for full details on these PMU events.
+ * */
+
+#define ARM_PMU_SW_INCR                              0x0000             /*!< Software update to the PMU_SWINC register, architecturally executed and condition code check pass */
+#define ARM_PMU_L1I_CACHE_REFILL                     0x0001             /*!< L1 I-Cache refill */
+#define ARM_PMU_L1D_CACHE_REFILL                     0x0003             /*!< L1 D-Cache refill */
+#define ARM_PMU_L1D_CACHE                            0x0004             /*!< L1 D-Cache access */
+#define ARM_PMU_LD_RETIRED                           0x0006             /*!< Memory-reading instruction architecturally executed and condition code check pass */
+#define ARM_PMU_ST_RETIRED                           0x0007             /*!< Memory-writing instruction architecturally executed and condition code check pass */
+#define ARM_PMU_INST_RETIRED                         0x0008             /*!< Instruction architecturally executed */
+#define ARM_PMU_EXC_TAKEN                            0x0009             /*!< Exception entry */
+#define ARM_PMU_EXC_RETURN                           0x000A             /*!< Exception return instruction architecturally executed and the condition code check pass */
+#define ARM_PMU_PC_WRITE_RETIRED                     0x000C             /*!< Software change to the Program Counter (PC). Instruction is architecturally executed and condition code check pass */
+#define ARM_PMU_BR_IMMED_RETIRED                     0x000D             /*!< Immediate branch architecturally executed */
+#define ARM_PMU_BR_RETURN_RETIRED                    0x000E             /*!< Function return instruction architecturally executed and the condition code check pass */
+#define ARM_PMU_UNALIGNED_LDST_RETIRED               0x000F             /*!< Unaligned memory memory-reading or memory-writing instruction architecturally executed and condition code check pass */
+#define ARM_PMU_BR_MIS_PRED                          0x0010             /*!< Mispredicted or not predicted branch speculatively executed */
+#define ARM_PMU_CPU_CYCLES                           0x0011             /*!< Cycle */
+#define ARM_PMU_BR_PRED                              0x0012             /*!< Predictable branch speculatively executed */
+#define ARM_PMU_MEM_ACCESS                           0x0013             /*!< Data memory access */
+#define ARM_PMU_L1I_CACHE                            0x0014             /*!< Level 1 instruction cache access */
+#define ARM_PMU_L1D_CACHE_WB                         0x0015             /*!< Level 1 data cache write-back */
+#define ARM_PMU_L2D_CACHE                            0x0016             /*!< Level 2 data cache access */
+#define ARM_PMU_L2D_CACHE_REFILL                     0x0017             /*!< Level 2 data cache refill */
+#define ARM_PMU_L2D_CACHE_WB                         0x0018             /*!< Level 2 data cache write-back */
+#define ARM_PMU_BUS_ACCESS                           0x0019             /*!< Bus access */
+#define ARM_PMU_MEMORY_ERROR                         0x001A             /*!< Local memory error */
+#define ARM_PMU_INST_SPEC                            0x001B             /*!< Instruction speculatively executed */
+#define ARM_PMU_BUS_CYCLES                           0x001D             /*!< Bus cycles */
+#define ARM_PMU_CHAIN                                0x001E             /*!< For an odd numbered counter, increment when an overflow occurs on the preceding even-numbered counter on the same PE */
+#define ARM_PMU_L1D_CACHE_ALLOCATE                   0x001F             /*!< Level 1 data cache allocation without refill */
+#define ARM_PMU_L2D_CACHE_ALLOCATE                   0x0020             /*!< Level 2 data cache allocation without refill */
+#define ARM_PMU_BR_RETIRED                           0x0021             /*!< Branch instruction architecturally executed */
+#define ARM_PMU_BR_MIS_PRED_RETIRED                  0x0022             /*!< Mispredicted branch instruction architecturally executed */
+#define ARM_PMU_STALL_FRONTEND                       0x0023             /*!< No operation issued because of the frontend */
+#define ARM_PMU_STALL_BACKEND                        0x0024             /*!< No operation issued because of the backend */
+#define ARM_PMU_L2I_CACHE                            0x0027             /*!< Level 2 instruction cache access */
+#define ARM_PMU_L2I_CACHE_REFILL                     0x0028             /*!< Level 2 instruction cache refill */
+#define ARM_PMU_L3D_CACHE_ALLOCATE                   0x0029             /*!< Level 3 data cache allocation without refill */
+#define ARM_PMU_L3D_CACHE_REFILL                     0x002A             /*!< Level 3 data cache refill */
+#define ARM_PMU_L3D_CACHE                            0x002B             /*!< Level 3 data cache access */
+#define ARM_PMU_L3D_CACHE_WB                         0x002C             /*!< Level 3 data cache write-back */
+#define ARM_PMU_LL_CACHE_RD                          0x0036             /*!< Last level data cache read */
+#define ARM_PMU_LL_CACHE_MISS_RD                     0x0037             /*!< Last level data cache read miss */
+#define ARM_PMU_L1D_CACHE_MISS_RD                    0x0039             /*!< Level 1 data cache read miss */
+#define ARM_PMU_OP_COMPLETE                          0x003A             /*!< Operation retired */
+#define ARM_PMU_OP_SPEC                              0x003B             /*!< Operation speculatively executed */
+#define ARM_PMU_STALL                                0x003C             /*!< Stall cycle for instruction or operation not sent for execution */
+#define ARM_PMU_STALL_OP_BACKEND                     0x003D             /*!< Stall cycle for instruction or operation not sent for execution due to pipeline backend */
+#define ARM_PMU_STALL_OP_FRONTEND                    0x003E             /*!< Stall cycle for instruction or operation not sent for execution due to pipeline frontend */
+#define ARM_PMU_STALL_OP                             0x003F             /*!< Instruction or operation slots not occupied each cycle */
+#define ARM_PMU_L1D_CACHE_RD                         0x0040             /*!< Level 1 data cache read */
+#define ARM_PMU_LE_RETIRED                           0x0100             /*!< Loop end instruction executed */
+#define ARM_PMU_LE_SPEC                              0x0101             /*!< Loop end instruction speculatively executed */
+#define ARM_PMU_BF_RETIRED                           0x0104             /*!< Branch future instruction architecturally executed and condition code check pass */
+#define ARM_PMU_BF_SPEC                              0x0105             /*!< Branch future instruction speculatively executed and condition code check pass */
+#define ARM_PMU_LE_CANCEL                            0x0108             /*!< Loop end instruction not taken */
+#define ARM_PMU_BF_CANCEL                            0x0109             /*!< Branch future instruction not taken */
+#define ARM_PMU_SE_CALL_S                            0x0114             /*!< Call to secure function, resulting in Security state change */
+#define ARM_PMU_SE_CALL_NS                           0x0115             /*!< Call to non-secure function, resulting in Security state change */
+#define ARM_PMU_DWT_CMPMATCH0                        0x0118             /*!< DWT comparator 0 match */
+#define ARM_PMU_DWT_CMPMATCH1                        0x0119             /*!< DWT comparator 1 match */
+#define ARM_PMU_DWT_CMPMATCH2                        0x011A             /*!< DWT comparator 2 match */
+#define ARM_PMU_DWT_CMPMATCH3                        0x011B             /*!< DWT comparator 3 match */
+#define ARM_PMU_MVE_INST_RETIRED                     0x0200             /*!< MVE instruction architecturally executed */
+#define ARM_PMU_MVE_INST_SPEC                        0x0201             /*!< MVE instruction speculatively executed */
+#define ARM_PMU_MVE_FP_RETIRED                       0x0204             /*!< MVE floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_SPEC                          0x0205             /*!< MVE floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_HP_RETIRED                    0x0208             /*!< MVE half-precision floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_HP_SPEC                       0x0209             /*!< MVE half-precision floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_SP_RETIRED                    0x020C             /*!< MVE single-precision floating-point instruction architecturally executed */
+#define ARM_PMU_MVE_FP_SP_SPEC                       0x020D             /*!< MVE single-precision floating-point instruction speculatively executed */
+#define ARM_PMU_MVE_FP_MAC_RETIRED                   0x0214             /*!< MVE floating-point multiply or multiply-accumulate instruction architecturally executed */
+#define ARM_PMU_MVE_FP_MAC_SPEC                      0x0215             /*!< MVE floating-point multiply or multiply-accumulate instruction speculatively executed */
+#define ARM_PMU_MVE_INT_RETIRED                      0x0224             /*!< MVE integer instruction architecturally executed */
+#define ARM_PMU_MVE_INT_SPEC                         0x0225             /*!< MVE integer instruction speculatively executed */
+#define ARM_PMU_MVE_INT_MAC_RETIRED                  0x0228             /*!< MVE multiply or multiply-accumulate instruction architecturally executed */
+#define ARM_PMU_MVE_INT_MAC_SPEC                     0x0229             /*!< MVE multiply or multiply-accumulate instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_RETIRED                     0x0238             /*!< MVE load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_SPEC                        0x0239             /*!< MVE load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_RETIRED                       0x023C             /*!< MVE load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_SPEC                          0x023D             /*!< MVE load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_RETIRED                       0x0240             /*!< MVE store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_SPEC                          0x0241             /*!< MVE store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_CONTIG_RETIRED              0x0244             /*!< MVE contiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_CONTIG_SPEC                 0x0245             /*!< MVE contiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_CONTIG_RETIRED                0x0248             /*!< MVE contiguous load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_CONTIG_SPEC                   0x0249             /*!< MVE contiguous load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_CONTIG_RETIRED                0x024C             /*!< MVE contiguous store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_CONTIG_SPEC                   0x024D             /*!< MVE contiguous store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_NONCONTIG_RETIRED           0x0250             /*!< MVE non-contiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_NONCONTIG_SPEC              0x0251             /*!< MVE non-contiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_NONCONTIG_RETIRED             0x0254             /*!< MVE non-contiguous load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_NONCONTIG_SPEC                0x0255             /*!< MVE non-contiguous load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_NONCONTIG_RETIRED             0x0258             /*!< MVE non-contiguous store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_NONCONTIG_SPEC                0x0259             /*!< MVE non-contiguous store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_MULTI_RETIRED               0x025C             /*!< MVE memory instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_LDST_MULTI_SPEC                  0x025D             /*!< MVE memory instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_LD_MULTI_RETIRED                 0x0260             /*!< MVE memory load instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_LD_MULTI_SPEC                    0x0261             /*!< MVE memory load instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_ST_MULTI_RETIRED                 0x0261             /*!< MVE memory store instruction targeting multiple registers architecturally executed */
+#define ARM_PMU_MVE_ST_MULTI_SPEC                    0x0265             /*!< MVE memory store instruction targeting multiple registers speculatively executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_RETIRED           0x028C             /*!< MVE unaligned memory load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_SPEC              0x028D             /*!< MVE unaligned memory load or store instruction speculatively executed */
+#define ARM_PMU_MVE_LD_UNALIGNED_RETIRED             0x0290             /*!< MVE unaligned load instruction architecturally executed */
+#define ARM_PMU_MVE_LD_UNALIGNED_SPEC                0x0291             /*!< MVE unaligned load instruction speculatively executed */
+#define ARM_PMU_MVE_ST_UNALIGNED_RETIRED             0x0294             /*!< MVE unaligned store instruction architecturally executed */
+#define ARM_PMU_MVE_ST_UNALIGNED_SPEC                0x0295             /*!< MVE unaligned store instruction speculatively executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_NONCONTIG_RETIRED 0x0298             /*!< MVE unaligned noncontiguous load or store instruction architecturally executed */
+#define ARM_PMU_MVE_LDST_UNALIGNED_NONCONTIG_SPEC    0x0299             /*!< MVE unaligned noncontiguous load or store instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_RETIRED                  0x02A0             /*!< MVE vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_SPEC                     0x02A1             /*!< MVE vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_FP_RETIRED               0x02A4             /*!< MVE floating-point vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_FP_SPEC                  0x02A5             /*!< MVE floating-point vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_VREDUCE_INT_RETIRED              0x02A8             /*!< MVE integer vector reduction instruction architecturally executed */
+#define ARM_PMU_MVE_VREDUCE_INT_SPEC                 0x02A9             /*!< MVE integer vector reduction instruction speculatively executed */
+#define ARM_PMU_MVE_PRED                             0x02B8             /*!< Cycles where one or more predicated beats architecturally executed */
+#define ARM_PMU_MVE_STALL                            0x02CC             /*!< Stall cycles caused by an MVE instruction */
+#define ARM_PMU_MVE_STALL_RESOURCE                   0x02CD             /*!< Stall cycles caused by an MVE instruction because of resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_MEM               0x02CE             /*!< Stall cycles caused by an MVE instruction because of memory resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_FP                0x02CF             /*!< Stall cycles caused by an MVE instruction because of floating-point resource conflicts */
+#define ARM_PMU_MVE_STALL_RESOURCE_INT               0x02D0             /*!< Stall cycles caused by an MVE instruction because of integer resource conflicts */
+#define ARM_PMU_MVE_STALL_BREAK                      0x02D3             /*!< Stall cycles caused by an MVE chain break */
+#define ARM_PMU_MVE_STALL_DEPENDENCY                 0x02D4             /*!< Stall cycles caused by MVE register dependency */
+#define ARM_PMU_ITCM_ACCESS                          0x4007             /*!< Instruction TCM access */
+#define ARM_PMU_DTCM_ACCESS                          0x4008             /*!< Data TCM access */
+#define ARM_PMU_TRCEXTOUT0                           0x4010             /*!< ETM external output 0 */
+#define ARM_PMU_TRCEXTOUT1                           0x4011             /*!< ETM external output 1 */
+#define ARM_PMU_TRCEXTOUT2                           0x4012             /*!< ETM external output 2 */
+#define ARM_PMU_TRCEXTOUT3                           0x4013             /*!< ETM external output 3 */
+#define ARM_PMU_CTI_TRIGOUT4                         0x4018             /*!< Cross-trigger Interface output trigger 4 */
+#define ARM_PMU_CTI_TRIGOUT5                         0x4019             /*!< Cross-trigger Interface output trigger 5 */
+#define ARM_PMU_CTI_TRIGOUT6                         0x401A             /*!< Cross-trigger Interface output trigger 6 */
+#define ARM_PMU_CTI_TRIGOUT7                         0x401B             /*!< Cross-trigger Interface output trigger 7 */
+
+/** \brief PMU Functions */
+
+__STATIC_INLINE void ARM_PMU_Enable(void);
+__STATIC_INLINE void ARM_PMU_Disable(void);
+
+__STATIC_INLINE void ARM_PMU_Set_EVTYPER(uint32_t num, uint32_t type);
+
+__STATIC_INLINE void ARM_PMU_CYCCNT_Reset(void);
+__STATIC_INLINE void ARM_PMU_EVCNTR_ALL_Reset(void);
+
+__STATIC_INLINE void ARM_PMU_CNTR_Enable(uint32_t mask);
+__STATIC_INLINE void ARM_PMU_CNTR_Disable(uint32_t mask);
+
+__STATIC_INLINE uint32_t ARM_PMU_Get_CCNTR(void);
+__STATIC_INLINE uint32_t ARM_PMU_Get_EVCNTR(uint32_t num);
+
+__STATIC_INLINE uint32_t ARM_PMU_Get_CNTR_OVS(void);
+__STATIC_INLINE void ARM_PMU_Set_CNTR_OVS(uint32_t mask);
+
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Enable(uint32_t mask);
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Disable(uint32_t mask);
+
+__STATIC_INLINE void ARM_PMU_CNTR_Increment(uint32_t mask);
+
+/**
+  \brief   Enable the PMU
+*/
+__STATIC_INLINE void ARM_PMU_Enable(void)
+{
+  PMU->CTRL |= PMU_CTRL_ENABLE_Msk;
+}
+
+/**
+  \brief   Disable the PMU
+*/
+__STATIC_INLINE void ARM_PMU_Disable(void)
+{
+  PMU->CTRL &= ~PMU_CTRL_ENABLE_Msk;
+}
+
+/**
+  \brief   Set event to count for PMU eventer counter
+  \param [in]    num     Event counter (0-30) to configure
+  \param [in]    type    Event to count
+*/
+__STATIC_INLINE void ARM_PMU_Set_EVTYPER(uint32_t num, uint32_t type)
+{
+  PMU->EVTYPER[num] = type;
+}
+
+/**
+  \brief  Reset cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CYCCNT_Reset(void)
+{
+  PMU->CTRL |= PMU_CTRL_CYCCNT_RESET_Msk;
+}
+
+/**
+  \brief  Reset all event counters
+*/
+__STATIC_INLINE void ARM_PMU_EVCNTR_ALL_Reset(void)
+{
+  PMU->CTRL |= PMU_CTRL_EVENTCNT_RESET_Msk;
+}
+
+/**
+  \brief  Enable counters
+  \param [in]     mask    Counters to enable
+  \note   Enables one or more of the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Enable(uint32_t mask)
+{
+  PMU->CNTENSET = mask;
+}
+
+/**
+  \brief  Disable counters
+  \param [in]     mask    Counters to enable
+  \note   Disables one or more of the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Disable(uint32_t mask)
+{
+  PMU->CNTENCLR = mask;
+}
+
+/**
+  \brief  Read cycle counter
+  \return                 Cycle count
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_CCNTR(void)
+{
+  return PMU->CCNTR;
+}
+
+/**
+  \brief   Read event counter
+  \param [in]     num     Event counter (0-30) to read
+  \return                 Event count
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_EVCNTR(uint32_t num)
+{
+  return PMU_EVCNTR_CNT_Msk & PMU->EVCNTR[num];
+}
+
+/**
+  \brief   Read counter overflow status
+  \return  Counter overflow status bits for the following:
+          - event counters (0-30)
+          - cycle counter
+*/
+__STATIC_INLINE uint32_t ARM_PMU_Get_CNTR_OVS(void)
+{
+  return PMU->OVSSET;
+}
+
+/**
+  \brief   Clear counter overflow status
+  \param [in]     mask    Counter overflow status bits to clear
+  \note    Clears overflow status bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_OVS(uint32_t mask)
+{
+  PMU->OVSCLR = mask;
+}
+
+/**
+  \brief   Enable counter overflow interrupt request
+  \param [in]     mask    Counter overflow interrupt request bits to set
+  \note    Sets overflow interrupt request bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Enable(uint32_t mask)
+{
+  PMU->INTENSET = mask;
+}
+
+/**
+  \brief   Disable counter overflow interrupt request
+  \param [in]     mask    Counter overflow interrupt request bits to clear
+  \note    Clears overflow interrupt request bits for one or more of the following:
+           - event counters (0-30)
+           - cycle counter
+*/
+__STATIC_INLINE void ARM_PMU_Set_CNTR_IRQ_Disable(uint32_t mask)
+{
+  PMU->INTENCLR = mask;
+}
+
+/**
+  \brief   Software increment event counter
+  \param [in]     mask    Counters to increment
+  \note    Software increment bits for one or more event counters (0-30)
+*/
+__STATIC_INLINE void ARM_PMU_CNTR_Increment(uint32_t mask)
+{
+  PMU->SWINC = mask;
+}
+
+#endif

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/cmsis_gcc_m.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/m-profile/cmsis_gcc_m.h
@@ -1,0 +1,1674 @@
+/*
+ * Copyright (c) 2009-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * CMSIS-Core(M) Compiler GCC Header File
+ */
+
+#ifndef __CMSIS_GCC_M_H
+#define __CMSIS_GCC_M_H
+
+/* ignore some GCC warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include <arm_acle.h>
+
+/* Fallback for __has_builtin */
+#ifndef __has_builtin
+  #define __has_builtin(x) (0)
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE                   __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+#ifndef   __COMPILER_BARRIER
+  #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
+#endif
+#ifndef __NO_INIT
+  #define __NO_INIT                              __attribute__ ((section (".noinit")))
+#endif
+#ifndef __ALIAS
+  #define __ALIAS(x)                             __attribute__ ((alias(x)))
+#endif
+
+/* #########################  Startup and Lowlevel Init  ######################## */
+#ifndef __PROGRAM_START
+
+/**
+  \brief   Initializes data and bss sections
+  \details This default implementations initialized all data and additional bss
+           sections relying on .copy.table and .zero.table specified properly
+           in the used linker script.
+
+ */
+__STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
+{
+  extern void _start(void) __NO_RETURN;
+
+  typedef struct __copy_table {
+    uint32_t const* src;
+    uint32_t* dest;
+    uint32_t  wlen;
+  } __copy_table_t;
+
+  typedef struct __zero_table {
+    uint32_t* dest;
+    uint32_t  wlen;
+  } __zero_table_t;
+
+  extern const __copy_table_t __copy_table_start__;
+  extern const __copy_table_t __copy_table_end__;
+  extern const __zero_table_t __zero_table_start__;
+  extern const __zero_table_t __zero_table_end__;
+
+  for (__copy_table_t const* pTable = &__copy_table_start__; pTable < &__copy_table_end__; ++pTable) {
+    for(uint32_t i=0u; i<pTable->wlen; ++i) {
+      pTable->dest[i] = pTable->src[i];
+    }
+  }
+
+  for (__zero_table_t const* pTable = &__zero_table_start__; pTable < &__zero_table_end__; ++pTable) {
+    for(uint32_t i=0u; i<pTable->wlen; ++i) {
+      pTable->dest[i] = 0u;
+    }
+  }
+
+  _start();
+}
+
+#define __PROGRAM_START           __cmsis_start
+#endif
+
+#ifndef __INITIAL_SP
+#define __INITIAL_SP              __StackTop
+#endif
+
+#ifndef __STACK_LIMIT
+#define __STACK_LIMIT             __StackLimit
+#endif
+
+#ifndef __VECTOR_TABLE
+#define __VECTOR_TABLE            __Vectors
+#endif
+
+#ifndef __VECTOR_TABLE_ATTRIBUTE
+#define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".vectors")))
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+#ifndef __STACK_SEAL
+#define __STACK_SEAL              __StackSeal
+#endif
+
+#ifndef __TZ_STACK_SEAL_SIZE
+#define __TZ_STACK_SEAL_SIZE      8U
+#endif
+
+#ifndef __TZ_STACK_SEAL_VALUE
+#define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
+#endif
+
+
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+  *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
+}
+#endif
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP()         __ASM volatile ("nop")
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI()         __ASM volatile ("wfi":::"memory")
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE()         __ASM volatile ("wfe":::"memory")
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV()         __ASM volatile ("sev")
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+__STATIC_FORCEINLINE void __ISB(void)
+{
+  __ASM volatile ("isb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+__STATIC_FORCEINLINE void __DSB(void)
+{
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+__STATIC_FORCEINLINE void __DMB(void)
+{
+  __ASM volatile ("dmb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in unsigned integer value. For example, 0x12345678 becomes 0x78563412.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV(uint32_t value)
+{
+  return __builtin_bswap32(value);
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order within each halfword of a word. For example, 0x12345678 becomes 0x34127856.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return (result);
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in a 16-bit value and returns the signed 16-bit result. For example, 0x0080 becomes 0x8000.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE int16_t __REVSH(int16_t value)
+{
+  return (int16_t)__builtin_bswap16(value);
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  op2 %= 32U;
+  if (op2 == 0U)
+  {
+    return op1;
+  }
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value) __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__STATIC_FORCEINLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+   __ASM ("rbit %0, %1" : "=r" (result) : "r" (value) );
+#else
+  uint32_t s = (4U /*sizeof(v)*/ * 8U) - 1U; /* extra shift needed at end */
+
+  result = value;                      /* r will be reversed bits of v; first get LSB of v */
+  for (value >>= 1U; value != 0U; value >>= 1U)
+  {
+    result <<= 1U;
+    result |= value & 1U;
+    s--;
+  }
+  result <<= s;                        /* shift when v's highest bits are zero */
+#endif
+  return (result);
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+__STATIC_FORCEINLINE uint8_t __CLZ(uint32_t value)
+{
+  /* Even though __builtin_clz produces a CLZ instruction on ARM, formally
+     __builtin_clz(0) is undefined behaviour, so handle this case specially.
+     This guarantees ARM-compatible results if happening to compile on a non-ARM
+     target, and ensures the compiler doesn't decide to activate any
+     optimisations using the logic "value was passed to __builtin_clz, so it
+     is non-zero".
+     ARM GCC 7.3 and possibly earlier will optimise this test away, leaving a
+     single CLZ instruction.
+   */
+  if (value == 0U)
+  {
+    return 32U;
+  }
+  return __builtin_clz(value);
+}
+
+
+#if (__ARM_FEATURE_SAT    >= 1)
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(value, sat) __ssat(value, sat)
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(value, sat) __usat(value, sat)
+
+#else /* (__ARM_FEATURE_SAT >= 1) */
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE int32_t __SSAT(int32_t val, uint32_t sat)
+{
+  if ((sat >= 1U) && (sat <= 32U))
+  {
+    const int32_t max = (int32_t)((1U << (sat - 1U)) - 1U);
+    const int32_t min = -1 - max ;
+    if (val > max)
+    {
+      return (max);
+    }
+    else if (val < min)
+    {
+      return (min);
+    }
+  }
+  return (val);
+}
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+__STATIC_FORCEINLINE uint32_t __USAT(int32_t val, uint32_t sat)
+{
+  if (sat <= 31U)
+  {
+    const uint32_t max = ((1U << sat) - 1U);
+    if (val > (int32_t)max)
+    {
+      return (max);
+    }
+    else if (val < 0)
+    {
+      return (0U);
+    }
+  }
+  return ((uint32_t)val);
+}
+#endif /* (__ARM_FEATURE_SAT >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 1)
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+__STATIC_FORCEINLINE void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDREXB(volatile uint8_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+  return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 1) */
+
+
+#if (__ARM_FEATURE_LDREX >= 2)
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDREXH(volatile uint16_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 2) */
+
+
+#if (__ARM_FEATURE_LDREX >= 4)
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDREXW(volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+  return (result);
+}
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+  return (result);
+}
+#endif /* (__ARM_FEATURE_LDREX >= 4) */
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__STATIC_FORCEINLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : "=r" (result) : "r" (value));
+  return (result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return (result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__STATIC_FORCEINLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint8_t __LDAEXB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaexb %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint8_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint16_t __LDAEXH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaexh %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return ((uint16_t)result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__STATIC_FORCEINLINE uint32_t __LDAEX(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldaex %0, %1" : "=r" (result) : "Q" (*ptr) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEXB(uint8_t value, volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlexb %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEXH(uint16_t value, volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlexh %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__STATIC_FORCEINLINE uint32_t __STLEX(uint32_t value, volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("stlex %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) : "memory" );
+  return (result);
+}
+
+#endif /* (__ARM_ARCH >= 8) */
+
+/** @}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting special-purpose register PRIMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+  __ISB();
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSP(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_SP_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return (result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_FORCEINLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if (__ARM_ARCH_ISA_THUMB >= 2)
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting special-purpose register FAULTMASK.
+           Can only be executed in Privileged modes.
+ */
+__STATIC_FORCEINLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_FORCEINLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return (result);
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return (result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
+
+
+#if (__ARM_ARCH >= 8)
+/**
+  \brief   Get Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always in non-secure
+  mode.
+
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return (result);
+#endif
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored in non-secure
+  mode.
+
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure PSPLIM is RAZ/WI */
+  (void)ProcStackPtrLimit;
+#else
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+#endif
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+  return (result);
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence zero is returned always.
+
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  return (0U);
+#else
+  uint32_t result;
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return (result);
+#endif
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
+  Stack Pointer Limit register hence the write is silently ignored.
+
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+  /* without main extensions, the non-secure MSPLIM is RAZ/WI */
+  (void)MainStackPtrLimit;
+#else
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+#endif
+}
+#endif
+
+#endif /* (__ARM_ARCH >= 8) */
+
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
+{
+#if (__ARM_FP >= 1)
+  return (__builtin_arm_get_fpscr());
+#else
+  return (0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if (__ARM_FP >= 1)
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+
+/** @} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)
+#define     __SADD8                 __sadd8
+#define     __QADD8                 __qadd8
+#define     __SHADD8                __shadd8
+#define     __UADD8                 __uadd8
+#define     __UQADD8                __uqadd8
+#define     __UHADD8                __uhadd8
+#define     __SSUB8                 __ssub8
+#define     __QSUB8                 __qsub8
+#define     __SHSUB8                __shsub8
+#define     __USUB8                 __usub8
+#define     __UQSUB8                __uqsub8
+#define     __UHSUB8                __uhsub8
+#define     __SADD16                __sadd16
+#define     __QADD16                __qadd16
+#define     __SHADD16               __shadd16
+#define     __UADD16                __uadd16
+#define     __UQADD16               __uqadd16
+#define     __UHADD16               __uhadd16
+#define     __SSUB16                __ssub16
+#define     __QSUB16                __qsub16
+#define     __SHSUB16               __shsub16
+#define     __USUB16                __usub16
+#define     __UQSUB16               __uqsub16
+#define     __UHSUB16               __uhsub16
+#define     __SASX                  __sasx
+#define     __QASX                  __qasx
+#define     __SHASX                 __shasx
+#define     __UASX                  __uasx
+#define     __UQASX                 __uqasx
+#define     __UHASX                 __uhasx
+#define     __SSAX                  __ssax
+#define     __QSAX                  __qsax
+#define     __SHSAX                 __shsax
+#define     __USAX                  __usax
+#define     __UQSAX                 __uqsax
+#define     __UHSAX                 __uhsax
+#define     __USAD8                 __usad8
+#define     __USADA8                __usada8
+#define     __SSAT16                __ssat16
+#define     __USAT16                __usat16
+#define     __UXTB16                __uxtb16
+#define     __UXTAB16               __uxtab16
+#define     __SXTB16                __sxtb16
+#define     __SXTAB16               __sxtab16
+#define     __SMUAD                 __smuad
+#define     __SMUADX                __smuadx
+#define     __SMLAD                 __smlad
+#define     __SMLADX                __smladx
+#define     __SMLALD                __smlald
+#define     __SMLALDX               __smlaldx
+#define     __SMUSD                 __smusd
+#define     __SMUSDX                __smusdx
+#define     __SMLSD                 __smlsd
+#define     __SMLSDX                __smlsdx
+#define     __SMLSLD                __smlsld
+#define     __SMLSLDX               __smlsldx
+#define     __SEL                   __sel
+#define     __QADD                  __qadd
+#define     __QSUB                  __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+__extension__ \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+__STATIC_FORCEINLINE uint32_t __SXTB16_RORn(uint32_t op1, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtb16 %0, %1, ROR %2" : "=r"(result) : "r"(op1), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTB16(__ROR(op1, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE uint32_t __SXTAB16_RORn(uint32_t op1, uint32_t op2, uint32_t rotate)
+{
+    uint32_t result;
+    if (__builtin_constant_p(rotate) && ((rotate == 8U) || (rotate == 16U) || (rotate == 24U)))
+    {
+        __ASM volatile("sxtab16 %0, %1, %2, ROR %3" : "=r"(result) : "r"(op1), "r"(op2), "i"(rotate));
+    }
+    else
+    {
+        result = __SXTAB16(op1, __ROR(op2, rotate));
+    }
+    return result;
+}
+
+__STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return (result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/** @} end of group CMSIS_SIMD_intrinsics */
+
+
+#pragma GCC diagnostic pop
+
+#endif /* __CMSIS_GCC_M_H */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_base_address.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_base_address.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2019-2023 Arm Limited
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file platform_base_address.h
+ * \brief This file defines all the peripheral base addresses for Corstone-310.
+ */
+
+#ifndef __PLATFORM_BASE_ADDRESS_H__
+#define __PLATFORM_BASE_ADDRESS_H__
+
+/* ======= Defines peripherals memory map addresses ======= */
+/* Non-secure memory map addresses */
+#define ITCM_BASE_NS                     0x00000000 /* Instruction TCM Non-Secure base address */
+#define SRAM_BASE_NS                     0x01000000 /* CODE SRAM Non-Secure base address */
+#define DTCM0_BASE_NS                    0x20000000 /* Data TCM block 0 Non-Secure base address */
+#define DTCM1_BASE_NS                    0x20002000 /* Data TCM block 1 Non-Secure base address */
+#define DTCM2_BASE_NS                    0x20004000 /* Data TCM block 2 Non-Secure base address */
+#define DTCM3_BASE_NS                    0x20006000 /* Data TCM block 3 Non-Secure base address */
+#define ISRAM0_BASE_NS                   0x21000000 /* Internal SRAM Area Non-Secure base address */
+#define ISRAM1_BASE_NS                   0x21200000 /* Internal SRAM Area Non-Secure base address */
+#define QSPI_SRAM_BASE_NS                0x28000000 /* QSPI SRAM Non-Secure base address */
+/* Non-Secure Subsystem peripheral region */
+#ifdef CORSTONE310_FVP
+#define DMA_350_BASE_NS                  0x40002000 /* DMA350 register block Non-Secure base address */
+#endif
+#define NPU0_APB_BASE_NS                 0x40004000 /* NPU0 APB Non-Secure base address */
+#define CPU0_PWRCTRL_BASE_NS             0x40012000 /* CPU 0 Power Control Block Non-Secure base address */
+#define CPU0_IDENTITY_BASE_NS            0x4001F000 /* CPU 0 Identity Block Non-Secure base address */
+#define CORSTONE310_NSACFG_BASE_NS       0x40080000 /* Corstone-310 Non-Secure Access Configuration Register Block Non-Secure base address */
+/* Non-Secure MSTEXPPILL Peripheral region */
+#define GPIO0_CMSDK_BASE_NS              0x41100000 /* GPIO 0 Non-Secure base address */
+#define GPIO1_CMSDK_BASE_NS              0x41101000 /* GPIO 1 Non-Secure base address */
+#define GPIO2_CMSDK_BASE_NS              0x41102000 /* GPIO 2 Non-Secure base address */
+#define GPIO3_CMSDK_BASE_NS              0x41103000 /* GPIO 3 Non-Secure base address */
+#define AHB_USER_0_BASE_NS               0x41104000 /* AHB USER 0 Non-Secure base address */
+#define AHB_USER_1_BASE_NS               0x41105000 /* AHB USER 1 Non-Secure base address */
+#define AHB_USER_2_BASE_NS               0x41106000 /* AHB USER 2 Non-Secure base address */
+#define AHB_USER_3_BASE_NS               0x41107000 /* AHB USER 3 Non-Secure base address */
+#ifdef CORSTONE310_AN555
+#define DMA_0_BASE_NS                    0x41200000 /* DMA0 Non-Secure base address */
+#define DMA_1_BASE_NS                    0x41201000 /* DMA1 Non-Secure base address */
+#define DMA_2_BASE_NS                    0x41202000 /* DMA2 Non-Secure base address */
+#define DMA_3_BASE_NS                    0x41203000 /* DMA3 Non-Secure base address */
+#endif
+#define ETHERNET_BASE_NS                 0x41400000 /* Ethernet Non-Secure base address */
+#define USB_BASE_NS                      0x41500000 /* USB Non-Secure base address */
+#define USER_APB0_BASE_NS                0x41700000 /* User APB 0 Non-Secure base address */
+#define USER_APB1_BASE_NS                0x41701000 /* User APB 1 Non-Secure base address */
+#define USER_APB2_BASE_NS                0x41702000 /* User APB 2 Non-Secure base address */
+#define USER_APB3_BASE_NS                0x41703000 /* User APB 3 Non-Secure base address */
+#define QSPI_CONFIG_BASE_NS              0x41800000 /* QSPI Config Non-Secure base address */
+#define QSPI_WRITE_BASE_NS               0x41801000 /* QSPI Write Non-Secure base address */
+/* Non-Secure Subsystem peripheral region */
+#define SYSTIMER0_ARMV8_M_BASE_NS        0x48000000 /* System Timer 0 Non-Secure base address */
+#define SYSTIMER1_ARMV8_M_BASE_NS        0x48001000 /* System Timer 1 Non-Secure base address */
+#define SYSTIMER2_ARMV8_M_BASE_NS        0x48002000 /* System Timer 2 Non-Secure base address */
+#define SYSTIMER3_ARMV8_M_BASE_NS        0x48003000 /* System Timer 3 Non-Secure base address */
+#define CORSTONE310_SYSINFO_BASE_NS      0x48020000 /* Corstone-310 System info Block Non-Secure base address */
+#define SLOWCLK_TIMER_CMSDK_BASE_NS      0x4802F000 /* CMSDK based SLOWCLK Timer Non-Secure base address */
+#define SYSWDOG_ARMV8_M_CNTRL_BASE_NS    0x48040000 /* Non-Secure Watchdog Timer control frame Non-Secure base address */
+#define SYSWDOG_ARMV8_M_REFRESH_BASE_NS  0x48041000 /* Non-Secure Watchdog Timer refresh frame Non-Secure base address */
+#define SYSCNTR_READ_BASE_NS             0x48101000 /* System Counter Read Secure base address */
+/* Non-Secure MSTEXPPIHL Peripheral region */
+#define FPGA_SBCon_I2C_TOUCH_BASE_NS     0x49200000 /* FPGA - SBCon I2C (Touch) Non-Secure base address */
+#define FPGA_SBCon_I2C_AUDIO_BASE_NS     0x49201000 /* FPGA - SBCon I2C (Audio Conf) Non-Secure base address */
+#define FPGA_SPI_ADC_BASE_NS             0x49202000 /* FPGA - PL022 (SPI ADC) Non-Secure base address */
+#define FPGA_SPI_SHIELD0_BASE_NS         0x49203000 /* FPGA - PL022 (SPI Shield0) Non-Secure base address */
+#define FPGA_SPI_SHIELD1_BASE_NS         0x49204000 /* FPGA - PL022 (SPI Shield1) Non-Secure base address */
+#define SBCon_I2C_SHIELD0_BASE_NS        0x49205000 /* SBCon (I2C - Shield0) Non-Secure base address */
+#define SBCon_I2C_SHIELD1_BASE_NS        0x49206000 /* SBCon (I2C – Shield1) Non-Secure base address */
+#define USER_APB_BASE_NS                 0x49207000 /* USER APB Non-Secure base address */
+#define FPGA_DDR4_EEPROM_BASE_NS         0x49208000 /* FPGA - SBCon I2C (DDR4 EEPROM) Non-Secure base address */
+#define FPGA_SCC_BASE_NS                 0x49300000 /* FPGA - SCC registers Non-Secure base address */
+#define FPGA_I2S_BASE_NS                 0x49301000 /* FPGA - I2S (Audio) Non-Secure base address */
+#define FPGA_IO_BASE_NS                  0x49302000 /* FPGA - IO (System Ctrl + I/O) Non-Secure base address */
+#define UART0_BASE_NS                    0x49303000 /* UART 0 Non-Secure base address */
+#define UART1_BASE_NS                    0x49304000 /* UART 1 Non-Secure base address */
+#define UART2_BASE_NS                    0x49305000 /* UART 2 Non-Secure base address */
+#define UART3_BASE_NS                    0x49306000 /* UART 3 Non-Secure base address */
+#define UART4_BASE_NS                    0x49307000 /* UART 4 Non-Secure base address */
+#define UART5_BASE_NS                    0x49308000 /* UART 5 Non-Secure base address */
+#define CLCD_Config_Reg_BASE_NS          0x4930A000 /* CLCD Config Reg Non-Secure base address */
+#define RTC_BASE_NS                      0x4930B000 /* RTC Non-Secure base address */
+
+#ifdef CORSTONE310_FVP
+#define VSOCKET_BASE_NS                  0x4FEE0000 /*!< VSOCKET Non-Secure base address */
+#define VIO_BASE_NS                      0x4FEF0000 /*!< VIO Non-Secure base address */
+#define VSI0_BASE_NS                     0x4FF00000 /*!< VSI 0 Non-Secure base address */
+#define VSI1_BASE_NS                     0x4FF10000 /*!< VSI 1 Non-Secure base address */
+#define VSI2_BASE_NS                     0x4FF20000 /*!< VSI 2 Non-Secure base address */
+#define VSI3_BASE_NS                     0x4FF30000 /*!< VSI 3 Non-Secure base address */
+#define VSI4_BASE_NS                     0x4FF40000 /*!< VSI 4 Non-Secure base address */
+#define VSI5_BASE_NS                     0x4FF50000 /*!< VSI 5 Non-Secure base address */
+#define VSI6_BASE_NS                     0x4FF60000 /*!< VSI 6 Non-Secure base address */
+#define VSI7_BASE_NS                     0x4FF70000 /*!< VSI 7 Non-Secure base address */
+#endif
+
+#define DDR4_BLK0_BASE_NS                0x60000000 /* DDR4 block 0 Non-Secure base address */
+#define DDR4_BLK2_BASE_NS                0x80000000 /* DDR4 block 2 Non-Secure base address */
+#define DDR4_BLK4_BASE_NS                0xA0000000 /* DDR4 block 4 Non-Secure base address */
+#define DDR4_BLK6_BASE_NS                0xC0000000 /* DDR4 block 6 Non-Secure base address */
+
+/* Secure memory map addresses */
+#define ITCM_BASE_S                      0x10000000 /* Instruction TCM Secure base address */
+#define SRAM_BASE_S                      0x11000000 /* CODE SRAM Secure base address */
+#define DTCM0_BASE_S                     0x30000000 /* Data TCM block 0 Secure base address */
+#define DTCM1_BASE_S                     0x30002000 /* Data TCM block 1 Secure base address */
+#define DTCM2_BASE_S                     0x30004000 /* Data TCM block 2 Secure base address */
+#define DTCM3_BASE_S                     0x30006000 /* Data TCM block 3 Secure base address */
+#define ISRAM0_BASE_S                    0x31000000 /* Internal SRAM Area Secure base address */
+#define ISRAM1_BASE_S                    0x31200000 /* Internal SRAM Area Secure base address */
+#define QSPI_SRAM_BASE_S                 0x38000000 /* QSPI SRAM Secure base address */
+/* Secure Subsystem peripheral region */
+#ifdef CORSTONE310_FVP
+#define DMA_350_BASE_S                   0x50002000 /* DMA350 register block Secure base address */
+#endif
+#define NPU0_APB_BASE_S                  0x50004000 /* NPU0 APB Secure base address */
+#define CPU0_SECCTRL_BASE_S              0x50011000 /* CPU 0 Local Security Control Block Secure base address */
+#define CPU0_PWRCTRL_BASE_S              0x50012000 /* CPU 0 Power Control Block Secure base address */
+#define CPU0_IDENTITY_BASE_S             0x5001F000 /* CPU 0 Identity Block Secure base address */
+#define CORSTONE310_SACFG_BASE_S         0x50080000 /* Corstone-310 Secure Access Configuration Register Secure base address */
+#define MPC_ISRAM0_BASE_S                0x50083000 /* Internal SRAM0 Memory Protection Controller Secure base address */
+#define MPC_ISRAM1_BASE_S                0x50084000 /* Internal SRAM1 Memory Protection Controller Secure base address */
+/* Secure MSTEXPPILL Peripheral region */
+#define GPIO0_CMSDK_BASE_S               0x51100000 /* GPIO 0 Secure base address */
+#define GPIO1_CMSDK_BASE_S               0x51101000 /* GPIO 1 Secure base address */
+#define GPIO2_CMSDK_BASE_S               0x51102000 /* GPIO 2 Secure base address */
+#define GPIO3_CMSDK_BASE_S               0x51103000 /* GPIO 3 Secure base address */
+#define AHB_USER_0_BASE_S                0x51104000 /* AHB USER 0 Secure base address */
+#define AHB_USER_1_BASE_S                0x51105000 /* AHB USER 1 Secure base address */
+#define AHB_USER_2_BASE_S                0x51106000 /* AHB USER 2 Secure base address */
+#define AHB_USER_3_BASE_S                0x51107000 /* AHB USER 3 Secure base address */
+#ifdef CORSTONE310_AN555
+#define DMA_0_BASE_S                     0x51200000  /* DMA0 Secure base address */
+#define DMA_1_BASE_S                     0x51201000  /* DMA1 Secure base address */
+#define DMA_2_BASE_S                     0x51202000  /* DMA2 Secure base address */
+#define DMA_3_BASE_S                     0x51203000  /* DMA3 Secure base address */
+#endif
+#define ETHERNET_BASE_S                  0x51400000 /* Ethernet Secure base address */
+#define USB_BASE_S                       0x51500000 /* USB Secure base address */
+#define USER_APB0_BASE_S                 0x51700000 /* User APB 0 Secure base address */
+#define USER_APB1_BASE_S                 0x51701000 /* User APB 1 Secure base address */
+#define USER_APB2_BASE_S                 0x51702000 /* User APB 2 Secure base address */
+#define USER_APB3_BASE_S                 0x51703000 /* User APB 3 Secure base address */
+#define QSPI_CONFIG_BASE_S               0x51800000 /* QSPI Config Secure base address */
+#define QSPI_WRITE_BASE_S                0x51801000 /* QSPI Write Secure base address */
+#define MPC_SRAM_BASE_S                  0x57000000 /* SRAM Memory Protection Controller Secure base address */
+#define MPC_QSPI_BASE_S                  0x57001000 /* QSPI Memory Protection Controller Secure base address */
+#define MPC_DDR4_BASE_S                  0x57002000 /* DDR4 Memory Protection Controller Secure base address */
+/* Secure Subsystem peripheral region */
+#define SYSTIMER0_ARMV8_M_BASE_S         0x58000000 /* System Timer 0 Secure base address */
+#define SYSTIMER1_ARMV8_M_BASE_S         0x58001000 /* System Timer 1 Secure base address */
+#define SYSTIMER2_ARMV8_M_BASE_S         0x58002000 /* System Timer 0 Secure base address */
+#define SYSTIMER3_ARMV8_M_BASE_S         0x58003000 /* System Timer 1 Secure base address */
+#define CORSTONE310_SYSINFO_BASE_S       0x58020000 /* Corstone-310 System info Block Secure base address */
+#define CORSTONE310_SYSCTRL_BASE_S       0x58021000 /* Corstone-310 System control Block Secure base address */
+#define CORSTONE310_SYSPPU_BASE_S        0x58022000 /* Corstone-310 System Power Policy Unit Secure base address */
+#define CORSTONE310_CPU0PPU_BASE_S       0x58023000 /* Corstone-310 CPU 0 Power Policy Unit Secure base address */
+#define CORSTONE310_MGMTPPU_BASE_S       0x58028000 /* Corstone-310 Management Power Policy Unit Secure base address */
+#define CORSTONE310_DBGPPU_BASE_S        0x58029000 /* Corstone-310 Debug Power Policy Unit Secure base address */
+#define CORSTONE310_NPU0PPU_BASE_S       0x5802A000 /* Corstone-310 NPU 0 Power Policy Unit Secure base address */
+#define SLOWCLK_WDOG_CMSDK_BASE_S        0x5802E000 /* CMSDK based SLOWCLK Watchdog Secure base address */
+#define SLOWCLK_TIMER_CMSDK_BASE_S       0x5802F000 /* CMSDK based SLOWCLK Timer Secure base address */
+#define SYSWDOG_ARMV8_M_CNTRL_BASE_S     0x58040000 /* Secure Watchdog Timer control frame Secure base address */
+#define SYSWDOG_ARMV8_M_REFRESH_BASE_S   0x58041000 /* Secure Watchdog Timer refresh frame Secure base address */
+#define SYSCNTR_CNTRL_BASE_S             0x58100000 /* System Counter Control Secure base address */
+#define SYSCNTR_READ_BASE_S              0x58101000 /* System Counter Read Secure base address */
+/* Secure MSTEXPPIHL Peripheral region */
+#define FPGA_SBCon_I2C_TOUCH_BASE_S      0x59200000 /* FPGA - SBCon I2C (Touch) Secure base address */
+#define FPGA_SBCon_I2C_AUDIO_BASE_S      0x59201000 /* FPGA - SBCon I2C (Audio Conf) Secure base address */
+#define FPGA_SPI_ADC_BASE_S              0x59202000 /* FPGA - PL022 (SPI ADC) Secure base address */
+#define FPGA_SPI_SHIELD0_BASE_S          0x59203000 /* FPGA - PL022 (SPI Shield0) Secure base address */
+#define FPGA_SPI_SHIELD1_BASE_S          0x59204000 /* FPGA - PL022 (SPI Shield1) Secure base address */
+#define SBCon_I2C_SHIELD0_BASE_S         0x59205000 /* SBCon (I2C - Shield0) Secure base address */
+#define SBCon_I2C_SHIELD1_BASE_S         0x59206000 /* SBCon (I2C – Shield1) Secure base address */
+#define USER_APB_BASE_S                  0x59207000 /* USER APB Secure base address */
+#define FPGA_DDR4_EEPROM_BASE_S          0x59208000 /* FPGA - SBCon I2C (DDR4 EEPROM) Secure base address */
+#define FPGA_SCC_BASE_S                  0x59300000 /* FPGA - SCC registers Secure base address */
+#define FPGA_I2S_BASE_S                  0x59301000 /* FPGA - I2S (Audio) Secure base address */
+#define FPGA_IO_BASE_S                   0x59302000 /* FPGA - IO (System Ctrl + I/O) Secure base address */
+#define UART0_BASE_S                     0x59303000 /* UART 0 Secure base address */
+#define UART1_BASE_S                     0x59304000 /* UART 1 Secure base address */
+#define UART2_BASE_S                     0x59305000 /* UART 2 Secure base address */
+#define UART3_BASE_S                     0x59306000 /* UART 3 Secure base address */
+#define UART4_BASE_S                     0x59307000 /* UART 4 Secure base address */
+#define UART5_BASE_S                     0x59308000 /* UART 5 Secure base address */
+#define CLCD_Config_Reg_BASE_S           0x5930A000 /* CLCD Config Reg Secure base address */
+#define RTC_BASE_S                       0x5930B000 /* RTC Secure base address */
+
+#ifdef CORSTONE310_FVP
+#define VSOCKET_BASE_S                   0x5FEE0000 /*!< VSOCKET Secure base address */
+#define VIO_BASE_S                       0x5FEF0000 /*!< VIO Secure base address */
+#define VSI0_BASE_S                      0x5FF00000 /*!< VSI 0 Secure base address */
+#define VSI1_BASE_S                      0x5FF10000 /*!< VSI 1 Secure base address */
+#define VSI2_BASE_S                      0x5FF20000 /*!< VSI 2 Secure base address */
+#define VSI3_BASE_S                      0x5FF30000 /*!< VSI 3 Secure base address */
+#define VSI4_BASE_S                      0x5FF40000 /*!< VSI 4 Secure base address */
+#define VSI5_BASE_S                      0x5FF50000 /*!< VSI 5 Secure base address */
+#define VSI6_BASE_S                      0x5FF60000 /*!< VSI 6 Secure base address */
+#define VSI7_BASE_S                      0x5FF70000 /*!< VSI 7 Secure base address */
+#endif
+
+#define DDR4_BLK1_BASE_S                 0x70000000 /* DDR4 block 1 Secure base address */
+#define DDR4_BLK3_BASE_S                 0x90000000 /* DDR4 block 3 Secure base address */
+#define DDR4_BLK5_BASE_S                 0xB0000000 /* DDR4 block 5 Secure base address */
+#define DDR4_BLK7_BASE_S                 0xD0000000 /* DDR4 block 7 Secure base address */
+
+/* TCM Security Gate register addresses */
+#define ITGU_CTRL_BASE                   0xE001E500 /* TGU control register for ITCM */
+#define ITGU_CFG_BASE                    0xE001E504 /* TGU configuration register for ITCM */
+#define ITGU_LUTn_BASE                   0xE001E510 /* TGU Look Up Table  register for ITCM */
+#define DTGU_CTRL_BASE                   0xE001E600 /* TGU control register for DTCM */
+#define DTGU_CFG_BASE                    0xE001E604 /* TGU configuration register for DTCM */
+#define DTGU_LUTn_BASE                   0xE001E610 /* TGU Look Up Table  register for DTCM */
+
+/* Memory map addresses exempt from memory attribution by both the SAU and IDAU */
+#define CORSTONE310_EWIC_BASE            0xE0047000 /* External Wakeup Interrupt Controller
+                                                     * Access from Non-secure software is only allowed
+                                                     * if AIRCR.BFHFNMINS is set to 1 */
+
+/* Memory size definitions */
+#define ITCM_SIZE       (0x00008000) /* 32 kB */
+#define DTCM_BLK_SIZE   (0x00002000) /* 8 kB */
+#define DTCM_BLK_NUM    (0x4)        /* Number of DTCM blocks */
+#define SRAM_SIZE       (0x00200000) /* 2 MB */
+#define ISRAM0_SIZE     (0x00200000) /* 2 MB */
+#define ISRAM1_SIZE     (0x00200000) /* 2 MB */
+#define QSPI_SRAM_SIZE  (0x00800000) /* 8 MB */
+#define DDR4_BLK_SIZE   (0x10000000) /* 256 MB */
+#define DDR4_BLK_NUM    (0x8)        /* Number of DDR4 blocks */
+
+/* All VMs use the same MPC block size as defined by VMMPCBLKSIZE. */
+#define SRAM_MPC_BLK_SIZE    (0x4000)     /* 16 kB */
+#define QSPI_MPC_BLK_SIZE    (0x40000)    /* 256 kB */
+#define DDR4_MPC_BLK_SIZE    (0x100000)   /* 1 MB */
+
+/* Defines for Driver MPC's */
+/* SRAM -- 2 MB */
+#define MPC_SRAM_RANGE_BASE_NS   (SRAM_BASE_NS)
+#define MPC_SRAM_RANGE_LIMIT_NS  (SRAM_BASE_NS + SRAM_SIZE-1)
+#define MPC_SRAM_RANGE_OFFSET_NS (0x0)
+#define MPC_SRAM_RANGE_BASE_S    (SRAM_BASE_S)
+#define MPC_SRAM_RANGE_LIMIT_S   (SRAM_BASE_S + SRAM_SIZE-1)
+#define MPC_SRAM_RANGE_OFFSET_S  (0x0)
+
+/* QSPI -- 8 MB */
+#define MPC_QSPI_RANGE_BASE_NS   (QSPI_SRAM_BASE_NS)
+#define MPC_QSPI_RANGE_LIMIT_NS  (QSPI_SRAM_BASE_NS + QSPI_SRAM_SIZE-1)
+#define MPC_QSPI_RANGE_OFFSET_NS (0x0)
+#define MPC_QSPI_RANGE_BASE_S    (QSPI_SRAM_BASE_S)
+#define MPC_QSPI_RANGE_LIMIT_S   (QSPI_SRAM_BASE_S + QSPI_SRAM_SIZE-1)
+#define MPC_QSPI_RANGE_OFFSET_S  (0x0)
+
+/* ISRAM0 -- 2 MB*/
+#define MPC_ISRAM0_RANGE_BASE_NS   (ISRAM0_BASE_NS)
+#define MPC_ISRAM0_RANGE_LIMIT_NS  (ISRAM0_BASE_NS + ISRAM0_SIZE-1)
+#define MPC_ISRAM0_RANGE_OFFSET_NS (0x0)
+#define MPC_ISRAM0_RANGE_BASE_S    (ISRAM0_BASE_S)
+#define MPC_ISRAM0_RANGE_LIMIT_S   (ISRAM0_BASE_S + ISRAM0_SIZE-1)
+#define MPC_ISRAM0_RANGE_OFFSET_S  (0x0)
+
+/* ISRAM1 -- 2 MB */
+#define MPC_ISRAM1_RANGE_BASE_NS   (ISRAM1_BASE_NS)
+#define MPC_ISRAM1_RANGE_LIMIT_NS  (ISRAM1_BASE_NS + ISRAM1_SIZE-1)
+#define MPC_ISRAM1_RANGE_OFFSET_NS (0x0)
+#define MPC_ISRAM1_RANGE_BASE_S    (ISRAM1_BASE_S)
+#define MPC_ISRAM1_RANGE_LIMIT_S   (ISRAM1_BASE_S + ISRAM1_SIZE-1)
+#define MPC_ISRAM1_RANGE_OFFSET_S  (0x0)
+
+/* DDR4 -- 2GB (8 * 256 MB) */
+#define MPC_DDR4_BLK0_RANGE_BASE_NS   (DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK0_RANGE_LIMIT_NS  (DDR4_BLK0_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK0_RANGE_OFFSET_NS (0x0)
+#define MPC_DDR4_BLK1_RANGE_BASE_S    (DDR4_BLK1_BASE_S)
+#define MPC_DDR4_BLK1_RANGE_LIMIT_S   (DDR4_BLK1_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK1_RANGE_OFFSET_S  (DDR4_BLK1_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK2_RANGE_BASE_NS   (DDR4_BLK2_BASE_NS)
+#define MPC_DDR4_BLK2_RANGE_LIMIT_NS  (DDR4_BLK2_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK2_RANGE_OFFSET_NS (DDR4_BLK2_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK3_RANGE_BASE_S    (DDR4_BLK3_BASE_S)
+#define MPC_DDR4_BLK3_RANGE_LIMIT_S   (DDR4_BLK3_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK3_RANGE_OFFSET_S  (DDR4_BLK3_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK4_RANGE_BASE_NS   (DDR4_BLK4_BASE_NS)
+#define MPC_DDR4_BLK4_RANGE_LIMIT_NS  (DDR4_BLK4_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK4_RANGE_OFFSET_NS (DDR4_BLK4_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK5_RANGE_BASE_S    (DDR4_BLK5_BASE_S)
+#define MPC_DDR4_BLK5_RANGE_LIMIT_S   (DDR4_BLK5_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK5_RANGE_OFFSET_S  (DDR4_BLK5_BASE_S - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK6_RANGE_BASE_NS   (DDR4_BLK6_BASE_NS)
+#define MPC_DDR4_BLK6_RANGE_LIMIT_NS  (DDR4_BLK6_BASE_NS + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK6_RANGE_OFFSET_NS (DDR4_BLK6_BASE_NS - DDR4_BLK0_BASE_NS)
+#define MPC_DDR4_BLK7_RANGE_BASE_S    (DDR4_BLK7_BASE_S)
+#define MPC_DDR4_BLK7_RANGE_LIMIT_S   (DDR4_BLK7_BASE_S + ((DDR4_BLK_SIZE)-1))
+#define MPC_DDR4_BLK7_RANGE_OFFSET_S  (DDR4_BLK7_BASE_S - DDR4_BLK0_BASE_NS)
+
+#endif  /* __PLATFORM_BASE_ADDRESS_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_irq.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_irq.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PLATFORM_IRQ_H__
+#define __PLATFORM_IRQ_H__
+
+typedef enum _IRQn_Type {
+    NonMaskableInt_IRQn                = -14,  /* Non Maskable Interrupt */
+    HardFault_IRQn                     = -13,  /* HardFault Interrupt */
+    MemoryManagement_IRQn              = -12,  /* Memory Management Interrupt */
+    BusFault_IRQn                      = -11,  /* Bus Fault Interrupt */
+    UsageFault_IRQn                    = -10,  /* Usage Fault Interrupt */
+    SecureFault_IRQn                   = -9,   /* Secure Fault Interrupt */
+    SVCall_IRQn                        = -5,   /* SV Call Interrupt */
+    DebugMonitor_IRQn                  = -4,   /* Debug Monitor Interrupt */
+    PendSV_IRQn                        = -2,   /* Pend SV Interrupt */
+    SysTick_IRQn                       = -1,   /* System Tick Interrupt */
+    NONSEC_WATCHDOG_RESET_REQ_IRQn     = 0,    /* Non-Secure Watchdog Reset
+                                                * Request Interrupt
+                                                */
+    NONSEC_WATCHDOG_IRQn               = 1,    /* Non-Secure Watchdog Interrupt */
+    SLOWCLK_TIMER_IRQn                 = 2,    /* SLOWCLK Timer Interrupt */
+    TIMER0_IRQn                        = 3,    /* TIMER 0 Interrupt */
+    TIMER1_IRQn                        = 4,    /* TIMER 1 Interrupt */
+    TIMER2_IRQn                        = 5,    /* TIMER 2 Interrupt */
+    /* Reserved                        = 6,       Reserved */
+    /* Reserved                        = 7,       Reserved */
+    /* Reserved                        = 8,       Reserved */
+    MPC_IRQn                           = 9,    /* MPC Combined (Secure) Interrupt */
+    PPC_IRQn                           = 10,   /* PPC Combined (Secure) Interrupt */
+    MSC_IRQn                           = 11,   /* MSC Combined (Secure) Interrput */
+    BRIDGE_ERROR_IRQn                  = 12,   /* Bridge Error Combined
+                                                * (Secure) Interrupt
+                                                */
+    /* Reserved                        = 13,      Reserved */
+    Combined_PPU_IRQn                  = 14,   /* Combined PPU */
+    /* Reserved                        = 15,      Reserved */
+    NPU0_IRQn                          = 16,   /* NPU0 */
+    /* Reserved                        = 17,      Reserved */
+    /* Reserved                        = 18,      Reserved */
+    /* Reserved                        = 19,      Reserved */
+    /* Reserved                        = 20,      Reserved */
+    /* Reserved                        = 21,      Reserved */
+    /* Reserved                        = 22,      Reserved */
+    /* Reserved                        = 23,      Reserved */
+    /* Reserved                        = 24,      Reserved */
+    /* Reserved                        = 25,      Reserved */
+    /* Reserved                        = 26,      Reserved */
+    TIMER3_AON_IRQn                    = 27,   /* TIMER 3 AON Interrupt */
+    CPU0_CTI_0_IRQn                    = 28,   /* CPU0 CTI IRQ 0 */
+    CPU0_CTI_1_IRQn                    = 29,   /* CPU0 CTI IRQ 1 */
+    /* Reserved                        = 30,      Reserved */
+    /* Reserved                        = 31,      Reserved */
+    System_Timestamp_Counter_IRQn      = 32,   /* System timestamp counter Interrupt */
+    UARTRX0_IRQn                       = 33,   /* UART 0 RX Interrupt */
+    UARTTX0_IRQn                       = 34,   /* UART 0 TX Interrupt */
+    UARTRX1_IRQn                       = 35,   /* UART 1 RX Interrupt */
+    UARTTX1_IRQn                       = 36,   /* UART 1 TX Interrupt */
+    UARTRX2_IRQn                       = 37,   /* UART 2 RX Interrupt */
+    UARTTX2_IRQn                       = 38,   /* UART 2 TX Interrupt */
+    UARTRX3_IRQn                       = 39,   /* UART 3 RX Interrupt */
+    UARTTX3_IRQn                       = 40,   /* UART 3 TX Interrupt */
+    UARTRX4_IRQn                       = 41,   /* UART 4 RX Interrupt */
+    UARTTX4_IRQn                       = 42,   /* UART 4 TX Interrupt */
+    UART0_Combined_IRQn                = 43,   /* UART 0 Combined Interrupt */
+    UART1_Combined_IRQn                = 44,   /* UART 1 Combined Interrupt */
+    UART2_Combined_IRQn                = 45,   /* UART 2 Combined Interrupt */
+    UART3_Combined_IRQn                = 46,   /* UART 3 Combined Interrupt */
+    UART4_Combined_IRQn                = 47,   /* UART 4 Combined Interrupt */
+    UARTOVF_IRQn                       = 48,   /* UART 0, 1, 2, 3, 4 & 5 Overflow Interrupt */
+    ETHERNET_IRQn                      = 49,   /* Ethernet Interrupt */
+    I2S_IRQn                           = 50,   /* Audio I2S Interrupt */
+    TOUCH_SCREEN_IRQn                  = 51,   /* Touch Screen Interrupt */
+    USB_IRQn                           = 52,   /* USB Interrupt */
+    SPI_ADC_IRQn                       = 53,   /* SPI ADC Interrupt */
+    SPI_SHIELD0_IRQn                   = 54,   /* SPI (Shield 0) Interrupt */
+    SPI_SHIELD1_IRQn                   = 55,   /* SPI (Shield 1) Interrupt */
+    /* Reserved                        = 56,      Reserved */
+#ifdef CORSTONE310_FVP
+    DMA_CHANNEL_0_IRQn                 = 57,   /* DMA Channel 0 Interrupt */
+    DMA_CHANNEL_1_IRQn                 = 58,   /* DMA Channel 1 Interrupt */
+    /* Reserved                        = 59:68    Reserved */
+#else
+    DMA_CHANNEL_0_Error_IRQn           = 57,   /*  57: DMA Ch0 Error Interrupt */
+    DMA_CHANNEL_0_Terminal_Count_IRQn  = 58,   /*  58: DMA Ch0 Terminal Count Interrupt */
+    DMA_CHANNEL_0_Combined_IRQn        = 59,   /*  59: DMA Ch0 Combined Interrupt */
+    DMA_CHANNEL_1_Error_IRQn           = 60,   /*  60: DMA Ch1 Error Interrupt */
+    DMA_CHANNEL_1_Terminal_Count_IRQn  = 61,   /*  61: DMA Ch1 Terminal Count Interrupt */
+    DMA_CHANNEL_1_Combined_IRQn        = 62,   /*  62: DMA Ch1 Combined Interrupt */
+    DMA_CHANNEL_2_Error_IRQn           = 63,   /*  63: DMA Ch2 Error Interrupt */
+    DMA_CHANNEL_2_Terminal_Count_IRQn  = 64,   /*  64: DMA Ch2 Terminal Count Interrupt */
+    DMA_CHANNEL_2_Combined_IRQn        = 65,   /*  65: DMA Ch2 Combined Interrupt */
+    DMA_CHANNEL_3_Error_IRQn           = 66,   /*  66: DMA Ch3 Error Interrupt */
+    DMA_CHANNEL_3_Terminal_Count_IRQn  = 67,   /*  67: DMA Ch3 Terminal Count Interrupt */
+    DMA_CHANNEL_3_Combined_IRQn        = 68,   /*  68: DMA Ch3 Combined Interrupt */
+#endif
+    GPIO0_Combined_IRQn                = 69,   /* GPIO 0 Combined Interrupt */
+    GPIO1_Combined_IRQn                = 70,   /* GPIO 1 Combined Interrupt */
+    GPIO2_Combined_IRQn                = 71,   /* GPIO 2 Combined Interrupt */
+    GPIO3_Combined_IRQn                = 72,   /* GPIO 3 Combined Interrupt */
+    GPIO0_0_IRQn                       = 73, /* GPIO0 has 16 pins with IRQs */
+    GPIO0_1_IRQn                       = 74,
+    GPIO0_2_IRQn                       = 75,
+    GPIO0_3_IRQn                       = 76,
+    GPIO0_4_IRQn                       = 77,
+    GPIO0_5_IRQn                       = 78,
+    GPIO0_6_IRQn                       = 79,
+    GPIO0_7_IRQn                       = 80,
+    GPIO0_8_IRQn                       = 81,
+    GPIO0_9_IRQn                       = 82,
+    GPIO0_10_IRQn                      = 83,
+    GPIO0_11_IRQn                      = 84,
+    GPIO0_12_IRQn                      = 85,
+    GPIO0_13_IRQn                      = 86,
+    GPIO0_14_IRQn                      = 87,
+    GPIO0_15_IRQn                      = 88,
+    GPIO1_0_IRQn                       = 89,   /* GPIO1 has 16 pins with IRQs */
+    GPIO1_1_IRQn                       = 90,
+    GPIO1_2_IRQn                       = 91,
+    GPIO1_3_IRQn                       = 92,
+    GPIO1_4_IRQn                       = 93,
+    GPIO1_5_IRQn                       = 94,
+    GPIO1_6_IRQn                       = 95,
+    GPIO1_7_IRQn                       = 96,
+    GPIO1_8_IRQn                       = 97,
+    GPIO1_9_IRQn                       = 98,
+    GPIO1_10_IRQn                      = 99,
+    GPIO1_11_IRQn                      = 100,
+    GPIO1_12_IRQn                      = 101,
+    GPIO1_13_IRQn                      = 102,
+    GPIO1_14_IRQn                      = 103,
+    GPIO1_15_IRQn                      = 104,
+    GPIO2_0_IRQn                       = 105,   /* GPIO2 has 16 pins with IRQs */
+    GPIO2_1_IRQn                       = 106,
+    GPIO2_2_IRQn                       = 107,
+    GPIO2_3_IRQn                       = 108,
+    GPIO2_4_IRQn                       = 109,
+    GPIO2_5_IRQn                       = 110,
+    GPIO2_6_IRQn                       = 111,
+    GPIO2_7_IRQn                       = 112,
+    GPIO2_8_IRQn                       = 113,
+    GPIO2_9_IRQn                       = 114,
+    GPIO2_10_IRQn                      = 115,
+    GPIO2_11_IRQn                      = 116,
+    GPIO2_12_IRQn                      = 117,
+    GPIO2_13_IRQn                      = 118,
+    GPIO2_14_IRQn                      = 119,
+    GPIO2_15_IRQn                      = 120,
+    GPIO3_0_IRQn                       = 121,   /* GPIO3 has 4 pins with IRQs */
+    GPIO3_1_IRQn                       = 122,
+    GPIO3_2_IRQn                       = 123,
+    GPIO3_3_IRQn                       = 124,
+    UARTRX5_IRQn                       = 125,   /* UART 5 RX Interrupt */
+    UARTTX5_IRQn                       = 126,   /* UART 5 TX Interrupt */
+    UART5_Combined_IRQn                = 127,   /* UART 5 combined Interrupt */
+    /* Reserved                        = 128:223   Reserved */
+#ifdef CORSTONE310_FVP
+    ARM_VSI0_IRQn                      = 224,    /* VSI 0 Interrupt */
+    ARM_VSI1_IRQn                      = 225,    /* VSI 1 Interrupt */
+    ARM_VSI2_IRQn                      = 226,    /* VSI 2 Interrupt */
+    ARM_VSI3_IRQn                      = 227,    /* VSI 3 Interrupt */
+    ARM_VSI4_IRQn                      = 228,    /* VSI 4 Interrupt */
+    ARM_VSI5_IRQn                      = 229,    /* VSI 5 Interrupt */
+    ARM_VSI6_IRQn                      = 230,    /* VSI 6 Interrupt */
+    ARM_VSI7_IRQn                      = 231,    /* VSI 7 Interrupt */
+#endif
+
+} IRQn_Type;
+
+#endif  /* __PLATFORM_IRQ_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_pins.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_pins.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019-2022 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file platform_pins.h
+ * \brief This file defines all the pins for this platform.
+ */
+
+#ifndef __PLATFORM_PINS_H__
+#define __PLATFORM_PINS_H__
+
+/* AHB GPIO pin names */
+enum arm_gpio_pin_name_t {
+    AHB_GPIO0_0 = 0U,
+    AHB_GPIO0_1 = 1U,
+    AHB_GPIO0_2 = 2U,
+    AHB_GPIO0_3 = 3U,
+    AHB_GPIO0_4 = 4U,
+    AHB_GPIO0_5 = 5U,
+    AHB_GPIO0_6 = 6U,
+    AHB_GPIO0_7 = 7U,
+    AHB_GPIO0_8 = 8U,
+    AHB_GPIO0_9 = 9U,
+    AHB_GPIO0_10 = 10U,
+    AHB_GPIO0_11 = 11U,
+    AHB_GPIO0_12 = 12U,
+    AHB_GPIO0_13 = 13U,
+    AHB_GPIO0_14 = 14U,
+    AHB_GPIO0_15 = 15U,
+    AHB_GPIO1_0 = 0U,
+    AHB_GPIO1_1 = 1U,
+    AHB_GPIO1_2 = 2U,
+    AHB_GPIO1_3 = 3U,
+    AHB_GPIO1_4 = 4U,
+    AHB_GPIO1_5 = 5U,
+    AHB_GPIO1_6 = 6U,
+    AHB_GPIO1_7 = 7U,
+    AHB_GPIO1_8 = 8U,
+    AHB_GPIO1_9 = 9U,
+    AHB_GPIO1_10 = 10U,
+    AHB_GPIO1_11 = 11U,
+    AHB_GPIO1_12 = 12U,
+    AHB_GPIO1_13 = 13U,
+    AHB_GPIO1_14 = 14U,
+    AHB_GPIO1_15 = 15U,
+    AHB_GPIO2_0 = 0U,
+    AHB_GPIO2_1 = 1U,
+    AHB_GPIO2_2 = 2U,
+    AHB_GPIO2_3 = 3U,
+    AHB_GPIO2_4 = 4U,
+    AHB_GPIO2_5 = 5U,
+    AHB_GPIO2_6 = 6U,
+    AHB_GPIO2_7 = 7U,
+    AHB_GPIO2_8 = 8U,
+    AHB_GPIO2_9 = 9U,
+    AHB_GPIO2_10 = 10U,
+    AHB_GPIO2_11 = 11U,
+    AHB_GPIO2_12 = 12U,
+    AHB_GPIO2_13 = 13U,
+    AHB_GPIO2_14 = 14U,
+    AHB_GPIO2_15 = 15U,
+    AHB_GPIO3_0 = 0U,
+    AHB_GPIO3_1 = 1U,
+    AHB_GPIO3_2 = 2U,
+    AHB_GPIO3_3 = 3U,
+    AHB_GPIO3_4 = 4U,
+    AHB_GPIO3_5 = 5U,
+    AHB_GPIO3_6 = 6U,
+    AHB_GPIO3_7 = 7U,
+    AHB_GPIO3_8 = 8U,
+    AHB_GPIO3_9 = 9U,
+    AHB_GPIO3_10 = 10U,
+    AHB_GPIO3_11 = 11U,
+    AHB_GPIO3_12 = 12U,
+    AHB_GPIO3_13 = 13U,
+    AHB_GPIO3_14 = 14U,
+    AHB_GPIO3_15 = 15U,
+};
+
+/* GPIO shield 0 definition */
+#define SH0_UART_RX      AHB_GPIO0_0
+#define SH0_UART_TX      AHB_GPIO0_1
+#define SH0_SPI_SS       AHB_GPIO0_10
+#define SH0_SPI_MOSI     AHB_GPIO0_11
+#define SH0_SPI_MISO     AHB_GPIO0_12
+#define SH0_SPI_SCK      AHB_GPIO0_13
+#define SH0_I2C_SDA      AHB_GPIO0_14
+#define SH0_I2C_SCL      AHB_GPIO0_15
+
+/* GPIO shield 1 definition */
+#define SH1_UART_RX      AHB_GPIO1_0
+#define SH1_UART_TX      AHB_GPIO1_1
+
+#define SH1_SPI_SS       AHB_GPIO1_10
+#define SH1_SPI_MOSI     AHB_GPIO1_11
+#define SH1_SPI_MISO     AHB_GPIO1_12
+#define SH1_SPI_SCK      AHB_GPIO1_13
+#define SH1_I2C_SDA      AHB_GPIO1_14
+#define SH1_I2C_SCL      AHB_GPIO1_15
+
+#endif  /* __PLATFORM_PINS_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_regs.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/platform_regs.h
@@ -1,0 +1,506 @@
+/*
+ * Copyright (c) 2019-2023 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PLATFORM_REGS_H__
+#define __PLATFORM_REGS_H__
+
+#include <stdint.h>
+
+/* Secure Access Configuration Register Block */
+struct corstone310_sacfg_t {
+    volatile uint32_t spcsecctrl;     /* 0x000 (R/W) Secure Privilege Controller
+                                                     Secure Configuration Control
+                                                     register */
+    volatile uint32_t buswait;        /* 0x004 (R/W) Bus Access wait control */
+    volatile uint32_t reserved0[2];
+    volatile uint32_t secrespcfg;     /* 0x010 (R/W) Security Violation Response
+                                       *             Configuration register */
+    volatile uint32_t nsccfg;         /* 0x014 (R/W) Non Secure Callable
+                                       *             Configuration for IDAU */
+    volatile uint32_t reserved1;
+    volatile uint32_t secmpcintstat;  /* 0x01C (R/ ) Secure MPC IRQ Status */
+    volatile uint32_t secppcintstat;  /* 0x020 (R/ ) Secure PPC IRQ Status */
+    volatile uint32_t secppcintclr;   /* 0x024 (R/W) Secure PPC IRQ Clear */
+    volatile uint32_t secppcinten;    /* 0x028 (R/W) Secure PPC IRQ Enable */
+    volatile uint32_t reserved2;
+    volatile uint32_t secmscintstat;  /* 0x030 (R/ ) Secure MSC IRQ Status */
+    volatile uint32_t secmscintclr;   /* 0x034 (R/W) Secure MSC IRQ Clear */
+    volatile uint32_t secmscinten;    /* 0x038 (R/W) Secure MSC IRQ Enable */
+    volatile uint32_t reserved3;
+    volatile uint32_t brgintstat;     /* 0x040 (R/ ) Bridge Buffer Error IRQ
+                                       *             Status */
+    volatile uint32_t brgintclr;      /* 0x044 (R/W) Bridge Buffer Error IRQ
+                                       *             Clear */
+    volatile uint32_t brginten;       /* 0x048 (R/W) Bridge Buffer Error IRQ
+                                       *             Enable */
+    volatile uint32_t reserved4;
+    volatile uint32_t mainnsppc0;     /* 0x050 (R/W) Non-secure Access
+                                       *             Peripheral Protection
+                                       *             Control 0 on the Main
+                                       *             Interconnect */
+    volatile uint32_t reserved5[3];
+    volatile uint32_t mainnsppcexp0;  /* 0x060 (R/W) Expansion 0 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on the
+                                       *             Main Interconnect */
+    volatile uint32_t mainnsppcexp1;  /* 0x064 (R/W) Expansion 1 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on the
+                                       *             Main Interconnect */
+    volatile uint32_t mainnsppcexp2;  /* 0x068 (R/W) Expansion 2 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on the
+                                       *             Main Interconnect */
+    volatile uint32_t mainnsppcexp3;  /* 0x06C (R/W) Expansion 3 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on the
+                                       *             Main Interconnect */
+    volatile uint32_t periphnsppc0;   /* 0x070 (R/W) Non-secure Access
+                                       *             Peripheral Protection
+                                       *             Control 0 on the Peripheral
+                                       *             Interconnect */
+    volatile uint32_t periphnsppc1;   /* 0x074 (R/W) Non-secure Access
+                                       *             Peripheral Protection
+                                       *             Control 1 on the Peripheral
+                                       *             Interconnect */
+    volatile uint32_t reserved6[2];
+    volatile uint32_t periphnsppcexp0;/* 0x080 (R/W) Expansion 0 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on
+                                       *             Peripheral Bus */
+    volatile uint32_t periphnsppcexp1;/* 0x084 (R/W) Expansion 1 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on
+                                       *             Peripheral Bus */
+    volatile uint32_t periphnsppcexp2;/* 0x088 (R/W) Expansion 2 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on
+                                       *             Peripheral Bus */
+    volatile uint32_t periphnsppcexp3;/* 0x08C (R/W) Expansion 3 Non-secure
+                                       *             Access Peripheral
+                                       *             Protection Control on
+                                       *             Peripheral Bus */
+    volatile uint32_t mainspppc0;     /* 0x090 (R/W) Secure Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control 0 on Main
+                                       *             Interconnect */
+    volatile uint32_t reserved7[3];
+    volatile uint32_t mainspppcexp0;  /* 0x0A0 (R/W) Expansion 0 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Main
+                                       *             Interconnect */
+    volatile uint32_t mainspppcexp1;  /* 0x0A4 (R/W) Expansion 1 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Main
+                                       *             Interconnect */
+    volatile uint32_t mainspppcexp2;  /* 0x0A8 (R/W) Expansion 2 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Main
+                                       *             Interconnect */
+    volatile uint32_t mainspppcexp3;  /* 0x0AC (R/W) Expansion 3 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Main
+                                       *             Interconnect */
+    volatile uint32_t periphspppc0;   /* 0x0B0 (R/W) Secure Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control 0 on
+                                       *             Peripheral Interconnect */
+    volatile uint32_t periphspppc1;   /* 0x0B4 (R/W) Secure Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control 1 on
+                                       *             Peripheral Interconnect */
+    volatile uint32_t npuspporpl;     /* 0x0B8 (R/W) Secure Access NPU privilege
+                                       *             level reset state
+                                       *             control */
+    volatile uint32_t reserved8[1];
+    volatile uint32_t periphspppcexp0;/* 0x0C0 (R/W) Expansion 0 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Peripheral
+                                       *             Interconnect */
+    volatile uint32_t periphspppcexp1;/* 0x0C4 (R/W) Expansion 1 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Peripheral
+                                       *             Interconnect */
+    volatile uint32_t periphspppcexp2;/* 0x0C8 (R/W) Expansion 2 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Peripheral
+                                       *             Interconnect */
+    volatile uint32_t periphspppcexp3;/* 0x0CC (R/W) Expansion 3 Secure
+                                       *             Unprivileged Access
+                                       *             Peripheral Protection
+                                       *             Control on Peripheral
+                                       *             Interconnect */
+    volatile uint32_t nsmscexp;       /* 0x0D0 (R/W) Expansion MSC Non-Secure
+                                       *             Configuration */
+    volatile uint32_t reserved9[959];
+    volatile uint32_t pidr4;          /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved10[3];
+    volatile uint32_t pidr0;          /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;          /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;          /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;          /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;          /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;          /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;          /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;          /* 0xFFC (R/ ) Component ID 3 */
+};
+
+/* PPC interrupt position mask */
+#define PERIPH_PPC0_INT_POS_MASK     (1UL << 0)
+#define PERIPH_PPC1_INT_POS_MASK     (1UL << 1)
+#define PERIPH_PPCEXP0_INT_POS_MASK  (1UL << 4)
+#define PERIPH_PPCEXP1_INT_POS_MASK  (1UL << 5)
+#define PERIPH_PPCEXP2_INT_POS_MASK  (1UL << 6)
+#define PERIPH_PPCEXP3_INT_POS_MASK  (1UL << 7)
+#define MAIN_PPC0_INT_POS_MASK       (1UL << 16)
+#define MAIN_PPCEXP0_INT_POS_MASK    (1UL << 20)
+#define MAIN_PPCEXP1_INT_POS_MASK    (1UL << 21)
+#define MAIN_PPCEXP2_INT_POS_MASK    (1UL << 22)
+#define MAIN_PPCEXP3_INT_POS_MASK    (1UL << 23)
+
+/* Non-secure Access Configuration Register Block */
+struct corstone310_nsacfg_t {
+    volatile uint32_t reserved0[36];
+    volatile uint32_t mainnspppc0;     /* 0x090 (R/W) Non-secure Unprivileged
+                                        *             Access Peripheral
+                                        *             Protection Control 0 on
+                                        *             Main Interconnect */
+    volatile uint32_t reserved1[3];
+
+    volatile uint32_t mainnspppcexp0;  /* 0x0A0 (R/W) Expansion 0 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Main
+                                        *             Interconnect */
+    volatile uint32_t mainnspppcexp1;  /* 0x0A4 (R/W) Expansion 1 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Main
+                                        *             Interconnect */
+    volatile uint32_t mainnspppcexp2;  /* 0x0A8 (R/W) Expansion 2 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Main
+                                        *             Interconnect */
+    volatile uint32_t mainnspppcexp3;  /* 0x0AC (R/W) Expansion 3 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Main
+                                        *             Interconnect */
+    volatile uint32_t periphnspppc0;   /* 0x0B0 (R/W) Non-secure Unprivileged
+                                        *             Access Peripheral
+                                        *             Protection Control 0 on
+                                        *             Peripheral Interconnect */
+    volatile uint32_t periphnspppc1;   /* 0x0B4 (R/W) Non-secure Unprivileged
+                                        *             Access Peripheral
+                                        *             Protection Control 1 on
+                                        *             Peripheral Interconnect */
+    volatile uint32_t npuspporpl;      /* 0x0B8 (R/W) Non-Secure Access NPU
+                                        *             privilege level reset
+                                        *             state control */
+    volatile uint32_t reserved2[1];
+    volatile uint32_t periphnspppcexp0;/* 0x0C0 (R/W) Expansion 0 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Peripheral
+                                        *             Interconnect */
+    volatile uint32_t periphnspppcexp1;/* 0x0C4 (R/W) Expansion 1 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Peripheral
+                                        *             Interconnect */
+    volatile uint32_t periphnspppcexp2;/* 0x0C8 (R/W) Expansion 2 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Peripheral
+                                        *             Interconnect */
+    volatile uint32_t periphnspppcexp3;/* 0x0CC (R/W) Expansion 3 Non-secure
+                                        *             Unprivileged Access
+                                        *             Peripheral Protection
+                                        *             Control on Peripheral
+                                        *             Interconnect */
+    volatile uint32_t reserved3[960];
+    volatile uint32_t pidr4;           /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved4[3];
+    volatile uint32_t pidr0;           /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;           /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;           /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;           /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;           /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;           /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;           /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;           /* 0xFFC (R/ ) Component ID 3 */
+};
+
+/* MAIN PPC0 peripherals definition */
+/* End MAIN PPC0 peripherals definition */
+
+/* MAIN PPCEXP0 peripherals definition */
+#define GPIO0_MAIN_PPCEXP0_POS_MASK             (1UL << 0)
+#define GPIO1_MAIN_PPCEXP0_POS_MASK             (1UL << 1)
+#define GPIO2_MAIN_PPCEXP0_POS_MASK             (1UL << 2)
+#define GPIO3_MAIN_PPCEXP0_POS_MASK             (1UL << 3)
+#define USB_AND_ETHERNET_MAIN_PPCEXP0_POS_MASK  (1UL << 8)
+#ifdef CORSTONE310_AN555
+#define ONBOARD_QSPI_CONT_MAIN_PPCEXP0_POS_MASK (1UL << 13)
+#define PMOD0_QSPI_CONT_MAIN_PPCEXP0_POS_MASK   (1UL << 14)
+#define PMOD1_QSPI_CONT_MAIN_PPCEXP0_POS_MASK   (1UL << 15)
+#endif
+/* End MAIN PPCEXP0 peripherals definition */
+
+/* MAIN PPCEXP1 peripherals definition */
+#ifdef CORSTONE310_AN555
+#define DMA0_MAIN_PPCEXP1_POS_MASK (1UL << 0)
+#define DMA1_MAIN_PPCEXP1_POS_MASK (1UL << 1)
+#define DMA2_MAIN_PPCEXP1_POS_MASK (1UL << 2)
+#define DMA3_MAIN_PPCEXP1_POS_MASK (1UL << 3)
+#endif
+/* End MAIN PPCEXP1 peripherals definition */
+
+/* MAIN PPCEXP2 peripherals definition */
+/* End MAIN PPCEXP2 peripherals definition */
+
+/* MAIN PPCEXP3 peripherals definition */
+/* End MAIN PPCEXP3 peripherals definition */
+
+/* PERIPH PPC0 peripherals definition */
+#define SYSTEM_TIMER0_PERIPH_PPC0_POS_MASK         (1UL << 0)
+#define SYSTEM_TIMER1_PERIPH_PPC0_POS_MASK         (1UL << 1)
+#define SYSTEM_TIMER2_PERIPH_PPC0_POS_MASK         (1UL << 2)
+#define SYSTEM_TIMER3_PERIPH_PPC0_POS_MASK         (1UL << 5)
+#define WATCHDOG_PERIPH_PPC0_POS_MASK              (1UL << 6)
+/* There are separate secure and non-secure watchdog peripherals, so this bit
+ * can only be used in the unprivileged access registers. */
+/* End PERIPH PPC0 peripherals definition */
+
+/* PERIPH PPC1 peripherals definition */
+#define SLOWCLK_TIMER_PERIPH_PPC1_POS_MASK         (1UL << 0)
+/* End PERIPH PPC1 peripherals definition */
+
+/* PERIPH PPCEXP0 peripherals definition */
+#ifdef CORSTONE310_AN555
+#define TIMING_ADAPTER_APB0_PERIPH_PPCEXP0_POS_MASK (1UL << 0)
+#define TIMING_ADAPTER_APB1_PERIPH_PPCEXP0_POS_MASK (1UL << 1)
+#define TIMING_ADAPTER_APB2_PERIPH_PPCEXP0_POS_MASK (1UL << 2)
+#endif
+#ifdef CORSTONE310_FVP
+#define TIMING_ADAPTERS_PERIPH_PPCEXP0_POS_MASK     (1UL << 5)
+#endif
+/* End PERIPH PPCEXP0 peripherals definition */
+
+/* PERIPH PPCEXP1 peripherals definition */
+#define FPGA_I2C_TOUCH_PERIPH_PPCEXP1_POS_MASK     (1UL << 0)
+#define FPGA_I2C_AUDIO_PERIPH_PPCEXP1_POS_MASK     (1UL << 1)
+#define FPGA_SPI_ADC_PERIPH_PPCEXP1_POS_MASK       (1UL << 2)
+#define FPGA_SPI_SHIELD0_PERIPH_PPCEXP1_POS_MASK   (1UL << 3)
+#define FPGA_SPI_SHIELD1_PERIPH_PPCEXP1_POS_MASK   (1UL << 4)
+#define SBCon_I2C_SHIELD0_PERIPH_PPCEXP1_POS_MASK  (1UL << 5)
+#define SBCon_I2C_SHIELD1_PERIPH_PPCEXP1_POS_MASK  (1UL << 6)
+#define FPGA_SBCon_I2C_PERIPH_PPCEXP1_POS_MASK     (1UL << 8)
+/* End PERIPH PPCEXP1 peripherals definition */
+
+/* PERIPH PPCEXP2 peripherals definition */
+#define FPGA_SCC_PERIPH_PPCEXP2_POS_MASK           (1UL << 0)
+#define FPGA_I2S_PERIPH_PPCEXP2_POS_MASK           (1UL << 1)
+#define FPGA_IO_PERIPH_PPCEXP2_POS_MASK            (1UL << 2)
+#define UART0_PERIPH_PPCEXP2_POS_MASK              (1UL << 3)
+#define UART1_PERIPH_PPCEXP2_POS_MASK              (1UL << 4)
+#define UART2_PERIPH_PPCEXP2_POS_MASK              (1UL << 5)
+#define UART3_PERIPH_PPCEXP2_POS_MASK              (1UL << 6)
+#define UART4_PERIPH_PPCEXP2_POS_MASK              (1UL << 7)
+#define UART5_PERIPH_PPCEXP2_POS_MASK              (1UL << 8)
+#define CLCD_PERIPH_PPCEXP2_POS_MASK               (1UL << 10)
+#define RTC_PERIPH_PPCEXP2_POS_MASK                (1UL << 11)
+
+#ifdef CORSTONE310_FVP
+#define VSI_PERIPH_PPCEXP2_POS_MASK                (1UL << 12)
+#define VIO_PERIPH_PPCEXP2_POS_MASK                (1UL << 13)
+#define VSOCKET_PERIPH_PPCEXP2_POS_MASK            (1UL << 14)
+#endif
+/* End PERIPH PPCEXP2 peripherals definition */
+
+/* PERIPH PPCEXP3 peripherals definition */
+/* End PERIPH PPCEXP3 peripherals definition */
+
+struct cpu0_pwrctrl_t {
+    volatile uint32_t cpupwrcfg;      /* 0x000 (R/W) CPU 0 Local Power
+                                       *             Configuration */
+    volatile uint32_t reserved0[1011];
+    volatile uint32_t pidr4;          /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved1[3];
+    volatile uint32_t pidr0;          /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;          /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;          /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;          /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;          /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;          /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;          /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;          /* 0xFFC (R/ ) Component ID 3 */
+};
+
+struct cpu0_secctrl_t {
+    volatile uint32_t cpuseccfg;      /* 0x000 (R/W) CPU Local Security
+                                       *             Configuration */
+    volatile uint32_t reserved0[1011];
+    volatile uint32_t pidr4;          /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved1[3];
+    volatile uint32_t pidr0;          /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;          /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;          /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;          /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;          /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;          /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;          /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;          /* 0xFFC (R/ ) Component ID 3 */
+};
+
+struct corstone310_sysinfo_t {
+    volatile uint32_t soc_identity;   /* 0x000 (R/ ) SoC Identity Register */
+    volatile uint32_t sys_config0;    /* 0x004 (R/ ) System Hardware
+                                       *             Configuration 0 */
+    volatile uint32_t sys_config1;    /* 0x008 (R/ ) System Hardware
+                                       *             Configuration 1 */
+    volatile uint32_t reserved0[1006];
+    volatile uint32_t iidr;           /* 0xFC8 (R/ ) Subsystem Implementation
+                                       *             Identity */
+    volatile uint32_t reserved1;
+    volatile uint32_t pidr4;          /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved2[3];
+    volatile uint32_t pidr0;          /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;          /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;          /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;          /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;          /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;          /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;          /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;          /* 0xFFC (R/ ) Component ID 3 */
+};
+
+struct corstone310_sysctrl_t {
+    volatile uint32_t secdbgstat;        /* 0x000 (R/ ) Secure Debug
+                                          *             Configuration Status */
+    volatile uint32_t secdbgset;         /* 0x004 (R/W) Secure Debug
+                                          *             Configuration Set */
+    volatile uint32_t secdbgclr;         /* 0x008 ( /W) Secure Debug
+                                          *             Configuration Clear */
+    volatile uint32_t scsecctrl;         /* 0x00C (R/W) System Control Security
+                                          *             Controls */
+    volatile uint32_t clk_cfg0;          /* 0x010 (R/W) Clock Configuration 0 */
+    volatile uint32_t clk_cfg1;          /* 0x014 (R/W) Clock Configuration 1 */
+    volatile uint32_t clock_force;       /* 0x018 (R/W) Clock Forces */
+    volatile uint32_t reserved0[57];
+    volatile uint32_t reset_syndrome;    /* 0x100 (R/W) Reset syndrome */
+    volatile uint32_t reset_mask;        /* 0x104 (R/W) Reset mask */
+    volatile uint32_t swreset;           /* 0x108 ( /W) Software Reset */
+    volatile uint32_t gretreg;           /* 0x10C (R/W) General Purpose
+                                          *             Retention */
+    volatile uint32_t initsvtor0;        /* 0x110 (R/W) CPU 0 Initial Secure
+                                          *             Reset Vector Register */
+    volatile uint32_t reserved1[3];
+    volatile uint32_t cpuwait;           /* 0x120 (R/W) CPU Boot Wait Control */
+    volatile uint32_t nmi_enable;        /* 0x124 (R/W) Non Maskable Interrupts
+                                          *             Enable */
+    volatile uint32_t reserved2[53];
+    volatile uint32_t pwrctrl;           /* 0x1FC (R/W) Power Configuration and
+                                          *             Control */
+    volatile uint32_t pdcm_pd_sys_sense; /* 0x200 (R/W) PDCM PD_SYS
+                                          *             Sensitivity */
+    volatile uint32_t pdcm_pd_cpu0_sense;/* 0x204 (R/ ) PDCM PD_CPU0
+                                          *             Sensitivity */
+    volatile uint32_t reserved3[3];
+    volatile uint32_t pdcm_pd_vmr0_sense;/* 0x214 (R/W) PDCM PD_VMR0
+                                          *             Sensitivity */
+    volatile uint32_t pdcm_pd_vmr1_sense;/* 0x218 (R/W) PDCM PD_VMR1
+                                          *             Sensitivity */
+    volatile uint32_t reserved4[877];
+    volatile uint32_t pidr4;             /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved5[3];
+    volatile uint32_t pidr0;             /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;             /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;             /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;             /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;             /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;             /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;             /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;             /* 0xFFC (R/ ) Component ID 3 */
+};
+
+struct corstone310_ewic_t {
+    volatile uint32_t ewic_cr;        /* 0x000 (R/W) EWIC Control */
+    volatile uint32_t ewic_ascr;      /* 0x004 (R/W) Automatic Sequence
+                                       *             Control */
+    volatile uint32_t ewic_clrmask;   /* 0x008 ( /W) Clear All Mask */
+    volatile uint32_t ewic_numid;     /* 0x00C (R/ ) ID Register for the number
+                                       *             of events supported */
+    volatile uint32_t reserved0[124];
+    volatile uint32_t ewic_maska;     /* 0x200 (R/W) Set which internal events
+                                       *             cause wakeup */
+    volatile uint32_t ewic_mask[15];  /* 0x204 (R/W) Set which external
+                                       *             interrupts cause wakeup
+                                       *             Only the first (total
+                                       *             system IRQ number)/32
+                                       *             registers are implemented
+                                       *             in array */
+    volatile uint32_t reserved1[112];
+    volatile uint32_t ewic_penda;     /* 0x400 (R/ ) Shows which internal
+                                       *             interrupts were pended
+                                       *             while the EWIC was
+                                       *             enabled */
+
+    volatile uint32_t ewic_pend[15];   /* 0x404 (R/W) Shows which external
+                                       *             interrupts were pended
+                                       *             while the EWIC was
+                                       *             enabled
+                                       *             Only the first (total
+                                       *             system IRQ number)/32
+                                       *             registers are implemented
+                                       *             in array */
+    volatile uint32_t reserved2[112];
+    volatile uint32_t ewic_psr;       /* 0x600 (R/ ) Pending Summary */
+    volatile uint32_t reserved3[575];
+    volatile uint32_t itctrl;         /* 0xF00 (R/ ) Integration Mode Control */
+    volatile uint32_t reserved4[39];
+    volatile uint32_t claimset;       /* 0xFA0 (R/W) Claim Tag Set */
+    volatile uint32_t claimclr;       /* 0xFA4 (R/W) Claim Tag Clear */
+    volatile uint32_t devaff0;        /* 0xFA8 (R/ ) Device Affinity 0 */
+    volatile uint32_t devaff1;        /* 0xFAC (R/ ) Device Affinity 1 */
+    volatile uint32_t lar;            /* 0xFB0 ( /W) Lock Access */
+    volatile uint32_t lsr;            /* 0xFB4 (R/ ) Lock Status */
+    volatile uint32_t authstatus;     /* 0xFB8 (R/ ) Authentication Status */
+    volatile uint32_t devarch;        /* 0xFBC (R/ ) Device Architecture */
+    volatile uint32_t devid2;         /* 0xFC0 (R/ ) Device Configuration 2 */
+    volatile uint32_t devid1;         /* 0xFC4 (R/ ) Device Configuration 1 */
+    volatile uint32_t devid;          /* 0xFC8 (R/ ) Device Configuration */
+    volatile uint32_t devtype;        /* 0xFCC (R/ ) Device Type */
+    volatile uint32_t pidr4;          /* 0xFD0 (R/ ) Peripheral ID 4 */
+    volatile uint32_t reserved5[3];
+    volatile uint32_t pidr0;          /* 0xFE0 (R/ ) Peripheral ID 0 */
+    volatile uint32_t pidr1;          /* 0xFE4 (R/ ) Peripheral ID 1 */
+    volatile uint32_t pidr2;          /* 0xFE8 (R/ ) Peripheral ID 2 */
+    volatile uint32_t pidr3;          /* 0xFEC (R/ ) Peripheral ID 3 */
+    volatile uint32_t cidr0;          /* 0xFF0 (R/ ) Component ID 0 */
+    volatile uint32_t cidr1;          /* 0xFF4 (R/ ) Component ID 1 */
+    volatile uint32_t cidr2;          /* 0xFF8 (R/ ) Component ID 2 */
+    volatile uint32_t cidr3;          /* 0xFFC (R/ ) Component ID 3 */
+};
+#endif /* __PLATFORM_REGS_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/system_SSE310MPS3.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/system_SSE310MPS3.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009-2022 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.9.0 system_ARMCM85.h
+ * Git SHA: 2b7495b8535bdcb306dac29b9ded4cfb679d7e5c
+ */
+
+#ifndef __SYSTEM_CORE_INIT_H__
+#define __SYSTEM_CORE_INIT_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern uint32_t SystemCoreClock;  /*!< System Clock Frequency (Core Clock)  */
+extern uint32_t PeripheralClock;  /*!< Peripheral Clock Frequency */
+
+/**
+  \brief Exception / Interrupt Handler Function Prototype
+*/
+typedef void(*VECTOR_TABLE_Type)(void);
+
+/**
+ * \brief  Initializes the system
+ */
+extern void SystemInit(void);
+
+/**
+ * \brief  Restores system core clock
+ */
+extern void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_CORE_INIT_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/uart_cmsdk_drv.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/uart_cmsdk_drv.h
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2016-2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file uart_cmsdk_drv.h
+ * \brief Generic driver for ARM CMSDK UART.
+ *      Features of the driver:
+ *          1. Initialize UART
+ *          2. Set/Get UART baudrate
+ *          3. Set system clock
+ *          4. Read/Write UART data
+ *          5. Enable/Disable TX interrupt
+ *          6. Enable/Disable RX interrupt
+ *          7. Clear interrupts
+ *          8. Verifies if RX has data
+ *          9. Verifies if TX is ready to send more data
+ */
+
+#ifndef __UART_CMSDK_DRV_H__
+#define __UART_CMSDK_DRV_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ARM UART device configuration structure */
+struct uart_cmsdk_dev_cfg_t {
+    const uint32_t base;              /*!< UART base address */
+    const uint32_t default_baudrate;  /*!< Default baudrate */
+};
+
+/* ARM UART device data structure */
+struct uart_cmsdk_dev_data_t {
+    uint32_t state;       /*!< Indicates if the uart driver
+                           *   is initialized and enabled
+                           */
+    uint32_t system_clk;  /*!< System clock */
+    uint32_t baudrate;    /*!< Baudrate */
+};
+
+/* ARM UART device structure */
+struct uart_cmsdk_dev_t {
+    const struct uart_cmsdk_dev_cfg_t* const cfg;  /*!< UART configuration */
+    struct uart_cmsdk_dev_data_t* const data;      /*!< UART data */
+};
+
+/* ARM UART enumeration types */
+enum uart_cmsdk_error_t {
+    UART_CMSDK_ERR_NONE = 0,      /*!< No error */
+    UART_CMSDK_ERR_INVALID_ARG,   /*!< Error invalid input argument */
+    UART_CMSDK_ERR_INVALID_BAUD,  /*!< Invalid baudrate */
+    UART_CMSDK_ERR_NOT_INIT,      /*!< Error UART not initialized */
+    UART_CMSDK_ERR_NOT_READY,     /*!< Error UART not ready */
+};
+
+enum uart_cmsdk_irq_t {
+    UART_CMSDK_IRQ_RX,       /*!< RX interrupt source */
+    UART_CMSDK_IRQ_TX,       /*!< TX interrupt source */
+    UART_CMSDK_IRQ_COMBINED  /*!< RX-TX combined interrupt source */
+};
+
+/**
+ * \brief Initializes UART. It uses the default baudrate to configure
+ * the peripheral at this point.
+ *
+ * \param[in] dev         UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] system_clk  System clock used by the device.
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_init(struct uart_cmsdk_dev_t* dev,
+                                    uint32_t system_clk);
+
+/**
+ * \brief Uninitializes UART to a known default state, which is:
+ *          - Rx and Tx are disabled
+ *          - Rx and Tx interrupts flags cleared
+ *          - Rx and Tx buffer overrun flags cleared
+ *          - Rx and Tx interrupts disabled
+ *        Init should be called prior to any other process and
+ *        it's the caller's responsibility to follow proper call order.
+ *        More than one call results fall through.
+ *
+ * \param[in] dev UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_uninit(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Sets the UART baudrate.
+ *
+ * \param[in] dev       UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] baudrate  New baudrate.
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_set_baudrate(struct uart_cmsdk_dev_t* dev,
+                                            uint32_t baudrate);
+
+/**
+ * \brief Gets the UART baudrate.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return Returns the UART baudrate.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t uart_cmsdk_get_baudrate(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Sets system clock.
+ *
+ * \param[in] dev         UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] system_clk  System clock used by the device.
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_set_clock(struct uart_cmsdk_dev_t* dev,
+                                         uint32_t system_clk);
+/**
+ * \brief Reads one byte from UART dev.
+ *
+ * \param[in] dev   UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] byte  Pointer to byte.
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note For better performance, this function doesn't check if dev and byte
+ * pointer are NULL, and if the driver is initialized.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_read(struct uart_cmsdk_dev_t* dev,
+                                                                uint8_t* byte);
+
+/**
+ * \brief Writes a byte to UART dev.
+ *
+ * \param[in] dev   UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] byte  Byte to write.
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note For better performance, this function doesn't check if dev is NULL and
+ * if the driver is initialized to have better performance.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_write(struct uart_cmsdk_dev_t* dev,
+                                                                 uint8_t byte);
+
+/**
+ * \brief Enables TX interrupt.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_irq_tx_enable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Disables TX interrupt.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_irq_tx_disable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief  Verifies if Tx is ready to send more data.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return  1 if TX is ready, 0 otherwise.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t uart_cmsdk_tx_ready(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Enables RX interrupt.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_irq_rx_enable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Disables RX interrupt
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_irq_rx_disable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Verifies if Rx has data.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return 1 if RX has data, 0 otherwise.
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+uint32_t uart_cmsdk_rx_ready(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Clears UART interrupt.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ * \param[in] irq  IRQ source to clean \ref uart_cmsdk_irq_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_clear_interrupt(struct uart_cmsdk_dev_t* dev,
+                              enum uart_cmsdk_irq_t irq);
+
+/**
+ * \brief Enables TX
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_tx_enable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Disables TX
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_tx_disable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Enables RX
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \return Returns error code as specified in \ref uart_cmsdk_error_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+enum uart_cmsdk_error_t uart_cmsdk_rx_enable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Disables RX
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_rx_disable(struct uart_cmsdk_dev_t* dev);
+
+/**
+ * \brief Clears UART RX buffer overrun flag.
+ *
+ * \param[in] dev  UART device struct \ref uart_cmsdk_dev_t
+ *
+ * \note This function doesn't check if dev is NULL.
+ */
+void uart_cmsdk_rx_overrun_clear(struct uart_cmsdk_dev_t* dev);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __UART_CMSDK_DRV_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/uart_cmsdk_reg_map.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/include/uart_cmsdk_reg_map.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * \file uart_cmsdk_reg_map.h
+ * \brief Register map for ARM CMSDK UART
+ */
+
+#ifndef __UART_CMSDK_REG_MAP_H__
+#define __UART_CMSDK_REG_MAP_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* UART register map structure */
+struct uart_cmsdk_reg_map_t {
+    volatile uint32_t data;   /* Offset: 0x000 (R/W) data register    */
+    volatile uint32_t state;  /* Offset: 0x004 (R/W) status register  */
+    volatile uint32_t ctrl;   /* Offset: 0x008 (R/W) control register */
+    union {
+        volatile uint32_t intrstatus;  /* Offset: 0x00c (R/ ) interrupt status
+                                        *                     register
+                                        */
+        volatile uint32_t intrclear;   /* Offset: 0x00c ( /W) interrupt clear
+                                        *                     register
+                                        */
+    }intr_reg;
+    volatile uint32_t bauddiv;        /* Offset: 0x010 (R/W) Baudrate divider
+                                       *                     register
+                                       */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __UART_CMSDK_REG_MAP_H__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/Driver_USART.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/Driver_USART.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013-2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Driver_USART_CMSDK.h"
+#include "RTE_Components.h"
+#include "cmsis_driver_config.h"
+
+#if (defined(RTE_USART0) && (RTE_USART0 == 1)) || (defined(RTE_USART1) && (RTE_USART1 == 1))    \
+    || (defined(RTE_USART2) && (RTE_USART2 == 1)) || (defined(RTE_USART3) && (RTE_USART3 == 1)) \
+    || (defined(RTE_USART4) && (RTE_USART4 == 1))
+
+#if (defined(RTE_USART0) && (RTE_USART0 == 1))
+
+ARM_DRIVER_USART_CMSDK(UART0_CMSDK_DEV, Driver_USART0, UARTRX0_Handler, UARTTX0_Handler, UARTRX0_IRQn, UARTTX0_IRQn);
+
+#endif /* RTE_USART0 */
+
+#if (defined(RTE_USART1) && (RTE_USART1 == 1))
+
+ARM_DRIVER_USART_CMSDK(UART1_CMSDK_DEV, Driver_USART1, UARTRX1_Handler, UARTTX1_Handler, UARTRX1_IRQn, UARTTX1_IRQn);
+
+#endif /* RTE_USART1 */
+
+#if (defined(RTE_USART2) && (RTE_USART2 == 1))
+
+ARM_DRIVER_USART_CMSDK(UART2_CMSDK_DEV, Driver_USART2, UARTRX2_Handler, UARTTX2_Handler, UARTRX2_IRQn, UARTTX2_IRQn);
+
+#endif /* RTE_USART2 */
+
+#if (defined(RTE_USART3) && (RTE_USART3 == 1))
+
+ARM_DRIVER_USART_CMSDK(UART3_CMSDK_DEV, Driver_USART3, UARTRX3_Handler, UARTTX3_Handler, UARTRX3_IRQn, UARTTX3_IRQn);
+
+#endif /* RTE_USART3 */
+
+#if (defined(RTE_USART4) && (RTE_USART4 == 1))
+
+ARM_DRIVER_USART_CMSDK(UART4_CMSDK_DEV, Driver_USART4, UARTRX4_Handler, UARTTX4_Handler, UARTRX4_IRQn, UARTTX4_IRQn);
+#endif /* RTE_USART4 */
+#endif

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/bsp_serial.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/bsp_serial.c
@@ -1,0 +1,228 @@
+/* Copyright 2017-2024 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "device_cfg.h"
+#include "Driver_USART.h"
+#include "bsp_serial.h"
+
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+#define STDIN_FILENO     0
+#define STDOUT_FILENO    1
+#define STDERR_FILENO    2
+
+typedef enum
+{
+    WRITE_ERROR_SEND_FAIL = -3,
+    WRITE_ERROR_SYNC_FAILED = -2,
+    WRITE_ERROR_INVALID_ARGS = -1,
+    WRITE_ERROR_NONE = 0
+} WriteError_t;
+
+typedef struct
+{
+    WriteError_t error;
+    unsigned int charsWritten;
+} WriteResult_t;
+
+extern ARM_DRIVER_USART Driver_USART0;
+
+static SemaphoreHandle_t xLoggingMutex = NULL;
+
+static bool prvValidFdHandle( int fd );
+static void prvWriteChars( int fd,
+                           const unsigned char * str,
+                           unsigned int len,
+                           WriteResult_t * result );
+
+void bsp_serial_init( void )
+{
+    Driver_USART0.Initialize( NULL );
+    Driver_USART0.PowerControl( ARM_POWER_FULL );
+    Driver_USART0.Control( ARM_USART_MODE_ASYNCHRONOUS, DEFAULT_UART_BAUDRATE );
+    Driver_USART0.Control( ARM_USART_CONTROL_TX, 1 );
+    Driver_USART0.Control( ARM_USART_CONTROL_RX, 1 );
+
+    if( xLoggingMutex == NULL )
+    {
+        xLoggingMutex = xSemaphoreCreateMutex();
+        configASSERT( xLoggingMutex );
+    }
+}
+
+void bsp_serial_print( char * str )
+{
+    ( void ) Driver_USART0.Send( str, strlen( str ) );
+
+    while( Driver_USART0.GetTxCount() != strlen( str ) )
+    {
+    }
+}
+
+#if defined( __ARMCOMPILER_VERSION )
+
+/* Retarget armclang, which requires all IO system calls to be overridden together. */
+
+    #include <rt_sys.h>
+
+    FILEHANDLE _sys_open( const char * name,
+                          int openmode )
+    {
+        if( name == NULL )
+        {
+            return -1;
+        }
+
+        /* By default, the Arm Compiler uses the special file path ":tt" for stdin, */
+        /* stdout and stderr and distinguishes between them using openmode. For details, */
+        /* see https://github.com/ARM-software/abi-aa/blob/2022Q1/semihosting/semihosting.rst#sys-open-0x01 */
+        if( strcmp( name, ":tt" ) == 0 )
+        {
+            if( openmode & OPEN_W )
+            {
+                return STDOUT_FILENO;
+            }
+
+            if( openmode & OPEN_A )
+            {
+                return STDERR_FILENO;
+            }
+
+            return STDIN_FILENO;
+        }
+
+        return -1;
+    }
+
+    int _sys_close( FILEHANDLE fh )
+    {
+        /* Not implemented */
+        ( void ) fh;
+        return -1;
+    }
+
+    int _sys_write( FILEHANDLE fd,
+                    const unsigned char * str,
+                    unsigned int len,
+                    int mode )
+    {
+        /* From <rt_sys.h>: `mode` exists for historical reasons and must be ignored. */
+        ( void ) mode;
+
+        WriteResult_t result = { .error = WRITE_ERROR_NONE, .charsWritten = 0 };
+        prvWriteChars( ( int ) fd, str, len, &result );
+
+        if( ( result.error == WRITE_ERROR_NONE ) && ( result.charsWritten == len ) )
+        {
+            return 0;
+        }
+        else if( result.error == WRITE_ERROR_SEND_FAIL )
+        {
+            return len - result.charsWritten;
+        }
+        else
+        {
+            return ( int ) result.error;
+        }
+    }
+
+    int _sys_read( FILEHANDLE fd,
+                   unsigned char * str,
+                   unsigned int len,
+                   int mode )
+    {
+        /* From <rt_sys.h>: `mode' exists for historical reasons and must be ignored. */
+        ( void ) mode;
+
+        /* Not implemented */
+        ( void ) str;
+        ( void ) len;
+        return -1;
+    }
+
+    int _sys_istty( FILEHANDLE fh )
+    {
+        /* Not implemented */
+        ( void ) fh;
+        return 0;
+    }
+
+    long _sys_flen( FILEHANDLE fh )
+    {
+        /* Not implemented */
+        ( void ) fh;
+        return -1;
+    }
+
+    int _sys_seek( FILEHANDLE fh,
+                   long offset )
+    {
+        /* Not implemented */
+        ( void ) fh;
+        ( void ) offset;
+        return -1;
+    }
+
+#else /* !defined(__ARMCOMPILER_VERSION) */
+
+/* Redirects gcc printf to UART0 */
+    int _write( int fd,
+                const unsigned char * str,
+                int len )
+    {
+        WriteResult_t result = { .error = WRITE_ERROR_NONE, .charsWritten = 0 };
+
+        prvWriteChars( fd, str, len, &result );
+
+        return ( ( result.error == WRITE_ERROR_NONE ) && ( result.charsWritten == len ) ) ? result.charsWritten : -1;
+    }
+
+#endif /* if defined( __ARMCOMPILER_VERSION ) */
+
+static bool prvValidFdHandle( int fd )
+{
+    return ( bool ) ( ( fd == STDOUT_FILENO ) || ( fd == STDERR_FILENO ) );
+}
+
+static void prvWriteChars( int fd,
+                           const unsigned char * str,
+                           unsigned int len,
+                           WriteResult_t * result )
+{
+    result->charsWritten = 0;
+
+    if( prvValidFdHandle( fd ) == false )
+    {
+        result->error = WRITE_ERROR_INVALID_ARGS;
+        return;
+    }
+
+    if( xSemaphoreTake( xLoggingMutex, portMAX_DELAY ) != pdTRUE )
+    {
+        result->error = WRITE_ERROR_SYNC_FAILED;
+        return;
+    }
+
+    bool allCharsWritten = ( bool ) ( Driver_USART0.Send( str, len ) == ARM_DRIVER_OK );
+
+    while( Driver_USART0.GetTxCount() != len )
+    {
+    }
+
+    ( void ) xSemaphoreGive( xLoggingMutex );
+
+    if( allCharsWritten == true )
+    {
+        result->charsWritten = len;
+        result->error = WRITE_ERROR_NONE;
+    }
+    else
+    {
+        result->error = WRITE_ERROR_SEND_FAIL;
+    }
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/device_definition.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/device_definition.c
@@ -1,0 +1,849 @@
+/*
+ * Copyright (c) 2019-2023 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file device_definition.c
+ * \brief This file defines exports the structures based on the peripheral
+ * definitions from device_cfg.h.
+ * This file is meant to be used as a helper for baremetal
+ * applications and/or as an example of how to configure the generic
+ * driver structures.
+ */
+
+#include "device_definition.h"
+#include "platform_base_address.h"
+
+/* UART CMSDK driver structures */
+#ifdef UART0_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART0_CMSDK_DEV_CFG_S = {.base = UART0_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART0_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART0_CMSDK_DEV_S = {&(UART0_CMSDK_DEV_CFG_S), &(UART0_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART0_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART0_CMSDK_DEV_CFG_NS = {.base = UART0_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART0_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART0_CMSDK_DEV_NS = {&(UART0_CMSDK_DEV_CFG_NS), &(UART0_CMSDK_DEV_DATA_NS)};
+#endif
+
+#ifdef UART1_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART1_CMSDK_DEV_CFG_S = {.base = UART1_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART1_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART1_CMSDK_DEV_S = {&(UART1_CMSDK_DEV_CFG_S), &(UART1_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART1_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART1_CMSDK_DEV_CFG_NS = {.base = UART1_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART1_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART1_CMSDK_DEV_NS = {&(UART1_CMSDK_DEV_CFG_NS), &(UART1_CMSDK_DEV_DATA_NS)};
+#endif
+
+#ifdef UART2_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART2_CMSDK_DEV_CFG_S = {.base = UART2_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART2_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART2_CMSDK_DEV_S = {&(UART2_CMSDK_DEV_CFG_S), &(UART2_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART2_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART2_CMSDK_DEV_CFG_NS = {.base = UART2_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART2_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART2_CMSDK_DEV_NS = {&(UART2_CMSDK_DEV_CFG_NS), &(UART2_CMSDK_DEV_DATA_NS)};
+#endif
+
+#ifdef UART3_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART3_CMSDK_DEV_CFG_S = {.base = UART3_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART3_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART3_CMSDK_DEV_S = {&(UART3_CMSDK_DEV_CFG_S), &(UART3_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART3_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART3_CMSDK_DEV_CFG_NS = {.base = UART3_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART3_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART3_CMSDK_DEV_NS = {&(UART3_CMSDK_DEV_CFG_NS), &(UART3_CMSDK_DEV_DATA_NS)};
+#endif
+
+#ifdef UART4_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART4_CMSDK_DEV_CFG_S = {.base = UART4_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART4_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART4_CMSDK_DEV_S = {&(UART4_CMSDK_DEV_CFG_S), &(UART4_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART4_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART4_CMSDK_DEV_CFG_NS = {.base = UART4_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART4_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART4_CMSDK_DEV_NS = {&(UART4_CMSDK_DEV_CFG_NS), &(UART4_CMSDK_DEV_DATA_NS)};
+#endif
+
+#ifdef UART5_CMSDK_S
+static const struct uart_cmsdk_dev_cfg_t UART5_CMSDK_DEV_CFG_S = {.base = UART5_BASE_S,
+                                                                  .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART5_CMSDK_DEV_DATA_S = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART5_CMSDK_DEV_S = {&(UART5_CMSDK_DEV_CFG_S), &(UART5_CMSDK_DEV_DATA_S)};
+#endif
+#ifdef UART5_CMSDK_NS
+static const struct uart_cmsdk_dev_cfg_t UART5_CMSDK_DEV_CFG_NS = {.base = UART5_BASE_NS,
+                                                                   .default_baudrate = DEFAULT_UART_BAUDRATE};
+static struct uart_cmsdk_dev_data_t UART5_CMSDK_DEV_DATA_NS = {.state = 0, .system_clk = 0, .baudrate = 0};
+struct uart_cmsdk_dev_t UART5_CMSDK_DEV_NS = {&(UART5_CMSDK_DEV_CFG_NS), &(UART5_CMSDK_DEV_DATA_NS)};
+#endif
+
+/* Corstone-310 PPC driver structures */
+#ifdef PPC_CORSTONE310_MAIN0_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_MAIN0_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                       .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                       .ppc_name = PPC_CORSTONE310_MAIN0};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_MAIN0_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN0_DEV_S = {&PPC_CORSTONE310_MAIN0_CFG_S,
+                                                            &PPC_CORSTONE310_MAIN0_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP0_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_MAIN_EXP0_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                           .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                           .ppc_name = PPC_CORSTONE310_MAIN_EXP0};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_MAIN_EXP0_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP0_DEV_S = {&PPC_CORSTONE310_MAIN_EXP0_CFG_S,
+                                                                &PPC_CORSTONE310_MAIN_EXP0_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP1_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_MAIN_EXP1_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                           .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                           .ppc_name = PPC_CORSTONE310_MAIN_EXP1};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_MAIN_EXP1_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP1_DEV_S = {&PPC_CORSTONE310_MAIN_EXP1_CFG_S,
+                                                                &PPC_CORSTONE310_MAIN_EXP1_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP2_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_MAIN_EXP2_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                           .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                           .ppc_name = PPC_CORSTONE310_MAIN_EXP2};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_MAIN_EXP2_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP2_DEV_S = {&PPC_CORSTONE310_MAIN_EXP2_CFG_S,
+                                                                &PPC_CORSTONE310_MAIN_EXP2_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_MAIN_EXP3_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_MAIN_EXP3_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                           .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                           .ppc_name = PPC_CORSTONE310_MAIN_EXP3};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_MAIN_EXP3_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_MAIN_EXP3_DEV_S = {&PPC_CORSTONE310_MAIN_EXP3_CFG_S,
+                                                                &PPC_CORSTONE310_MAIN_EXP3_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH0_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH0_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                         .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                         .ppc_name = PPC_CORSTONE310_PERIPH0};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH0_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH0_DEV_S = {&PPC_CORSTONE310_PERIPH0_CFG_S,
+                                                              &PPC_CORSTONE310_PERIPH0_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH1_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH1_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                         .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                         .ppc_name = PPC_CORSTONE310_PERIPH1};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH1_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH1_DEV_S = {&PPC_CORSTONE310_PERIPH1_CFG_S,
+                                                              &PPC_CORSTONE310_PERIPH1_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP0_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH_EXP0_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                             .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                             .ppc_name = PPC_CORSTONE310_PERIPH_EXP0};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH_EXP0_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP0_DEV_S = {&PPC_CORSTONE310_PERIPH_EXP0_CFG_S,
+                                                                  &PPC_CORSTONE310_PERIPH_EXP0_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP1_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH_EXP1_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                             .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                             .ppc_name = PPC_CORSTONE310_PERIPH_EXP1};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH_EXP1_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP1_DEV_S = {&PPC_CORSTONE310_PERIPH_EXP1_CFG_S,
+                                                                  &PPC_CORSTONE310_PERIPH_EXP1_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP2_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH_EXP2_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                             .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                             .ppc_name = PPC_CORSTONE310_PERIPH_EXP2};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH_EXP2_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP2_DEV_S = {&PPC_CORSTONE310_PERIPH_EXP2_CFG_S,
+                                                                  &PPC_CORSTONE310_PERIPH_EXP2_DATA_S};
+#endif
+
+#ifdef PPC_CORSTONE310_PERIPH_EXP3_S
+static struct ppc_corstone310_dev_cfg_t PPC_CORSTONE310_PERIPH_EXP3_CFG_S = {.sacfg_base = CORSTONE310_SACFG_BASE_S,
+                                                                             .nsacfg_base = CORSTONE310_NSACFG_BASE_NS,
+                                                                             .ppc_name = PPC_CORSTONE310_PERIPH_EXP3};
+static struct ppc_corstone310_dev_data_t PPC_CORSTONE310_PERIPH_EXP3_DATA_S = {
+    .sacfg_ns_ppc = 0, .sacfg_sp_ppc = 0, .nsacfg_nsp_ppc = 0, .int_bit_mask = 0, .is_initialized = false};
+struct ppc_corstone310_dev_t PPC_CORSTONE310_PERIPH_EXP3_DEV_S = {&PPC_CORSTONE310_PERIPH_EXP3_CFG_S,
+                                                                  &PPC_CORSTONE310_PERIPH_EXP3_DATA_S};
+#endif
+
+/* System counters */
+#ifdef SYSCOUNTER_CNTRL_ARMV8_M_S
+
+#if SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_INT > SYSCOUNTER_ARMV8_M_SCALE_VAL_INT_MAX
+#error SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_INT is invalid.
+#endif
+#if SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_FRACT > SYSCOUNTER_ARMV8_M_SCALE_VAL_FRACT_MAX
+#error SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_FRACT is invalid.
+#endif
+#if SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_INT > SYSCOUNTER_ARMV8_M_SCALE_VAL_INT_MAX
+#error SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_INT is invalid.
+#endif
+#if SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_FRACT > SYSCOUNTER_ARMV8_M_SCALE_VAL_FRACT_MAX
+#error SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_FRACT is invalid.
+#endif
+
+static const struct syscounter_armv8_m_cntrl_dev_cfg_t SYSCOUNTER_CNTRL_ARMV8_M_DEV_CFG_S = {
+    .base = SYSCNTR_CNTRL_BASE_S,
+    .scale0.integer = SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_INT,
+    .scale0.fixed_point_fraction = SYSCOUNTER_ARMV8_M_DEFAULT_SCALE0_FRACT,
+    .scale1.integer = SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_INT,
+    .scale1.fixed_point_fraction = SYSCOUNTER_ARMV8_M_DEFAULT_SCALE1_FRACT};
+static struct syscounter_armv8_m_cntrl_dev_data_t SYSCOUNTER_CNTRL_ARMV8_M_DEV_DATA_S = {.is_initialized = false};
+struct syscounter_armv8_m_cntrl_dev_t SYSCOUNTER_CNTRL_ARMV8_M_DEV_S = {&(SYSCOUNTER_CNTRL_ARMV8_M_DEV_CFG_S),
+                                                                        &(SYSCOUNTER_CNTRL_ARMV8_M_DEV_DATA_S)};
+#endif
+
+#ifdef SYSCOUNTER_READ_ARMV8_M_S
+static const struct syscounter_armv8_m_read_dev_cfg_t SYSCOUNTER_READ_ARMV8_M_DEV_CFG_S = {
+    .base = SYSCNTR_READ_BASE_S,
+};
+struct syscounter_armv8_m_read_dev_t SYSCOUNTER_READ_ARMV8_M_DEV_S = {
+    &(SYSCOUNTER_READ_ARMV8_M_DEV_CFG_S),
+};
+#endif
+#ifdef SYSCOUNTER_READ_ARMV8_M_NS
+static const struct syscounter_armv8_m_read_dev_cfg_t SYSCOUNTER_READ_ARMV8_M_DEV_CFG_NS = {
+    .base = SYSCNTR_READ_BASE_NS,
+};
+struct syscounter_armv8_m_read_dev_t SYSCOUNTER_READ_ARMV8_M_DEV_NS = {
+    &(SYSCOUNTER_CNTRL_ARMV8_M_DEV_CFG_NS),
+};
+#endif
+
+/* System timers */
+#ifdef SYSTIMER0_ARMV8_M_S
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER0_ARMV8_M_DEV_CFG_S
+#ifdef TEST_NS_SLIH_IRQ
+    TFM_LINK_SET_RO_IN_PARTITION_SECTION("TFM_SP_SLIH_TEST", "APP-ROT")
+#elif defined(TEST_NS_FLIH_IRQ)
+    TFM_LINK_SET_RO_IN_PARTITION_SECTION("TFM_SP_FLIH_TEST", "APP-ROT")
+#endif
+    = {.base = SYSTIMER0_ARMV8_M_BASE_S, .default_freq_hz = SYSTIMER0_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER0_ARMV8_M_DEV_DATA_S
+#ifdef TEST_NS_SLIH_IRQ
+    TFM_LINK_SET_RW_IN_PARTITION_SECTION("TFM_SP_SLIH_TEST", "APP-ROT")
+#elif defined(TEST_NS_FLIH_IRQ)
+    TFM_LINK_SET_RW_IN_PARTITION_SECTION("TFM_SP_FLIH_TEST", "APP-ROT")
+#endif
+    = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER0_ARMV8_M_DEV_S
+#ifdef TEST_NS_SLIH_IRQ
+    TFM_LINK_SET_RW_IN_PARTITION_SECTION("TFM_SP_SLIH_TEST", "APP-ROT")
+#elif defined(TEST_NS_FLIH_IRQ)
+    TFM_LINK_SET_RW_IN_PARTITION_SECTION("TFM_SP_FLIH_TEST", "APP-ROT")
+#endif
+    = {&(SYSTIMER0_ARMV8_M_DEV_CFG_S), &(SYSTIMER0_ARMV8_M_DEV_DATA_S)};
+#endif
+
+#ifdef SYSTIMER0_ARMV8_M_NS
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER0_ARMV8_M_DEV_CFG_NS = {
+    .base = SYSTIMER0_ARMV8_M_BASE_NS, .default_freq_hz = SYSTIMER0_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER0_ARMV8_M_DEV_DATA_NS = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER0_ARMV8_M_DEV_NS = {&(SYSTIMER0_ARMV8_M_DEV_CFG_NS),
+                                                          &(SYSTIMER0_ARMV8_M_DEV_DATA_NS)};
+#endif
+
+#ifdef SYSTIMER1_ARMV8_M_S
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER1_ARMV8_M_DEV_CFG_S = {
+    .base = SYSTIMER1_ARMV8_M_BASE_S, .default_freq_hz = SYSTIMER1_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER1_ARMV8_M_DEV_DATA_S = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER1_ARMV8_M_DEV_S = {&(SYSTIMER1_ARMV8_M_DEV_CFG_S),
+                                                         &(SYSTIMER1_ARMV8_M_DEV_DATA_S)};
+#endif
+
+#ifdef SYSTIMER1_ARMV8_M_NS
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER1_ARMV8_M_DEV_CFG_NS = {
+    .base = SYSTIMER1_ARMV8_M_BASE_NS, .default_freq_hz = SYSTIMER1_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER1_ARMV8_M_DEV_DATA_NS = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER1_ARMV8_M_DEV_NS = {&(SYSTIMER1_ARMV8_M_DEV_CFG_NS),
+                                                          &(SYSTIMER1_ARMV8_M_DEV_DATA_NS)};
+#endif
+
+#ifdef SYSTIMER2_ARMV8_M_S
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER2_ARMV8_M_DEV_CFG_S = {
+    .base = SYSTIMER2_ARMV8_M_BASE_S, .default_freq_hz = SYSTIMER2_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER2_ARMV8_M_DEV_DATA_S = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER2_ARMV8_M_DEV_S = {&(SYSTIMER2_ARMV8_M_DEV_CFG_S),
+                                                         &(SYSTIMER2_ARMV8_M_DEV_DATA_S)};
+#endif
+
+#ifdef SYSTIMER2_ARMV8_M_NS
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER2_ARMV8_M_DEV_CFG_NS = {
+    .base = SYSTIMER2_ARMV8_M_BASE_NS, .default_freq_hz = SYSTIMER2_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER2_ARMV8_M_DEV_DATA_NS = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER2_ARMV8_M_DEV_NS = {&(SYSTIMER2_ARMV8_M_DEV_CFG_NS),
+                                                          &(SYSTIMER2_ARMV8_M_DEV_DATA_NS)};
+#endif
+
+#ifdef SYSTIMER3_ARMV8_M_S
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER3_ARMV8_M_DEV_CFG_S = {
+    .base = SYSTIMER3_ARMV8_M_BASE_S, .default_freq_hz = SYSTIMER3_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER3_ARMV8_M_DEV_DATA_S = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER3_ARMV8_M_DEV_S = {&(SYSTIMER3_ARMV8_M_DEV_CFG_S),
+                                                         &(SYSTIMER3_ARMV8_M_DEV_DATA_S)};
+#endif
+
+#ifdef SYSTIMER3_ARMV8_M_NS
+static const struct systimer_armv8_m_dev_cfg_t SYSTIMER3_ARMV8_M_DEV_CFG_NS = {
+    .base = SYSTIMER3_ARMV8_M_BASE_NS, .default_freq_hz = SYSTIMER3_ARMV8M_DEFAULT_FREQ_HZ};
+static struct systimer_armv8_m_dev_data_t SYSTIMER3_ARMV8_M_DEV_DATA_NS = {.is_initialized = false};
+struct systimer_armv8_m_dev_t SYSTIMER3_ARMV8_M_DEV_NS = {&(SYSTIMER3_ARMV8_M_DEV_CFG_NS),
+                                                          &(SYSTIMER3_ARMV8_M_DEV_DATA_NS)};
+#endif
+
+/* System Watchdogs */
+#ifdef SYSWDOG_ARMV8_M_S
+static const struct syswdog_armv8_m_dev_cfg_t SYSWDOG_ARMV8_M_DEV_CFG_S = {.base = SYSWDOG_ARMV8_M_CNTRL_BASE_S};
+struct syswdog_armv8_m_dev_t SYSWDOG_ARMV8_M_DEV_S = {&(SYSWDOG_ARMV8_M_DEV_CFG_S)};
+#endif
+
+#ifdef SYSWDOG_ARMV8_M_NS
+static const struct syswdog_armv8_m_dev_cfg_t SYSWDOG_ARMV8_M_DEV_CFG_NS = {.base = SYSWDOG_ARMV8_M_CNTRL_BASE_NS};
+struct syswdog_armv8_m_dev_t SYSWDOG_ARMV8_M_DEV_NS = {&(SYSWDOG_ARMV8_M_DEV_CFG_NS)};
+#endif
+
+/* ARM MPC SIE 300 driver structures */
+#ifdef MPC_SRAM_S
+/* Ranges controlled by this SRAM_MPC */
+static const struct mpc_sie_memory_range_t MPC_SRAM_RANGE_S = {
+    .base = MPC_SRAM_RANGE_BASE_S, .limit = MPC_SRAM_RANGE_LIMIT_S, .range_offset = 0, .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_SRAM_RANGE_NS = {.base = MPC_SRAM_RANGE_BASE_NS,
+                                                                .limit = MPC_SRAM_RANGE_LIMIT_NS,
+                                                                .range_offset = 0,
+                                                                .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+#define MPC_SRAM_RANGE_LIST_LEN 2u
+static const struct mpc_sie_memory_range_t *MPC_SRAM_RANGE_LIST[MPC_SRAM_RANGE_LIST_LEN] = {&MPC_SRAM_RANGE_S,
+                                                                                            &MPC_SRAM_RANGE_NS};
+
+static struct mpc_sie_dev_cfg_t MPC_SRAM_DEV_CFG_S = {
+    .base = MPC_SRAM_BASE_S, .range_list = MPC_SRAM_RANGE_LIST, .nbr_of_ranges = MPC_SRAM_RANGE_LIST_LEN};
+static struct mpc_sie_dev_data_t MPC_SRAM_DEV_DATA_S = {.is_initialized = false};
+struct mpc_sie_dev_t MPC_SRAM_DEV_S = {&(MPC_SRAM_DEV_CFG_S), &(MPC_SRAM_DEV_DATA_S)};
+#endif
+
+#ifdef MPC_QSPI_S
+/* Ranges controlled by this QSPI_MPC */
+static const struct mpc_sie_memory_range_t MPC_QSPI_RANGE_S = {
+    .base = MPC_QSPI_RANGE_BASE_S, .limit = MPC_QSPI_RANGE_LIMIT_S, .range_offset = 0, .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_QSPI_RANGE_NS = {.base = MPC_QSPI_RANGE_BASE_NS,
+                                                                .limit = MPC_QSPI_RANGE_LIMIT_NS,
+                                                                .range_offset = 0,
+                                                                .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+#define MPC_QSPI_RANGE_LIST_LEN 2u
+static const struct mpc_sie_memory_range_t *MPC_QSPI_RANGE_LIST[MPC_QSPI_RANGE_LIST_LEN] = {&MPC_QSPI_RANGE_S,
+                                                                                            &MPC_QSPI_RANGE_NS};
+
+static struct mpc_sie_dev_cfg_t MPC_QSPI_DEV_CFG_S = {
+    .base = MPC_QSPI_BASE_S, .range_list = MPC_QSPI_RANGE_LIST, .nbr_of_ranges = MPC_QSPI_RANGE_LIST_LEN};
+static struct mpc_sie_dev_data_t MPC_QSPI_DEV_DATA_S = {.is_initialized = false};
+struct mpc_sie_dev_t MPC_QSPI_DEV_S = {&(MPC_QSPI_DEV_CFG_S), &(MPC_QSPI_DEV_DATA_S)};
+#endif
+
+#ifdef MPC_DDR4_S
+/* Ranges controlled by this DDR4_MPC */
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK0_RANGE_NS = {.base = MPC_DDR4_BLK0_RANGE_BASE_NS,
+                                                                     .limit = MPC_DDR4_BLK0_RANGE_LIMIT_NS,
+                                                                     .range_offset = MPC_DDR4_BLK0_RANGE_OFFSET_NS,
+                                                                     .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK1_RANGE_S = {.base = MPC_DDR4_BLK1_RANGE_BASE_S,
+                                                                    .limit = MPC_DDR4_BLK1_RANGE_LIMIT_S,
+                                                                    .range_offset = MPC_DDR4_BLK1_RANGE_OFFSET_S,
+                                                                    .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK2_RANGE_NS = {.base = MPC_DDR4_BLK2_RANGE_BASE_NS,
+                                                                     .limit = MPC_DDR4_BLK2_RANGE_LIMIT_NS,
+                                                                     .range_offset = MPC_DDR4_BLK2_RANGE_OFFSET_NS,
+                                                                     .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK3_RANGE_S = {.base = MPC_DDR4_BLK3_RANGE_BASE_S,
+                                                                    .limit = MPC_DDR4_BLK3_RANGE_LIMIT_S,
+                                                                    .range_offset = MPC_DDR4_BLK3_RANGE_OFFSET_S,
+                                                                    .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK4_RANGE_NS = {.base = MPC_DDR4_BLK4_RANGE_BASE_NS,
+                                                                     .limit = MPC_DDR4_BLK4_RANGE_LIMIT_NS,
+                                                                     .range_offset = MPC_DDR4_BLK4_RANGE_OFFSET_NS,
+                                                                     .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK5_RANGE_S = {.base = MPC_DDR4_BLK5_RANGE_BASE_S,
+                                                                    .limit = MPC_DDR4_BLK5_RANGE_LIMIT_S,
+                                                                    .range_offset = MPC_DDR4_BLK5_RANGE_OFFSET_S,
+                                                                    .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK6_RANGE_NS = {.base = MPC_DDR4_BLK6_RANGE_BASE_NS,
+                                                                     .limit = MPC_DDR4_BLK6_RANGE_LIMIT_NS,
+                                                                     .range_offset = MPC_DDR4_BLK6_RANGE_OFFSET_NS,
+                                                                     .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+static const struct mpc_sie_memory_range_t MPC_DDR4_BLK7_RANGE_S = {.base = MPC_DDR4_BLK7_RANGE_BASE_S,
+                                                                    .limit = MPC_DDR4_BLK7_RANGE_LIMIT_S,
+                                                                    .range_offset = MPC_DDR4_BLK7_RANGE_OFFSET_S,
+                                                                    .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+#define MPC_DDR4_RANGE_LIST_LEN 8u
+static const struct mpc_sie_memory_range_t *MPC_DDR4_RANGE_LIST[MPC_DDR4_RANGE_LIST_LEN] = {
+    &MPC_DDR4_BLK0_RANGE_NS,
+    &MPC_DDR4_BLK1_RANGE_S,
+    &MPC_DDR4_BLK2_RANGE_NS,
+    &MPC_DDR4_BLK3_RANGE_S,
+    &MPC_DDR4_BLK4_RANGE_NS,
+    &MPC_DDR4_BLK5_RANGE_S,
+    &MPC_DDR4_BLK6_RANGE_NS,
+    &MPC_DDR4_BLK7_RANGE_S,
+};
+static struct mpc_sie_dev_cfg_t MPC_DDR4_DEV_CFG_S = {
+    .base = MPC_DDR4_BASE_S, .range_list = MPC_DDR4_RANGE_LIST, .nbr_of_ranges = MPC_DDR4_RANGE_LIST_LEN};
+static struct mpc_sie_dev_data_t MPC_DDR4_DEV_DATA_S = {.is_initialized = false};
+struct mpc_sie_dev_t MPC_DDR4_DEV_S = {&(MPC_DDR4_DEV_CFG_S), &(MPC_DDR4_DEV_DATA_S)};
+#endif
+
+#ifdef MPC_ISRAM0_S
+/* Ranges controlled by this ISRAM0_MPC */
+static const struct mpc_sie_memory_range_t MPC_ISRAM0_RANGE_S = {.base = MPC_ISRAM0_RANGE_BASE_S,
+                                                                 .limit = MPC_ISRAM0_RANGE_LIMIT_S,
+                                                                 .range_offset = 0,
+                                                                 .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_ISRAM0_RANGE_NS = {.base = MPC_ISRAM0_RANGE_BASE_NS,
+                                                                  .limit = MPC_ISRAM0_RANGE_LIMIT_NS,
+                                                                  .range_offset = 0,
+                                                                  .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+#define MPC_ISRAM0_RANGE_LIST_LEN 2u
+static const struct mpc_sie_memory_range_t *MPC_ISRAM0_RANGE_LIST[MPC_ISRAM0_RANGE_LIST_LEN] = {&MPC_ISRAM0_RANGE_S,
+                                                                                                &MPC_ISRAM0_RANGE_NS};
+
+static struct mpc_sie_dev_cfg_t MPC_ISRAM0_DEV_CFG_S = {
+    .base = MPC_ISRAM0_BASE_S, .range_list = MPC_ISRAM0_RANGE_LIST, .nbr_of_ranges = MPC_ISRAM0_RANGE_LIST_LEN};
+static struct mpc_sie_dev_data_t MPC_ISRAM0_DEV_DATA_S = {.is_initialized = false};
+struct mpc_sie_dev_t MPC_ISRAM0_DEV_S = {&(MPC_ISRAM0_DEV_CFG_S), &(MPC_ISRAM0_DEV_DATA_S)};
+#endif
+
+#ifdef MPC_ISRAM1_S
+/* Ranges controlled by this ISRAM1_MPC */
+static const struct mpc_sie_memory_range_t MPC_ISRAM1_RANGE_S = {.base = MPC_ISRAM1_RANGE_BASE_S,
+                                                                 .limit = MPC_ISRAM1_RANGE_LIMIT_S,
+                                                                 .range_offset = 0,
+                                                                 .attr = MPC_SIE_SEC_ATTR_SECURE};
+
+static const struct mpc_sie_memory_range_t MPC_ISRAM1_RANGE_NS = {.base = MPC_ISRAM1_RANGE_BASE_NS,
+                                                                  .limit = MPC_ISRAM1_RANGE_LIMIT_NS,
+                                                                  .range_offset = 0,
+                                                                  .attr = MPC_SIE_SEC_ATTR_NONSECURE};
+
+#define MPC_ISRAM1_RANGE_LIST_LEN 2u
+static const struct mpc_sie_memory_range_t *MPC_ISRAM1_RANGE_LIST[MPC_ISRAM1_RANGE_LIST_LEN] = {&MPC_ISRAM1_RANGE_S,
+                                                                                                &MPC_ISRAM1_RANGE_NS};
+
+static struct mpc_sie_dev_cfg_t MPC_ISRAM1_DEV_CFG_S = {
+    .base = MPC_ISRAM1_BASE_S, .range_list = MPC_ISRAM1_RANGE_LIST, .nbr_of_ranges = MPC_ISRAM1_RANGE_LIST_LEN};
+static struct mpc_sie_dev_data_t MPC_ISRAM1_DEV_DATA_S = {.is_initialized = false};
+struct mpc_sie_dev_t MPC_ISRAM1_DEV_S = {&(MPC_ISRAM1_DEV_CFG_S), &(MPC_ISRAM1_DEV_DATA_S)};
+#endif
+
+#ifdef MPS3_IO_S
+static struct arm_mps3_io_dev_cfg_t MPS3_IO_DEV_CFG_S = {.base = FPGA_IO_BASE_S};
+struct arm_mps3_io_dev_t MPS3_IO_DEV_S = {.cfg = &(MPS3_IO_DEV_CFG_S)};
+#endif
+
+#ifdef MPS3_IO_NS
+static struct arm_mps3_io_dev_cfg_t MPS3_IO_DEV_CFG_NS = {.base = FPGA_IO_BASE_NS};
+struct arm_mps3_io_dev_t MPS3_IO_DEV_NS = {.cfg = &(MPS3_IO_DEV_CFG_NS)};
+#endif
+
+#ifdef SMSC9220_ETH_S
+static struct smsc9220_eth_dev_cfg_t SMSC9220_ETH_DEV_CFG_S = {.base = ETHERNET_BASE_S};
+static struct smsc9220_eth_dev_data_t SMSC9220_ETH_DEV_DATA_S = {
+    .state = 0,
+    .wait_ms = 0,
+    .ongoing_packet_length = 0,
+    .ongoing_packet_length_sent = 0,
+    .current_rx_size_words = 0,
+};
+struct smsc9220_eth_dev_t SMSC9220_ETH_DEV_S = {
+    .cfg = &(SMSC9220_ETH_DEV_CFG_S),
+    .data = &(SMSC9220_ETH_DEV_DATA_S),
+};
+#endif
+
+#ifdef SMSC9220_ETH_NS
+static struct smsc9220_eth_dev_cfg_t SMSC9220_ETH_DEV_CFG_NS = {.base = ETHERNET_BASE_NS};
+static struct smsc9220_eth_dev_data_t SMSC9220_ETH_DEV_DATA_NS = {
+    .state = 0,
+    .wait_ms = 0,
+    .ongoing_packet_length = 0,
+    .ongoing_packet_length_sent = 0,
+    .current_rx_size_words = 0,
+};
+struct smsc9220_eth_dev_t SMSC9220_ETH_DEV_NS = {
+    .cfg = &(SMSC9220_ETH_DEV_CFG_NS),
+    .data = &(SMSC9220_ETH_DEV_DATA_NS),
+};
+#endif
+
+/* CMSDK GPIO driver structures */
+#ifdef GPIO0_CMSDK_S
+static const struct gpio_cmsdk_dev_cfg_t GPIO0_CMSDK_DEV_CFG_S = {.base = GPIO0_CMSDK_BASE_S};
+struct gpio_cmsdk_dev_t GPIO0_CMSDK_DEV_S = {&(GPIO0_CMSDK_DEV_CFG_S)};
+#endif
+
+#ifdef GPIO0_CMSDK_NS
+static const struct gpio_cmsdk_dev_cfg_t GPIO0_CMSDK_DEV_CFG_NS = {.base = GPIO0_CMSDK_BASE_NS};
+struct gpio_cmsdk_dev_t GPIO0_CMSDK_DEV_NS = {&(GPIO0_CMSDK_DEV_CFG_NS)};
+#endif
+
+#ifdef GPIO1_CMSDK_S
+static const struct gpio_cmsdk_dev_cfg_t GPIO1_CMSDK_DEV_CFG_S = {.base = GPIO1_CMSDK_BASE_S};
+struct gpio_cmsdk_dev_t GPIO1_CMSDK_DEV_S = {&(GPIO1_CMSDK_DEV_CFG_S)};
+#endif
+
+#ifdef GPIO1_CMSDK_NS
+static const struct gpio_cmsdk_dev_cfg_t GPIO1_CMSDK_DEV_CFG_NS = {.base = GPIO1_CMSDK_BASE_NS};
+struct gpio_cmsdk_dev_t GPIO1_CMSDK_DEV_NS = {&(GPIO1_CMSDK_DEV_CFG_NS)};
+#endif
+
+#ifdef GPIO2_CMSDK_S
+static const struct gpio_cmsdk_dev_cfg_t GPIO2_CMSDK_DEV_CFG_S = {.base = GPIO2_CMSDK_BASE_S};
+struct gpio_cmsdk_dev_t GPIO2_CMSDK_DEV_S = {&(GPIO2_CMSDK_DEV_CFG_S)};
+#endif
+
+#ifdef GPIO2_CMSDK_NS
+static const struct gpio_cmsdk_dev_cfg_t GPIO2_CMSDK_DEV_CFG_NS = {.base = GPIO2_CMSDK_BASE_NS};
+struct gpio_cmsdk_dev_t GPIO2_CMSDK_DEV_NS = {&(GPIO2_CMSDK_DEV_CFG_NS)};
+#endif
+
+#ifdef GPIO3_CMSDK_S
+static const struct gpio_cmsdk_dev_cfg_t GPIO3_CMSDK_DEV_CFG_S = {.base = GPIO3_CMSDK_BASE_S};
+struct gpio_cmsdk_dev_t GPIO3_CMSDK_DEV_S = {&(GPIO3_CMSDK_DEV_CFG_S)};
+#endif
+
+#ifdef GPIO3_CMSDK_NS
+static const struct gpio_cmsdk_dev_cfg_t GPIO3_CMSDK_DEV_CFG_NS = {.base = GPIO3_CMSDK_BASE_NS};
+struct gpio_cmsdk_dev_t GPIO3_CMSDK_DEV_NS = {&(GPIO3_CMSDK_DEV_CFG_NS)};
+#endif
+
+/* PL022 SPI driver structures */
+#ifdef SPI0_PL022_S
+static const struct spi_pl022_dev_cfg_t SPI0_PL022_DEV_CFG_S = {
+    .base = FPGA_SPI_ADC_BASE_S,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI0_PL022_DEV_DATA_S = {.state = 0,
+                                                            .sys_clk = 0,
+                                                            .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                         .word_size = 8,
+                                                                         .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI0_PL022_DEV_S = {.cfg = &(SPI0_PL022_DEV_CFG_S), .data = &(SPI0_PL022_DEV_DATA_S)};
+#endif
+
+#ifdef SPI0_PL022_NS
+static const struct spi_pl022_dev_cfg_t SPI0_PL022_DEV_CFG_NS = {
+    .base = FPGA_SPI_ADC_BASE_NS,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI0_PL022_DEV_DATA_NS = {.state = 0,
+                                                             .sys_clk = 0,
+                                                             .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                          .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                          .word_size = 8,
+                                                                          .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI0_PL022_DEV_NS = {.cfg = &(SPI0_PL022_DEV_CFG_NS), .data = &(SPI0_PL022_DEV_DATA_NS)};
+#endif
+
+#ifdef SPI1_PL022_S
+static const struct spi_pl022_dev_cfg_t SPI1_PL022_DEV_CFG_S = {
+    .base = FPGA_SPI_SHIELD0_BASE_S,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI1_PL022_DEV_DATA_S = {.state = 0,
+                                                            .sys_clk = 0,
+                                                            .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                         .word_size = 8,
+                                                                         .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI1_PL022_DEV_S = {.cfg = &(SPI1_PL022_DEV_CFG_S), .data = &(SPI1_PL022_DEV_DATA_S)};
+#endif
+
+#ifdef SPI1_PL022_NS
+static const struct spi_pl022_dev_cfg_t SPI1_PL022_DEV_CFG_NS = {
+    .base = FPGA_SPI_SHIELD0_BASE_NS,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI1_PL022_DEV_DATA_NS = {.state = 0,
+                                                             .sys_clk = 0,
+                                                             .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                          .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                          .word_size = 8,
+                                                                          .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI1_PL022_DEV_NS = {.cfg = &(SPI1_PL022_DEV_CFG_NS), .data = &(SPI1_PL022_DEV_DATA_NS)};
+#endif
+
+#ifdef SPI2_PL022_S
+static const struct spi_pl022_dev_cfg_t SPI2_PL022_DEV_CFG_S = {
+    .base = FPGA_SPI_SHIELD1_BASE_S,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI2_PL022_DEV_DATA_S = {.state = 0,
+                                                            .sys_clk = 0,
+                                                            .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                         .word_size = 8,
+                                                                         .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI2_PL022_DEV_S = {.cfg = &(SPI2_PL022_DEV_CFG_S), .data = &(SPI2_PL022_DEV_DATA_S)};
+#endif
+
+#ifdef SPI2_PL022_NS
+static const struct spi_pl022_dev_cfg_t SPI2_PL022_DEV_CFG_NS = {
+    .base = FPGA_SPI_SHIELD1_BASE_NS,
+    .default_ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                         .frame_format = SPI_PL022_CFG_FRF_MOT,
+                         .word_size = 8,
+                         .bit_rate = 100000}};
+static struct spi_pl022_dev_data_t SPI2_PL022_DEV_DATA_NS = {.state = 0,
+                                                             .sys_clk = 0,
+                                                             .ctrl_cfg = {.spi_mode = SPI_PL022_MASTER_SELECT,
+                                                                          .frame_format = SPI_PL022_CFG_FRF_MOT,
+                                                                          .word_size = 8,
+                                                                          .bit_rate = 100000}};
+struct spi_pl022_dev_t SPI2_PL022_DEV_NS = {.cfg = &(SPI2_PL022_DEV_CFG_NS), .data = &(SPI2_PL022_DEV_DATA_NS)};
+#endif
+
+/* I2C_SBCon driver structures */
+#ifdef I2C0_SBCON_S
+static struct i2c_sbcon_dev_cfg_t I2C0_SBCON_DEV_CFG_S = {
+    .base = FPGA_SBCon_I2C_AUDIO_BASE_S, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C0_SBCON_DEV_DATA_S = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C0_SBCON_DEV_S = {.cfg = &(I2C0_SBCON_DEV_CFG_S), .data = &(I2C0_SBCON_DEV_DATA_S)};
+#endif
+
+#ifdef I2C0_SBCON_NS
+static struct i2c_sbcon_dev_cfg_t I2C0_SBCON_DEV_CFG_NS = {
+    .base = FPGA_SBCon_I2C_AUDIO_BASE_NS, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C0_SBCON_DEV_DATA_NS = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C0_SBCON_DEV_NS = {.cfg = &(I2C0_SBCON_DEV_CFG_NS), .data = &(I2C0_SBCON_DEV_DATA_NS)};
+#endif
+
+#ifdef I2C1_SBCON_S
+static struct i2c_sbcon_dev_cfg_t I2C1_SBCON_DEV_CFG_S = {
+    .base = FPGA_SBCon_I2C_SHIELD0_BASE_S, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C1_SBCON_DEV_DATA_S = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C1_SBCON_DEV_S = {.cfg = &(I2C1_SBCON_DEV_CFG_S), .data = &(I2C1_SBCON_DEV_DATA_S)};
+#endif
+
+#ifdef I2C1_SBCON_NS
+static struct i2c_sbcon_dev_cfg_t I2C1_SBCON_DEV_CFG_NS = {
+    .base = FPGA_SBCon_I2C_SHIELD0_BASE_NS, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C1_SBCON_DEV_DATA_NS = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C1_SBCON_DEV_NS = {.cfg = &(I2C1_SBCON_DEV_CFG_NS), .data = &(I2C1_SBCON_DEV_DATA_NS)};
+#endif
+
+#ifdef I2C2_SBCON_S
+static struct i2c_sbcon_dev_cfg_t I2C2_SBCON_DEV_CFG_S = {
+    .base = FPGA_SBCon_I2C_SHIELD1_BASE_S, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C2_SBCON_DEV_DATA_S = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C2_SBCON_DEV_S = {.cfg = &(I2C2_SBCON_DEV_CFG_S), .data = &(I2C2_SBCON_DEV_DATA_S)};
+#endif
+
+#ifdef I2C2_SBCON_NS
+static struct i2c_sbcon_dev_cfg_t I2C2_SBCON_DEV_CFG_NS = {
+    .base = FPGA_SBCon_I2C_SHIELD1_BASE_NS, .default_freq_hz = 100000, .sleep_us = &wait_us};
+static struct i2c_sbcon_dev_data_t I2C2_SBCON_DEV_DATA_NS = {.freq_us = 0, .sys_clk = 0, .state = 0};
+struct i2c_sbcon_dev_t I2C2_SBCON_DEV_NS = {.cfg = &(I2C2_SBCON_DEV_CFG_NS), .data = &(I2C2_SBCON_DEV_DATA_NS)};
+#endif
+
+/* I2S driver structures */
+#ifdef MPS3_I2S_S
+static const struct audio_i2s_mps3_dev_cfg_t MPS3_I2S_DEV_CFG_S = {.base = FPGA_I2S_BASE_S};
+struct audio_i2s_mps3_dev_t MPS3_I2S_DEV_S = {
+    &(MPS3_I2S_DEV_CFG_S),
+};
+#endif
+
+#ifdef MPS3_I2S_NS
+static const struct audio_i2s_mps3_dev_cfg_t MPS3_I2S_DEV_CFG_NS = {.base = FPGA_I2S_BASE_NS};
+struct audio_i2s_mps3_dev_t MPS3_I2S_DEV_NS = {
+    &(MPS3_I2S_DEV_CFG_NS),
+};
+#endif
+
+/* DMA350 driver structures */
+#ifdef DMA350_DMA0_S
+static const struct dma350_dev_cfg_t DMA350_DMA0_DEV_CFG_S = {
+    .dma_sec_cfg = (DMASECCFG_TypeDef *)(DMA_350_BASE_S + 0x0UL),
+    .dma_sec_ctrl = (DMASECCTRL_TypeDef *)(DMA_350_BASE_S + 0x100UL),
+    .dma_nsec_ctrl = (DMANSECCTRL_TypeDef *)(DMA_350_BASE_S + 0x200UL),
+    .dma_info = (DMAINFO_TypeDef *)(DMA_350_BASE_S + 0xF00UL)};
+static struct dma350_dev_data_t DMA350_DMA0_DEV_DATA_S = {.state = 0};
+struct dma350_dev_t DMA350_DMA0_DEV_S = {&(DMA350_DMA0_DEV_CFG_S), &(DMA350_DMA0_DEV_DATA_S)};
+
+#ifdef DMA350_DMA0_CH0_S
+struct dma350_ch_dev_t DMA350_DMA0_CH0_DEV_S = {
+    .cfg = {.ch_base = (DMACH_TypeDef *)(DMA_350_BASE_S + 0x1000UL), .channel = 0}, .data = {0}};
+#endif /* DMA350_DMA0_CH0_S */
+
+#ifdef DMA350_DMA0_CH1_S
+struct dma350_ch_dev_t DMA350_DMA0_CH1_DEV_S = {
+    .cfg = {.ch_base = (DMACH_TypeDef *)(DMA_350_BASE_S + 0x1100UL), .channel = 1}, .data = {0}};
+#endif /* DMA350_DMA0_CH1_S */
+
+#ifdef DMA350_DMA0_CH0_NS
+struct dma350_ch_dev_t DMA350_DMA0_CH0_DEV_NS = {
+    .cfg = {.ch_base = (DMACH_TypeDef *)(DMA_350_BASE_NS + 0x1000UL), .channel = 0}, .data = {0}};
+#endif /* DMA350_DMA0_CH0_NS */
+
+#ifdef DMA350_DMA0_CH1_NS
+struct dma350_ch_dev_t DMA350_DMA0_CH1_DEV_NS = {
+    .cfg = {.ch_base = (DMACH_TypeDef *)(DMA_350_BASE_NS + 0x1100UL), .channel = 1}, .data = {0}};
+#endif /* DMA350_DMA0_CH1_NS */
+
+#endif /* DMA350_DMA0_S */
+
+#if defined(DMA350_DMA0_S)
+/* ADA DMA checker layer has to know the TCM remaps */
+static const struct dma350_remap_range_t dma350_address_remap_list[] = {
+    {.begin = 0x00000000, .end = 0x00007FFF, .offset = 0x0A000000},
+    {.begin = 0x10000000, .end = 0x10007FFF, .offset = 0x0A000000},
+    {.begin = 0x20000000, .end = 0x20007FFF, .offset = 0x04000000},
+    {.begin = 0x30000000, .end = 0x30007FFF, .offset = 0x04000000}};
+const struct dma350_remap_list_t dma350_address_remap = {
+    .size = sizeof(dma350_address_remap_list) / sizeof(dma350_address_remap_list[0]), .map = dma350_address_remap_list};
+#endif
+
+/* TGU driver structures */
+#ifdef TGU_ARMV8_M_ITCM_S
+static const struct tgu_armv8_m_mem_range_t TGU_ITCM_RANGE_S = {
+    .base = ITCM_BASE_S, .limit = ITCM_BASE_S + ITCM_SIZE - 1, .range_offset = 0x0, .attr = TGU_SEC_ATTR_SECURE};
+
+static const struct tgu_armv8_m_mem_range_t TGU_ITCM_RANGE_NS = {
+    .base = ITCM_BASE_NS, .limit = ITCM_BASE_NS + ITCM_SIZE - 1, .range_offset = 0x0, .attr = TGU_SEC_ATTR_NONSECURE};
+
+#define TGU_ITCM_RANGE_LIST_LEN 2u
+static const struct tgu_armv8_m_mem_range_t *TGU_ITCM_RANGE_LIST[TGU_ITCM_RANGE_LIST_LEN] = {&TGU_ITCM_RANGE_S,
+                                                                                             &TGU_ITCM_RANGE_NS};
+
+static struct tgu_armv8_m_dev_cfg_t TGU_ARMV8_M_ITCM_DEV_CFG_S = {.base = ITGU_CTRL_BASE};
+static struct tgu_armv8_m_dev_data_t TGU_ARMV8_M_ITCM_DEV_DATA_S = {
+    .range_list = TGU_ITCM_RANGE_LIST, .nbr_of_ranges = TGU_ITCM_RANGE_LIST_LEN, .is_initialized = true};
+struct tgu_armv8_m_dev_t TGU_ARMV8_M_ITCM_DEV_S = {
+    &(TGU_ARMV8_M_ITCM_DEV_CFG_S),
+    &(TGU_ARMV8_M_ITCM_DEV_DATA_S),
+};
+#endif
+
+#ifdef TGU_ARMV8_M_DTCM_S
+
+static const struct tgu_armv8_m_mem_range_t TGU_DTCM_RANGE_S = {
+    .base = DTCM0_BASE_S, .limit = DTCM3_BASE_S + DTCM_BLK_SIZE - 1, .range_offset = 0x0, .attr = TGU_SEC_ATTR_SECURE};
+
+static const struct tgu_armv8_m_mem_range_t TGU_DTCM_RANGE_NS = {.base = DTCM0_BASE_NS,
+                                                                 .limit = DTCM3_BASE_NS + DTCM_BLK_SIZE - 1,
+                                                                 .range_offset = 0x0,
+                                                                 .attr = TGU_SEC_ATTR_NONSECURE};
+
+#define TGU_DTCM_RANGE_LIST_LEN 2u
+static const struct tgu_armv8_m_mem_range_t *TGU_DTCM_RANGE_LIST[TGU_DTCM_RANGE_LIST_LEN] = {&TGU_DTCM_RANGE_S,
+                                                                                             &TGU_DTCM_RANGE_NS};
+
+static struct tgu_armv8_m_dev_cfg_t TGU_ARMV8_M_DTCM_DEV_CFG_S = {.base = DTGU_CTRL_BASE};
+static struct tgu_armv8_m_dev_data_t TGU_ARMV8_M_DTCM_DEV_DATA_S = {
+    .range_list = TGU_DTCM_RANGE_LIST,
+    .nbr_of_ranges = TGU_DTCM_RANGE_LIST_LEN,
+    .is_initialized = true,
+};
+struct tgu_armv8_m_dev_t TGU_ARMV8_M_DTCM_DEV_S = {
+    &(TGU_ARMV8_M_DTCM_DEV_CFG_S),
+    &(TGU_ARMV8_M_DTCM_DEV_DATA_S),
+};
+#endif
+
+/* Color LCD driver structures */
+#ifdef MPS3_CLCD_S
+static const struct clcd_mps3_dev_cfg_t MPS3_CLCD_DEV_CFG_S = {.base = CLCD_Config_Reg_BASE_S};
+struct clcd_mps3_dev_t MPS3_CLCD_DEV_S = {
+    &(MPS3_CLCD_DEV_CFG_S),
+};
+#endif
+
+#ifdef MPS3_CLCD_NS
+static const struct clcd_mps3_dev_cfg_t MPS3_CLCD_DEV_CFG_NS = {.base = CLCD_Config_Reg_BASE_NS};
+struct clcd_mps3_dev_t MPS3_CLCD_DEV_NS = {
+    &(MPS3_CLCD_DEV_CFG_NS),
+};
+#endif
+
+/* RTC driver structures */
+#ifdef RTC_PL031_S
+static const struct rtc_pl031_dev_cfg_t RTC_PL031_DEV_CFG_S = {.base = RTC_BASE_S};
+struct rtc_pl031_dev_t RTC_PL031_DEV_S = {.cfg = &(RTC_PL031_DEV_CFG_S)};
+#endif
+
+#ifdef RTC_PL031_NS
+static const struct rtc_pl031_dev_cfg_t RTC_PL031_DEV_CFG_NS = {.base = RTC_BASE_NS};
+struct rtc_pl031_dev_t RTC_PL031_DEV_NS = {.cfg = &(RTC_PL031_DEV_CFG_NS)};
+#endif

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/startup_SSE310MPS3.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/startup_SSE310MPS3.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2022-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.9.0 startup_ARMCM85.c
+ * Git SHA: 2b7495b8535bdcb306dac29b9ded4cfb679d7e5c
+ */
+
+#include "SSE310MPS3.h"
+#include "system_SSE310MPS3.h"
+
+/*----------------------------------------------------------------------------
+  External References
+ *----------------------------------------------------------------------------*/
+extern uint32_t __INITIAL_SP;
+extern uint32_t __STACK_LIMIT;
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+extern uint64_t __STACK_SEAL;
+#endif
+
+extern __NO_RETURN void __PROGRAM_START(void);
+
+/*----------------------------------------------------------------------------
+  Internal References
+ *----------------------------------------------------------------------------*/
+void __NO_RETURN Reset_Handler  (void) __attribute__ ((naked));
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Handler
+ *----------------------------------------------------------------------------*/
+#define DEFAULT_IRQ_HANDLER(handler_name)  \
+void __NO_RETURN __WEAK handler_name(void); \
+void handler_name(void) { \
+    while(1); \
+}
+
+/* Exceptions */
+DEFAULT_IRQ_HANDLER(NMI_Handler)
+DEFAULT_IRQ_HANDLER(HardFault_Handler)
+DEFAULT_IRQ_HANDLER(MemManage_Handler)
+DEFAULT_IRQ_HANDLER(BusFault_Handler)
+DEFAULT_IRQ_HANDLER(UsageFault_Handler)
+DEFAULT_IRQ_HANDLER(SecureFault_Handler)
+DEFAULT_IRQ_HANDLER(SVC_Handler)
+DEFAULT_IRQ_HANDLER(DebugMon_Handler)
+DEFAULT_IRQ_HANDLER(PendSV_Handler)
+DEFAULT_IRQ_HANDLER(SysTick_Handler)
+
+DEFAULT_IRQ_HANDLER(NONSEC_WATCHDOG_RESET_REQ_Handler)
+DEFAULT_IRQ_HANDLER(NONSEC_WATCHDOG_Handler)
+DEFAULT_IRQ_HANDLER(SLOWCLK_Timer_Handler)
+DEFAULT_IRQ_HANDLER(TFM_TIMER0_IRQ_Handler)
+DEFAULT_IRQ_HANDLER(TIMER1_Handler)
+DEFAULT_IRQ_HANDLER(TIMER2_Handler)
+DEFAULT_IRQ_HANDLER(MPC_Handler)
+DEFAULT_IRQ_HANDLER(PPC_Handler)
+DEFAULT_IRQ_HANDLER(MSC_Handler)
+DEFAULT_IRQ_HANDLER(BRIDGE_ERROR_Handler)
+DEFAULT_IRQ_HANDLER(COMBINED_PPU_Handler)
+DEFAULT_IRQ_HANDLER(DEBUG_PPU_Handler)
+DEFAULT_IRQ_HANDLER(TIMER3_AON_Handler)
+DEFAULT_IRQ_HANDLER(CPU0_CTI_0_Handler)
+DEFAULT_IRQ_HANDLER(CPU0_CTI_1_Handler)
+
+DEFAULT_IRQ_HANDLER(System_Timestamp_Counter_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX0_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX0_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX1_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX1_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX2_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX2_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX3_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX3_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX4_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX4_Handler)
+DEFAULT_IRQ_HANDLER(UART0_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART1_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART2_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART3_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UART4_Combined_Handler)
+DEFAULT_IRQ_HANDLER(UARTOVF_Handler)
+DEFAULT_IRQ_HANDLER(ETHERNET_Handler)
+DEFAULT_IRQ_HANDLER(I2S_Handler)
+DEFAULT_IRQ_HANDLER(TOUCH_SCREEN_Handler)
+DEFAULT_IRQ_HANDLER(USB_Handler)
+DEFAULT_IRQ_HANDLER(SPI_ADC_Handler)
+DEFAULT_IRQ_HANDLER(SPI_SHIELD0_Handler)
+DEFAULT_IRQ_HANDLER(SPI_SHIELD1_Handler)
+#ifdef CORSTONE310_FVP
+DEFAULT_IRQ_HANDLER(DMA_Channel_0_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Channel_1_Handler)
+#else
+DEFAULT_IRQ_HANDLER(DMA_Ch_0_Error_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_0_Terminal_Count_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_0_Combined_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_1_Error_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_1_Terminal_Count_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_1_Combined_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_2_Error_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_2_Terminal_Count_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_2_Combined_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_3_Error_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_3_Terminal_Count_Handler)
+DEFAULT_IRQ_HANDLER(DMA_Ch_3_Combined_Handler)
+#endif
+DEFAULT_IRQ_HANDLER(NPU0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_Combined_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO0_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO1_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_3_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_4_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_5_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_6_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_7_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_8_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_9_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_10_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_11_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_12_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_13_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_14_Handler)
+DEFAULT_IRQ_HANDLER(GPIO2_15_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_0_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_1_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_2_Handler)
+DEFAULT_IRQ_HANDLER(GPIO3_3_Handler)
+DEFAULT_IRQ_HANDLER(UARTRX5_Handler)
+DEFAULT_IRQ_HANDLER(UARTTX5_Handler)
+DEFAULT_IRQ_HANDLER(UART5_Combined_Handler)
+#ifdef CORSTONE310_FVP
+DEFAULT_IRQ_HANDLER(ARM_VSI0_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI1_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI2_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI3_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI4_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI5_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI6_Handler)
+DEFAULT_IRQ_HANDLER(ARM_VSI7_Handler)
+#endif
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[];
+       const VECTOR_TABLE_Type __VECTOR_TABLE[] __VECTOR_TABLE_ATTRIBUTE = {
+  (VECTOR_TABLE_Type)(&__INITIAL_SP),            /*      Initial Stack Pointer */
+  Reset_Handler,                     /*      Reset Handler */
+  NMI_Handler,                       /* -14: NMI Handler */
+  HardFault_Handler,                 /* -13: Hard Fault Handler */
+  MemManage_Handler,                 /* -12: MPU Fault Handler */
+  BusFault_Handler,                  /* -11: Bus Fault Handler */
+  UsageFault_Handler,                /* -10: Usage Fault Handler */
+  SecureFault_Handler,               /*  -9: Secure Fault Handler */
+  0,                                 /*      Reserved */
+  0,                                 /*      Reserved */
+  0,                                 /*      Reserved */
+  SVC_Handler,                       /*  -5: SVCall Handler */
+  DebugMon_Handler,                  /*  -4: Debug Monitor Handler */
+  0,                                 /*      Reserved */
+  PendSV_Handler,                    /*  -2: PendSV Handler */
+  SysTick_Handler,                   /*  -1: SysTick Handler */
+
+  NONSEC_WATCHDOG_RESET_REQ_Handler, /*   0: Non-Secure Watchdog Reset Request Handler */
+  NONSEC_WATCHDOG_Handler,           /*   1: Non-Secure Watchdog Handler */
+  SLOWCLK_Timer_Handler,             /*   2: SLOWCLK Timer Handler */
+  TFM_TIMER0_IRQ_Handler,            /*   3: TIMER 0 Handler */
+  TIMER1_Handler,                    /*   4: TIMER 1 Handler */
+  TIMER2_Handler,                    /*   5: TIMER 2 Handler */
+  0,                                 /*   6: Reserved */
+  0,                                 /*   7: Reserved */
+  0,                                 /*   8: Reserved */
+  MPC_Handler,                       /*   9: MPC Combined (Secure) Handler */
+  PPC_Handler,                       /*  10: PPC Combined (Secure) Handler */
+  MSC_Handler,                       /*  11: MSC Combined (Secure) Handler */
+  BRIDGE_ERROR_Handler,              /*  12: Bridge Error (Secure) Handler */
+  0,                                 /*  13: Reserved */
+  COMBINED_PPU_Handler,              /*  14: Combined PPU Handler */
+  0,                                 /*  15: Reserved */
+  NPU0_Handler,                      /*  16: NPU0 Handler */
+  0,                                 /*  17: Reserved */
+  0,                                 /*  18: Reserved */
+  0,                                 /*  19: Reserved */
+  0,                                 /*  20: Reserved */
+  0,                                 /*  21: Reserved */
+  0,                                 /*  22: Reserved */
+  0,                                 /*  23: Reserved */
+  0,                                 /*  24: Reserved */
+  0,                                 /*  25: Reserved */
+  0,                                 /*  26: Reserved */
+  TIMER3_AON_Handler,                /*  27: TIMER 3 AON Handler */
+  CPU0_CTI_0_Handler,                /*  28: CPU0 CTI IRQ 0 Handler */
+  CPU0_CTI_1_Handler,                /*  29: CPU0 CTI IRQ 1 Handler */
+  0,                                 /*  30: Reserved */
+  0,                                 /*  31: Reserved */
+
+  /* External interrupts */
+  System_Timestamp_Counter_Handler,  /*  32: System timestamp counter Handler */
+  UARTRX0_Handler,                   /*  33: UART 0 RX Handler */
+  UARTTX0_Handler,                   /*  34: UART 0 TX Handler */
+  UARTRX1_Handler,                   /*  35: UART 1 RX Handler */
+  UARTTX1_Handler,                   /*  36: UART 1 TX Handler */
+  UARTRX2_Handler,                   /*  37: UART 2 RX Handler */
+  UARTTX2_Handler,                   /*  38: UART 2 TX Handler */
+  UARTRX3_Handler,                   /*  39: UART 3 RX Handler */
+  UARTTX3_Handler,                   /*  40: UART 3 TX Handler */
+  UARTRX4_Handler,                   /*  41: UART 4 RX Handler */
+  UARTTX4_Handler,                   /*  42: UART 4 TX Handler */
+  UART0_Combined_Handler,            /*  43: UART 0 Combined Handler */
+  UART1_Combined_Handler,            /*  44: UART 1 Combined Handler */
+  UART2_Combined_Handler,            /*  45: UART 2 Combined Handler */
+  UART3_Combined_Handler,            /*  46: UART 3 Combined Handler */
+  UART4_Combined_Handler,            /*  47: UART 4 Combined Handler */
+  UARTOVF_Handler,                   /*  48: UART 0, 1, 2, 3, 4 & 5 Overflow Handler */
+  ETHERNET_Handler,                  /*  49: Ethernet Handler */
+  I2S_Handler,                       /*  50: Audio I2S Handler */
+  TOUCH_SCREEN_Handler,              /*  51: Touch Screen Handler */
+  USB_Handler,                       /*  52: USB Handler */
+  SPI_ADC_Handler,                   /*  53: SPI ADC Handler */
+  SPI_SHIELD0_Handler,               /*  54: SPI (Shield 0) Handler */
+  SPI_SHIELD1_Handler,               /*  55: SPI (Shield 0) Handler */
+  0,                                 /*  56: Reserved */
+#ifdef CORSTONE310_FVP
+  DMA_Channel_0_Handler,             /*  57: DMA (DMA350) Channel 0 Handler */
+  DMA_Channel_1_Handler,             /*  58: DMA (DMA350) Channel 1 Handler */
+  0,                                 /*  59: Reserved */
+  0,                                 /*  60: Reserved */
+  0,                                 /*  61: Reserved */
+  0,                                 /*  62: Reserved */
+  0,                                 /*  63: Reserved */
+  0,                                 /*  64: Reserved */
+  0,                                 /*  65: Reserved */
+  0,                                 /*  66: Reserved */
+  0,                                 /*  67: Reserved */
+  0,                                 /*  68: Reserved */
+#else
+  DMA_Ch_0_Error_Handler,            /*  57: DMA Ch0 Error Handler */
+  DMA_Ch_0_Terminal_Count_Handler,   /*  58: DMA Ch0 Terminal Count Handler */
+  DMA_Ch_0_Combined_Handler,         /*  59: DMA Ch0 Combined Handler */
+  DMA_Ch_1_Error_Handler,            /*  60: DMA Ch1 Error Handler */
+  DMA_Ch_1_Terminal_Count_Handler,   /*  61: DMA Ch1 Terminal Count Handler */
+  DMA_Ch_1_Combined_Handler,         /*  62: DMA Ch1 Combined Handler */
+  DMA_Ch_2_Error_Handler,            /*  63: DMA Ch2 Error Handler */
+  DMA_Ch_2_Terminal_Count_Handler,   /*  64: DMA Ch2 Terminal Count Handler */
+  DMA_Ch_2_Combined_Handler,         /*  65: DMA Ch2 Combined Handler */
+  DMA_Ch_3_Error_Handler,            /*  66: DMA Ch3 Error Handler */
+  DMA_Ch_3_Terminal_Count_Handler,   /*  67: DMA Ch3 Terminal Count Handler */
+  DMA_Ch_3_Combined_Handler,         /*  68: DMA Ch3 Combined Handler */
+#endif
+  GPIO0_Combined_Handler,            /*  69: GPIO 0 Combined Handler */
+  GPIO1_Combined_Handler,            /*  70: GPIO 1 Combined Handler */
+  GPIO2_Combined_Handler,            /*  71: GPIO 2 Combined Handler */
+  GPIO3_Combined_Handler,            /*  72: GPIO 3 Combined Handler */
+  GPIO0_0_Handler,                   /*  73: GPIO0 Pin 0 Handler */
+  GPIO0_1_Handler,                   /*  74: GPIO0 Pin 1 Handler */
+  GPIO0_2_Handler,                   /*  75: GPIO0 Pin 2 Handler */
+  GPIO0_3_Handler,                   /*  76: GPIO0 Pin 3 Handler */
+  GPIO0_4_Handler,                   /*  77: GPIO0 Pin 4 Handler */
+  GPIO0_5_Handler,                   /*  78: GPIO0 Pin 5 Handler */
+  GPIO0_6_Handler,                   /*  79: GPIO0 Pin 6 Handler */
+  GPIO0_7_Handler,                   /*  80: GPIO0 Pin 7 Handler */
+  GPIO0_8_Handler,                   /*  81: GPIO0 Pin 8 Handler */
+  GPIO0_9_Handler,                   /*  82: GPIO0 Pin 9 Handler */
+  GPIO0_10_Handler,                  /*  83: GPIO0 Pin 10 Handler */
+  GPIO0_11_Handler,                  /*  84: GPIO0 Pin 11 Handler */
+  GPIO0_12_Handler,                  /*  85: GPIO0 Pin 12 Handler */
+  GPIO0_13_Handler,                  /*  86: GPIO0 Pin 13 Handler */
+  GPIO0_14_Handler,                  /*  87: GPIO0 Pin 14 Handler */
+  GPIO0_15_Handler,                  /*  88: GPIO0 Pin 15 Handler */
+  GPIO1_0_Handler,                   /*  89: GPIO1 Pin 0 Handler */
+  GPIO1_1_Handler,                   /*  90: GPIO1 Pin 1 Handler */
+  GPIO1_2_Handler,                   /*  91: GPIO1 Pin 2 Handler */
+  GPIO1_3_Handler,                   /*  92: GPIO1 Pin 3 Handler */
+  GPIO1_4_Handler,                   /*  93: GPIO1 Pin 4 Handler */
+  GPIO1_5_Handler,                   /*  94: GPIO1 Pin 5 Handler */
+  GPIO1_6_Handler,                   /*  95: GPIO1 Pin 6 Handler */
+  GPIO1_7_Handler,                   /*  96: GPIO1 Pin 7 Handler */
+  GPIO1_8_Handler,                   /*  97: GPIO1 Pin 8 Handler */
+  GPIO1_9_Handler,                   /*  98: GPIO1 Pin 9 Handler */
+  GPIO1_10_Handler,                  /*  99: GPIO1 Pin 10 Handler */
+  GPIO1_11_Handler,                  /*  100: GPIO1 Pin 11 Handler */
+  GPIO1_12_Handler,                  /*  101: GPIO1 Pin 12 Handler */
+  GPIO1_13_Handler,                  /*  102: GPIO1 Pin 13 Handler */
+  GPIO1_14_Handler,                  /*  103: GPIO1 Pin 14 Handler */
+  GPIO1_15_Handler,                  /*  104: GPIO1 Pin 15 Handler */
+  GPIO2_0_Handler,                   /*  105: GPIO2 Pin 0 Handler */
+  GPIO2_1_Handler,                   /*  106: GPIO2 Pin 1 Handler */
+  GPIO2_2_Handler,                   /*  107: GPIO2 Pin 2 Handler */
+  GPIO2_3_Handler,                   /*  108: GPIO2 Pin 3 Handler */
+  GPIO2_4_Handler,                   /*  109: GPIO2 Pin 4 Handler */
+  GPIO2_5_Handler,                   /*  110: GPIO2 Pin 5 Handler */
+  GPIO2_6_Handler,                   /*  111: GPIO2 Pin 6 Handler */
+  GPIO2_7_Handler,                   /*  112: GPIO2 Pin 7 Handler */
+  GPIO2_8_Handler,                   /*  113: GPIO2 Pin 8 Handler */
+  GPIO2_9_Handler,                   /*  114: GPIO2 Pin 9 Handler */
+  GPIO2_10_Handler,                  /*  115: GPIO2 Pin 10 Handler */
+  GPIO2_11_Handler,                  /*  116: GPIO2 Pin 11 Handler */
+  GPIO2_12_Handler,                  /*  117: GPIO2 Pin 12 Handler */
+  GPIO2_13_Handler,                  /*  118: GPIO2 Pin 13 Handler */
+  GPIO2_14_Handler,                  /*  119: GPIO2 Pin 14 Handler */
+  GPIO2_15_Handler,                  /*  120: GPIO2 Pin 15 Handler */
+  GPIO3_0_Handler,                   /*  121: GPIO3 Pin 0 Handler */
+  GPIO3_1_Handler,                   /*  122: GPIO3 Pin 1 Handler */
+  GPIO3_2_Handler,                   /*  123: GPIO3 Pin 2 Handler */
+  GPIO3_3_Handler,                   /*  124: GPIO3 Pin 3 Handler */
+  UARTRX5_Handler,                   /*  125: UART 5 RX Interrupt */
+  UARTTX5_Handler,                   /*  126: UART 5 TX Interrupt */
+  UART5_Combined_Handler,            /*  127: UART 5 combined Interrupt */
+#ifdef CORSTONE310_FVP
+  0,                                 /*  128: Reserved */
+  0,                                 /*  129: Reserved */
+  0,                                 /*  130: Reserved */
+  0,                                 /*  131: Reserved */
+  0,                                 /*  132: Reserved */
+  0,                                 /*  133: Reserved */
+  0,                                 /*  134: Reserved */
+  0,                                 /*  135: Reserved */
+  0,                                 /*  136: Reserved */
+  0,                                 /*  137: Reserved */
+  0,                                 /*  138: Reserved */
+  0,                                 /*  139: Reserved */
+  0,                                 /*  140: Reserved */
+  0,                                 /*  141: Reserved */
+  0,                                 /*  142: Reserved */
+  0,                                 /*  143: Reserved */
+  0,                                 /*  144: Reserved */
+  0,                                 /*  145: Reserved */
+  0,                                 /*  146: Reserved */
+  0,                                 /*  147: Reserved */
+  0,                                 /*  148: Reserved */
+  0,                                 /*  149: Reserved */
+  0,                                 /*  150: Reserved */
+  0,                                 /*  151: Reserved */
+  0,                                 /*  152: Reserved */
+  0,                                 /*  153: Reserved */
+  0,                                 /*  154: Reserved */
+  0,                                 /*  155: Reserved */
+  0,                                 /*  156: Reserved */
+  0,                                 /*  157: Reserved */
+  0,                                 /*  158: Reserved */
+  0,                                 /*  159: Reserved */
+  0,                                 /*  160: Reserved */
+  0,                                 /*  161: Reserved */
+  0,                                 /*  162: Reserved */
+  0,                                 /*  163: Reserved */
+  0,                                 /*  164: Reserved */
+  0,                                 /*  165: Reserved */
+  0,                                 /*  166: Reserved */
+  0,                                 /*  167: Reserved */
+  0,                                 /*  168: Reserved */
+  0,                                 /*  169: Reserved */
+  0,                                 /*  170: Reserved */
+  0,                                 /*  171: Reserved */
+  0,                                 /*  172: Reserved */
+  0,                                 /*  173: Reserved */
+  0,                                 /*  174: Reserved */
+  0,                                 /*  175: Reserved */
+  0,                                 /*  176: Reserved */
+  0,                                 /*  177: Reserved */
+  0,                                 /*  178: Reserved */
+  0,                                 /*  179: Reserved */
+  0,                                 /*  180: Reserved */
+  0,                                 /*  181: Reserved */
+  0,                                 /*  182: Reserved */
+  0,                                 /*  183: Reserved */
+  0,                                 /*  184: Reserved */
+  0,                                 /*  185: Reserved */
+  0,                                 /*  186: Reserved */
+  0,                                 /*  187: Reserved */
+  0,                                 /*  188: Reserved */
+  0,                                 /*  189: Reserved */
+  0,                                 /*  190: Reserved */
+  0,                                 /*  191: Reserved */
+  0,                                 /*  192: Reserved */
+  0,                                 /*  193: Reserved */
+  0,                                 /*  194: Reserved */
+  0,                                 /*  195: Reserved */
+  0,                                 /*  196: Reserved */
+  0,                                 /*  197: Reserved */
+  0,                                 /*  198: Reserved */
+  0,                                 /*  199: Reserved */
+  0,                                 /*  200: Reserved */
+  0,                                 /*  201: Reserved */
+  0,                                 /*  202: Reserved */
+  0,                                 /*  203: Reserved */
+  0,                                 /*  204: Reserved */
+  0,                                 /*  205: Reserved */
+  0,                                 /*  206: Reserved */
+  0,                                 /*  207: Reserved */
+  0,                                 /*  208: Reserved */
+  0,                                 /*  209: Reserved */
+  0,                                 /*  210: Reserved */
+  0,                                 /*  211: Reserved */
+  0,                                 /*  212: Reserved */
+  0,                                 /*  213: Reserved */
+  0,                                 /*  214: Reserved */
+  0,                                 /*  215: Reserved */
+  0,                                 /*  216: Reserved */
+  0,                                 /*  217: Reserved */
+  0,                                 /*  218: Reserved */
+  0,                                 /*  219: Reserved */
+  0,                                 /*  220: Reserved */
+  0,                                 /*  221: Reserved */
+  0,                                 /*  222: Reserved */
+  0,                                 /*  223: Reserved */
+  ARM_VSI0_Handler,                  /*  224: VSI 0 Handler */
+  ARM_VSI1_Handler,                  /*  225: VSI 1 Handler */
+  ARM_VSI2_Handler,                  /*  226: VSI 2 Handler */
+  ARM_VSI3_Handler,                  /*  227: VSI 3 Handler */
+  ARM_VSI4_Handler,                  /*  228: VSI 4 Handler */
+  ARM_VSI5_Handler,                  /*  229: VSI 5 Handler */
+  ARM_VSI6_Handler,                  /*  230: VSI 6 Handler */
+  ARM_VSI7_Handler,                  /*  231: VSI 7 Handler */
+#endif
+};
+
+#if defined ( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+
+/*----------------------------------------------------------------------------
+  Reset Handler called on controller reset
+ *----------------------------------------------------------------------------*/
+void Reset_Handler(void)
+{
+    __set_PSP((uint32_t)(&__INITIAL_SP));
+
+    __set_MSPLIM((uint32_t)(&__STACK_LIMIT));
+    __set_PSPLIM((uint32_t)(&__STACK_LIMIT));
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    __TZ_set_STACKSEAL_S((uint32_t *)(&__STACK_SEAL));
+#endif
+
+    SystemInit();                             /* CMSIS System Initialization */
+    __PROGRAM_START();                        /* Enter PreMain (C library entry point) */
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/syscalls_stub.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/syscalls_stub.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2024, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Based on: https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/platform/ext/common/syscalls_stub.c?id=9ca8a5eb3c85eecee1303dffa262800ea0385584
+ *
+ */
+
+/*
+ * Note: Arm GNU toolchain version 12 and above require user defined definitions of the functions below.
+ * However, in prior versions those definitions were provided as weakly linked definitions by the toolchain.
+ * Provide them here as weakly linked functions to allow applications that consume the FRI to provide
+ * their own definitions as intended by the toolchain.
+ */
+
+#ifdef __GNUC__
+#if defined( __ARM_ARCH )
+    #include <stddef.h>
+    #include <stdint.h>
+
+    __attribute__( ( weak ) )
+    void _close( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _fstat( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _getpid( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _isatty( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _kill( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _lseek( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _read( void )
+    {
+    }
+
+    __attribute__( ( weak ) )
+    void _write( void )
+    {
+    }
+#endif /* if defined( __ARM_ARCH ) */
+#endif /* ifdef __GNUC__ */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/system_SSE310MPS3.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/system_SSE310MPS3.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is derivative of CMSIS V5.9.0 system_ARMCM85.c
+ * Git SHA: 2b7495b8535bdcb306dac29b9ded4cfb679d7e5c
+ */
+
+#include "SSE310MPS3.h"
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+ #define  XTAL             (25000000UL)
+ #define  SYSTEM_CLOCK     (XTAL)
+ #define  PERIPHERAL_CLOCK (25000000UL)
+
+/*----------------------------------------------------------------------------
+  Exception / Interrupt Vector table
+ *----------------------------------------------------------------------------*/
+extern const VECTOR_TABLE_Type __VECTOR_TABLE[496];
+
+/*----------------------------------------------------------------------------
+  System Core Clock Variable
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = SYSTEM_CLOCK;
+uint32_t PeripheralClock = PERIPHERAL_CLOCK;
+
+/*----------------------------------------------------------------------------
+  System Core Clock update function
+ *----------------------------------------------------------------------------*/
+void SystemCoreClockUpdate (void)
+{
+    SystemCoreClock = SYSTEM_CLOCK;
+    PeripheralClock = PERIPHERAL_CLOCK;
+}
+
+/*----------------------------------------------------------------------------
+  System initialization function
+ *----------------------------------------------------------------------------*/
+void SystemInit (void)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+    SCB->VTOR = (uint32_t)(&__VECTOR_TABLE[0]);
+#endif
+
+    /* Set CPDLPSTATE.RLPSTATE to 0
+       Set CPDLPSTATE.ELPSTATE to 0, to stop the processor from trying to switch the EPU into retention state.
+       Set CPDLPSTATE.CLPSTATE to 0, so PDCORE will not enter low-power state. */
+    PWRMODCTL->CPDLPSTATE &= ~(PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk |
+                               PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk |
+                               PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  );
+
+#if (defined (__FPU_USED) && (__FPU_USED == 1U)) || \
+    (defined (__ARM_FEATURE_MVE) && (__ARM_FEATURE_MVE > 0U))
+    SCB->CPACR |= ((3U << 10U*2U) |           /* enable CP10 Full Access */
+                   (3U << 11U*2U)  );         /* enable CP11 Full Access */
+
+    /* Favor best FP/MVE performance by default, avoid EPU switch-ON delays */
+    /* PDEPU ON, Clock OFF */
+    PWRMODCTL->CPDLPSTATE |= 0x1 << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos;
+#endif
+
+#ifdef UNALIGNED_SUPPORT_DISABLE
+    SCB->CCR |= SCB_CCR_UNALIGN_TRP_Msk;
+#endif
+
+    /* Enable Loop and branch info cache */
+    SCB->CCR |= SCB_CCR_LOB_Msk;
+
+    /* Enable Branch Prediction */
+    SCB->CCR |= SCB_CCR_BP_Msk;
+
+    __DSB();
+    __ISB();
+
+    /* Disable cache, because of BL2->Secure change.
+       If cache is enabled, then code decompression can fail or cause uncertain
+       behaviour after switching to main.
+       If cache  needed to be Enabled before decompression, make sure to Clean
+       and Invalidate it at the begining of main(..)!
+
+       If so, use:
+       SCB_InvalidateICache();      // I cache cannot be cleaned
+       SCB_CleanInvalidateDCache();
+    */
+    SCB_DisableICache();
+    SCB_DisableDCache();
+
+    SystemCoreClock = SYSTEM_CLOCK;
+    PeripheralClock = PERIPHERAL_CLOCK;
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/uart_cmsdk_drv.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMSIS/source/uart_cmsdk_drv.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2016-2024 Arm Limited. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "uart_cmsdk_drv.h"
+#include "uart_cmsdk_reg_map.h"
+
+#include <stddef.h>
+
+/* CTRL Register */
+#define UART_CMSDK_TX_EN       (1ul << 0)
+#define UART_CMSDK_RX_EN       (1ul << 1)
+#define UART_CMSDK_TX_INTR_EN  (1ul << 2)
+#define UART_CMSDK_RX_INTR_EN  (1ul << 3)
+
+/* STATE Register */
+#define UART_CMSDK_TX_BF  (1ul << 0)
+#define UART_CMSDK_RX_BF  (1ul << 1)
+#define UART_CMSDK_TX_BO  (1ul << 2)
+#define UART_CMSDK_RX_BO  (1ul << 3)
+
+/* INTSTATUS Register */
+#define UART_CMSDK_TX_INTR  (1ul << 0)
+#define UART_CMSDK_RX_INTR  (1ul << 1)
+
+/* UART state definitions */
+#define UART_CMSDK_INITIALIZED  (1ul << 0)
+
+enum uart_cmsdk_error_t uart_cmsdk_init(struct uart_cmsdk_dev_t* dev,
+                                    uint32_t system_clk)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+    if(system_clk == 0) {
+        return UART_CMSDK_ERR_INVALID_ARG;
+    }
+
+    /* Sets baudrate and system clock */
+    dev->data->system_clk = system_clk;
+    dev->data->baudrate = dev->cfg->default_baudrate;
+
+    /* Sets baudrate */
+    p_uart->bauddiv = (dev->data->system_clk / dev->cfg->default_baudrate);
+
+    /* Disables receiver and transmitter */
+    p_uart->ctrl &= ~(UART_CMSDK_RX_EN | UART_CMSDK_TX_EN);
+
+    p_uart->intr_reg.intrclear = UART_CMSDK_RX_INTR | UART_CMSDK_TX_INTR;
+
+    dev->data->state = UART_CMSDK_INITIALIZED;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+void uart_cmsdk_uninit(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return;
+    }
+
+    uart_cmsdk_irq_rx_disable(dev);
+    uart_cmsdk_irq_tx_disable(dev);
+
+    p_uart->intr_reg.intrclear = UART_CMSDK_RX_INTR | UART_CMSDK_TX_INTR;
+    p_uart->ctrl &= ~(UART_CMSDK_RX_EN | UART_CMSDK_TX_EN);
+    p_uart->state |= (UART_CMSDK_RX_BO | UART_CMSDK_TX_BO);
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_set_baudrate(struct uart_cmsdk_dev_t* dev,
+                                            uint32_t baudrate)
+{
+    uint32_t bauddiv;
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(baudrate == 0) {
+        return UART_CMSDK_ERR_INVALID_BAUD;
+    }
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    bauddiv = (dev->data->system_clk / baudrate);
+
+    /* Minimum bauddiv value */
+    if(bauddiv < 16) {
+        return UART_CMSDK_ERR_INVALID_BAUD;
+    }
+
+    /* Sets baudrate */
+    dev->data->baudrate = baudrate;
+    p_uart->bauddiv = bauddiv;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+uint32_t uart_cmsdk_get_baudrate(struct uart_cmsdk_dev_t* dev)
+{
+    return dev->data->baudrate;
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_set_clock(struct uart_cmsdk_dev_t* dev,
+                                         uint32_t system_clk)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(system_clk == 0) {
+        return UART_CMSDK_ERR_INVALID_ARG;
+    }
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    /* Sets system clock */
+    dev->data->system_clk = system_clk;
+
+    /* Updates baudrate divider */
+    p_uart->bauddiv = (dev->data->system_clk / dev->data->baudrate);
+
+    /* Enables receiver and transmitter */
+    return UART_CMSDK_ERR_NONE;
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_read(struct uart_cmsdk_dev_t* dev,
+                                                                 uint8_t* byte)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(p_uart->state & UART_CMSDK_RX_BF)) {
+        return UART_CMSDK_ERR_NOT_READY;
+    }
+
+    /* Reads data */
+    *byte = (uint8_t)p_uart->data;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_write(struct uart_cmsdk_dev_t* dev,
+                                                                  uint8_t byte)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(p_uart->state & UART_CMSDK_TX_BF) {
+        return UART_CMSDK_ERR_NOT_READY;
+    }
+
+    /* Sends data */
+    p_uart->data = byte;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_irq_tx_enable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    p_uart->ctrl |= UART_CMSDK_TX_INTR_EN;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+void uart_cmsdk_irq_tx_disable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(dev->data->state & UART_CMSDK_INITIALIZED ) {
+        p_uart->ctrl &= ~UART_CMSDK_TX_INTR_EN;
+    }
+}
+
+uint32_t uart_cmsdk_tx_ready(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return 0;
+    }
+
+    return !(p_uart->state & UART_CMSDK_TX_BF);
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_irq_rx_enable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    p_uart->ctrl |= UART_CMSDK_RX_INTR_EN;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+void uart_cmsdk_irq_rx_disable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(dev->data->state & UART_CMSDK_INITIALIZED) {
+        p_uart->ctrl &= ~UART_CMSDK_RX_INTR_EN;
+    }
+}
+
+uint32_t uart_cmsdk_rx_ready(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                  (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return 0;
+    }
+
+    return (p_uart->state & UART_CMSDK_RX_BF);
+}
+
+void uart_cmsdk_clear_interrupt(struct uart_cmsdk_dev_t* dev,
+                              enum uart_cmsdk_irq_t irq)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(dev->data->state & UART_CMSDK_INITIALIZED) {
+        /* Clears pending interrupts */
+        switch(irq) {
+        case UART_CMSDK_IRQ_RX:
+            p_uart->intr_reg.intrclear = UART_CMSDK_RX_INTR;
+            break;
+        case UART_CMSDK_IRQ_TX:
+            p_uart->intr_reg.intrclear = UART_CMSDK_TX_INTR;
+            break;
+        case UART_CMSDK_IRQ_COMBINED:
+            p_uart->intr_reg.intrclear =
+                                      (UART_CMSDK_RX_INTR | UART_CMSDK_TX_INTR);
+            break;
+        /* default: not defined to force all cases to be handled */
+        }
+    }
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_tx_enable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if (!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    p_uart->ctrl |= UART_CMSDK_TX_EN;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+void uart_cmsdk_tx_disable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if (dev->data->state & UART_CMSDK_INITIALIZED ) {
+        p_uart->ctrl &= ~UART_CMSDK_TX_EN;
+    }
+}
+
+enum uart_cmsdk_error_t uart_cmsdk_rx_enable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if (!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return UART_CMSDK_ERR_NOT_INIT;
+    }
+
+    p_uart->ctrl |= UART_CMSDK_RX_EN;
+
+    return UART_CMSDK_ERR_NONE;
+}
+
+void uart_cmsdk_rx_disable(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                 (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if (dev->data->state & UART_CMSDK_INITIALIZED ) {
+        p_uart->ctrl &= ~UART_CMSDK_RX_EN;
+    }
+}
+
+void uart_cmsdk_rx_overrun_clear(struct uart_cmsdk_dev_t* dev)
+{
+    struct uart_cmsdk_reg_map_t* p_uart =
+                                  (struct uart_cmsdk_reg_map_t*)dev->cfg->base;
+
+    if(!(dev->data->state & UART_CMSDK_INITIALIZED)) {
+        return;
+    }
+
+    p_uart->state = UART_CMSDK_RX_BO;
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/CMakeLists.txt
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.15)
+
+project(
+  example
+  VERSION 0.1
+  LANGUAGES C ASM)
+
+set(CMAKE_BUILD_TYPE Debug)
+
+set(CMAKE_EXECUTABLE_SUFFIX ".axf")
+
+get_filename_component(FREERTOS_DIR_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../.. REALPATH)
+message(DEBUG "FREERTOS_DIR_PATH is ${FREERTOS_DIR_PATH}")
+
+set(KERNEL_DIR_PATH ${FREERTOS_DIR_PATH}/Source)
+set(DEMO_COMMON_PATH ${FREERTOS_DIR_PATH}/Demo/Common)
+message(DEBUG "KERNEL_DIR_PATH is ${KERNEL_DIR_PATH}")
+message(DEBUG "DEMO_COMMON_PATH is ${DEMO_COMMON_PATH}")
+
+add_executable(cortex_m85_mpu_pxn_fvp_example)
+
+target_sources(cortex_m85_mpu_pxn_fvp_example
+	PRIVATE
+    	${CMAKE_CURRENT_SOURCE_DIR}/main.c
+)
+
+add_subdirectory(CMSIS)
+
+target_link_libraries(cortex_m85_mpu_pxn_fvp_example
+	PRIVATE
+  		cmsis_bsp
+)
+
+add_library(freertos_config INTERFACE)
+
+target_include_directories(freertos_config SYSTEM
+	INTERFACE
+    	config
+)
+
+set( FREERTOS_HEAP "4" CACHE STRING "" FORCE)
+
+# Select the native compile PORT
+set( FREERTOS_PORT "GCC_ARM_CM85_NTZ_NONSECURE" CACHE STRING "" FORCE )
+
+add_subdirectory(../../../../Source freertos_kernel)
+
+target_link_options(cortex_m85_mpu_pxn_fvp_example
+	PRIVATE
+		-T ${CMAKE_CURRENT_SOURCE_DIR}/gcc_arm.ld
+		-Wl,--gc-sections,-Map=cortex_m85_mpu_pxn_fvp_example.map
+)
+
+target_link_libraries(cortex_m85_mpu_pxn_fvp_example
+	PRIVATE
+  		freertos_kernel
+)

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/README.md
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/README.md
@@ -1,0 +1,93 @@
+
+# MPU PXN example on Armv8.1-M Cortex-M85 Fixed Virtual Platform
+# Introduction
+A new MPU region attribute Privileged eXecute Never (PXN) is introduced in Armv8.1-M architecture, where if an MPU region has PXN attribute set and the processor attempts to execute the code inside with privileged level, the Memory Management Fault exception would be triggered, with IACCVIOL bit in MemManage Fault State Register set to 1. The PXN feature allows privileged software to ensure specific application tasks (threads) to execute in unprivileged level only. For example, a hacker cannot use stack corruption in a privileged peripheral handler to branch into unprivileged codes and execute them with privileged level.
+Please refer to the Security related enhancements section in Introduction to Armv8.1-M architecture white paper document for more information.
+
+This example demonstrates how the new MPU region attribute Privileged eXecute Never (PXN) introduced in Armv8.1-M architecture can be used on Cortex-M85 MCU. The example is based on Corstone-310 Ecosystem Fixed Virtual Platform (Arm Cortex-M85 CPU and Ethos-U55 NPU). Follow the [link](https://www.arm.com/products/development-tools/simulation/fixed-virtual-platforms) to learn more about Arm fixed virtual platforms.
+
+The example simulates a privileged task trying to execute an instruction from an MPU region with Privileged eXecute Never (PXN) attribute set, this result in a memory fault exception which recovers gracefully after clearing an entry in a fault tracker buffer indicating that the exception was triggered and recovered.
+
+# Prerequisites
+
+## Fixed Virtual Platform
+### Downloading and installing Corstone-310 Ecosystem Fixed Virtual Platform
+Follow the instructions on the [page](https://developer.arm.com/downloads/-/arm-ecosystem-fvps) to download Corstone-310 Ecosystem FVP based on your operating system.
+
+Ensure that requirements mentioned in the [page](https://developer.arm.com/documentation/100966/1126/Getting-Started-with-Fixed-Virtual-Platforms/Requirements-for-FVPs?lang=en) are met.
+
+Then, follow these instructions to install the Corstone-310 Ecosystem FVP
+```bash
+cd FVP_Corstone_SSE_310_11.xx_yy_<Linux/Win>64
+
+./FVP_Corstone_SSE-310.sh
+
+Do you want to proceed with the installation? [default: yes]
+Yes.
+
+Do you agree to the above terms and conditions?
+Yes.
+
+Where would you like to install to? [default: /home/<user>/FVP_Corstone_SSE-310]
+Press Enter for the default installation location or specify the absolute path for the required location.
+
+Installation is now completed.
+```
+
+Add the path to FVP_Corstone_SSE-310 executable to the environment variable `PATH` (if the default installation location was used, the executable path would be something like `/home/<user>/FVP_Corstone_SSE-310/v11.xx.yy/models/<Linux/Win>64_<armv8l/x86>_GCC-9.3/`).
+
+Execute the following command to ensure that the Fixed Virtual Platform for Corstone-310 was installed successfully
+```bash
+FVP_Corstone_SSE-310 --version
+
+Fast Models [11.xx.yy (month day year)]
+Copyright 2000-2024 ARM Limited.
+All Rights Reserved.
+```
+
+## Build tools
+* [CMake](https://cmake.org/download/)
+* [GNU Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
+
+# The MPU PXN example
+The MPU PXN example uses `CMake` as the build system.
+
+Run the following command to clone FreeRTOS repository:
+
+```bash
+git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules
+```
+
+## Building and running the MPU PXN example
+### Building the MPU PXN example
+Run the following commands to build the MPU PXN example:
+
+```bash
+cd FreeRTOS/FreeRTOS/Demo/ThirdParty/Partner-Supported-Demos/CORTEX_M85_MPU_PXN_FVP_GCC
+rm -rf build && cmake -B build --toolchain=gcc_toolchain.cmake . && cmake --build build
+```
+
+### Running the example
+Execute the following script to run the MPU PXN example:
+```bash
+./run.sh
+```
+
+### Expected output
+```bash
+$ ./run.sh
+telnetterminal0: Listening for serial connection on port 5000
+telnetterminal1: Listening for serial connection on port 5001
+telnetterminal2: Listening for serial connection on port 5002
+telnetterminal5: Listening for serial connection on port 5003
+
+    Ethos-U rev 136b7d75 --- Apr 12 2023 13:47:17
+    (C) COPYRIGHT 2019-2023 Arm Limited
+    ALL RIGHTS RESERVED
+
+ Exception recovered gracefully
+ Exception recovered gracefully
+ Exception recovered gracefully
+^C
+Stopping simulation...
+```

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/config/FreeRTOSConfig.h
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/config/FreeRTOSConfig.h
@@ -1,0 +1,184 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/******************************************************************************
+*   See http://www.freertos.org/a00110.html for an explanation of the
+*   definitions contained in this file.
+******************************************************************************/
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* https://www.FreeRTOS.org/a00110.html
+*----------------------------------------------------------*/
+
+extern uint32_t SystemCoreClock;
+
+/* See https://freertos.org/a00110.html#configPROTECTED_KERNEL_OBJECT_POOL_SIZE for details. */
+#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE   150
+/* See https://freertos.org/a00110.html#configSYSTEM_CALL_STACK_SIZE for details. */
+#define configSYSTEM_CALL_STACK_SIZE              128
+
+/* Cortex M33 port configuration. */
+#define configENABLE_MPU                                 1
+#define configENABLE_FPU                                 1
+#define configENABLE_TRUSTZONE                           0
+#define configENABLE_MVE                                 0
+
+/* This part has 16 MPU regions. */
+#define configTOTAL_MPU_REGIONS                          8
+
+/* Run FreeRTOS on the secure side and never jump to the non-secure side. */
+#define configRUN_FREERTOS_SECURE_ONLY                   1
+
+/* Constants related to the behaviour or the scheduler. */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
+#define configUSE_PREEMPTION                             1
+#define configUSE_TIME_SLICING                           1
+#define configMAX_PRIORITIES                             ( 10 )
+#define configIDLE_SHOULD_YIELD                          1
+#define configTICK_TYPE_WIDTH_IN_BITS                    TICK_TYPE_WIDTH_32_BITS
+
+/* Constants that describe the hardware and memory usage. */
+#define configCPU_CLOCK_HZ                               SystemCoreClock
+#define configMINIMAL_STACK_SIZE                         ( ( uint16_t ) 512 )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 512 * 1024 ) )
+
+/* Constants that build features in or out. */
+#define configUSE_MUTEXES                                1
+#define configUSE_TICKLESS_IDLE                          0
+#define configUSE_APPLICATION_TASK_TAG                   0
+#define configUSE_NEWLIB_REENTRANT                       0
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configUSE_QUEUE_SETS                             0
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configUSE_TRACE_FACILITY                         1
+#define configNUM_TX_DESCRIPTORS                         15
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    2
+
+/* Constants that define which hook (callback) functions should be used. */
+#define configUSE_IDLE_HOOK                              1
+#define configUSE_TICK_HOOK                              1
+#define configUSE_MALLOC_FAILED_HOOK                     1
+
+/* Constants provided for debugging and optimisation assistance. */
+#define configCHECK_FOR_STACK_OVERFLOW                   2
+#define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ );
+#define configQUEUE_REGISTRY_SIZE                        20
+
+/* Software timer definitions. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  NOTE:  Setting an INCLUDE_ parameter to 0 is
+ * only necessary if the linker does not automatically remove functions that are
+ * not referenced anyway. */
+#define INCLUDE_vTaskPrioritySet                         1
+#define INCLUDE_uxTaskPriorityGet                        1
+#define INCLUDE_vTaskDelete                              1
+#define INCLUDE_vTaskCleanUpResources                    0
+#define INCLUDE_vTaskSuspend                             1
+#define INCLUDE_vTaskDelayUntil                          1
+#define INCLUDE_vTaskDelay                               1
+#define INCLUDE_uxTaskGetStackHighWaterMark              1
+#define INCLUDE_uxTaskGetStackHighWaterMark2             1
+#define INCLUDE_xTaskGetIdleTaskHandle                   1
+#define INCLUDE_eTaskGetState                            1
+#define INCLUDE_xTaskResumeFromISR                       1
+#define INCLUDE_xTaskGetCurrentTaskHandle                1
+#define INCLUDE_xTaskGetSchedulerState                   1
+#define INCLUDE_xSemaphoreGetMutexHolder                 1
+#define INCLUDE_xTimerPendFunctionCall                   1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle           1
+#define INCLUDE_xTaskGetHandle                           1
+#define INCLUDE_xTaskAbortDelay                          1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to
+ * human readable ASCII form.  See the notes in the implementation of vTaskList()
+ * within FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS             1
+
+/* Dimensions a buffer that can be used by the FreeRTOS+CLI command interpreter.
+ * See the FreeRTOS+CLI documentation for more information:
+ * https://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_CLI/ */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE                2048
+
+/* Interrupt priority configuration follows...................... */
+
+/* Use the system definition, if there is one. */
+#ifdef __NVIC_PRIO_BITS
+    #define configPRIO_BITS    __NVIC_PRIO_BITS
+#else
+    #define configPRIO_BITS    3                              /* 8 priority levels. */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+ * function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0x07
+
+/* The highest interrupt priority that can be used by any interrupt service
+ * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
+ * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
+ * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY    5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+* to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY                 ( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+ * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY            ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+/* Constants related to the generation of run time stats. */
+#define configGENERATE_RUN_TIME_STATS                   0
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
+#define portGET_RUN_TIME_COUNTER_VALUE()    0
+
+/* Adjust configTICK_RATE_HZ and pdMS_TO_TICKS to simulate a tick per ms on a fast model */
+#define configTICK_RATE_HZ    ( ( TickType_t ) 100 )
+#define pdMS_TO_TICKS( xTimeInMs )    ( ( TickType_t ) xTimeInMs )
+
+
+/* Enable dynamic allocation. */
+#define configSUPPORT_STATIC_ALLOCATION     0
+#define configSUPPORT_DYNAMIC_ALLOCATION    1
+
+#endif /* FREERTOS_CONFIG_H */

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/gcc_arm.ld
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/gcc_arm.ld
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *-------- <<< Use Configuration Wizard in Context Menu >>> -------------------
+ */
+
+/*---------------------- Flash Configuration ----------------------------------
+  <h> Flash Configuration
+    <o0> Flash Base Address <0x0-0xFFFFFFFF:8>
+    <o1> Flash Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+
+__ROM_BASE = 0x11000000;
+__ROM_SIZE = 0x001FFFFF;
+
+/*--------------------- Embedded RAM Configuration ----------------------------
+  <h> RAM Configuration
+    <o0> RAM Base Address    <0x0-0xFFFFFFFF:8>
+    <o1> RAM Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+ -----------------------------------------------------------------------------*/
+
+__RAM_BASE = 0x31000000;
+__RAM_SIZE = 0x003FFFFE;
+
+/*--------------------- Stack / Heap Configuration ----------------------------
+  <h> Stack / Heap Configuration
+    <o0> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+    <o1> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+  </h>
+  -----------------------------------------------------------------------------*/
+__STACK_SIZE = 0x00001000;
+__HEAP_SIZE  = 0x00080000;
+
+/* Variables used by FreeRTOS-MPU. */
+_Privileged_Functions_Region_Size = 64K;
+_Privileged_Sram_Region_Size = 16K;
+
+__privileged_functions_start__ = __ROM_BASE;
+__privileged_functions_end__ = __privileged_functions_start__ + _Privileged_Functions_Region_Size;
+
+__SRAM_segment_start__ = __RAM_BASE;
+__SRAM_segment_end__ = __SRAM_segment_start__ + __RAM_SIZE;
+
+__privileged_sram_start__ = __SRAM_segment_start__;
+__privileged_sram_end__ = __privileged_sram_start__ + _Privileged_Sram_Region_Size;
+
+/*
+ *-------------------- <<< end of configuration section >>> -------------------
+ */
+
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = __ROM_BASE,  LENGTH = __ROM_SIZE
+  RAM   (rwx) : ORIGIN = __RAM_BASE,  LENGTH = __RAM_SIZE
+}
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+
+  /* Privileged functions - Section needs to be 32 byte aligned to satisfy MPU requirements. */
+  .privileged_functions : ALIGN(32)
+  {
+      KEEP(*(.vectors))
+      . = ALIGN(32);
+      __privileged_functions_start__ = .;
+      *(privileged_functions)
+      . = ALIGN(32);
+      /* End address must be the last address in the region, therefore, -1. */
+      __privileged_functions_end__ = . - 1;
+  } > FLASH
+
+  /* FreeRTOS System calls - Section needs to be 32 byte aligned to satisfy MPU requirements. */
+  .freertos_system_calls : ALIGN(32)
+  {
+      . = ALIGN(32);
+      __syscalls_flash_start__ = .;
+      *(freertos_system_calls)
+      . = ALIGN(32);
+      /* End address must be the last address in the region, therefore, -1. */
+      __syscalls_flash_end__ = . - 1;
+  } > FLASH
+
+  /* FreeRTOS System calls - Section needs to be 32 byte aligned to satisfy MPU requirements. */
+  .unprivileged_functions : ALIGN(32)
+  {
+      . = ALIGN(32);
+      __unprivileged_functions_start__ = .;
+      *(unprivileged_functions)
+      . = ALIGN(32);
+  } > FLASH
+
+  /* Main Text Section - Section needs to be 32 byte aligned to satisfy MPU requirements. */
+  .text : ALIGN(32)
+  {
+    . = ALIGN(32);
+    __unprivileged_flash_start__ = .;
+    *(.text*)
+    /*
+      * These are the old initialisation sections, intended to contain
+      * naked code, with the prologue/epilogue added by crti.o/crtn.o
+      * when linking with startup files. The standalone startup code
+      * currently does not run these, better use the init arrays below.
+    */
+    KEEP(*(.init))
+    KEEP(*(.fini))
+    KEEP(*(.eh_frame))
+
+    __copy_table_start__ = .;
+    LONG (LOADADDR(.data))
+    LONG (ADDR(.data))
+    LONG (SIZEOF(.data) / 4)
+    __copy_table_end__ = .;
+
+    /* .zero.table */
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (ADDR(.bss))
+    LONG (SIZEOF(.bss) / 4)
+    __zero_table_end__ = .;
+
+    *(.rodata*)
+
+    . = ALIGN(32);
+    /* End address must be the last address in the region, therefore, -1. */
+    __unprivileged_flash_end__ = . - 1;
+  } > FLASH
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  /**
+   * Location counter can end up 2byte aligned with narrow Thumb code but
+   * __etext is assumed by startup code to be the LMA of a section in RAM
+   * which must be 4byte aligned
+   */
+  __etext = ALIGN (4);
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+
+    /* Privileged data - It needs to be 32 byte aligned to satisfy MPU requirements. */
+    . = ALIGN(32);
+    __privileged_sram_start__ = .;
+    *(privileged_data)
+    . = ALIGN(32);
+    /* End address must be the last address in the region, therefore, -1. */
+    __privileged_sram_end__ = . - 1;
+
+    *(vtable)
+    *(.data)
+    *(.data.*)
+
+    . = ALIGN(4);
+    *(tasks_share)
+    /* All data end */
+
+    __data_end__ = .;
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss.*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM AT > RAM
+
+  .heap (COPY) :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    . = . + __HEAP_SIZE;
+    . = ALIGN(8);
+    __HeapLimit = .;
+  } > RAM
+  PROVIDE(__RAM_segment_used_end__ = __HeapLimit);
+
+  .stack (ORIGIN(RAM) + LENGTH(RAM) - __STACK_SIZE) (COPY) :
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    . = . + __STACK_SIZE;
+    . = ALIGN(8);
+    __StackTop = .;
+  } > RAM
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/gcc_toolchain.cmake
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/gcc_toolchain.cmake
@@ -1,0 +1,15 @@
+# Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: MIT
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR=cortex-m85)
+
+set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
+
+set(CMAKE_C_STANDARD 11)
+
+set(CMAKE_C_FLAGS "-march=armv8.1-m.main+fp.dp+mve.fp -mfloat-abi=hard -mthumb -Wall")
+set(CMAKE_ASM_FLAGS "-march=armv8.1-m.main+fp.dp+mve.fp -mfloat-abi=hard -mthumb")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-warn-rwx-segment -specs=nano.specs -specs=nosys.specs")

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/main.c
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/main.c
@@ -1,0 +1,251 @@
+/* Copyright 2023-2024 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "bsp_serial.h"
+
+extern uint32_t __unprivileged_functions_start__[];
+uint32_t * pulRecoveryAddress = NULL;
+
+/**
+ * @brief Memory region used to track Memory Fault intentionally caused by the
+ * Pxn task.
+ *
+ * Pxn task sets ucPxnTaskFaultTracker[ 0 ] to 1 before executing from
+ * Privileged eXecute Never memory region resulting in Memory Fault where the fault handler
+ * checks ucPxnTaskFaultTracker[ 0 ] to see if this is an expected fault. We
+ * recover gracefully from an expected fault by jumping to the next statement
+ * after the Privileged eXecute Never marked memory region.
+ *
+ * @note We are declaring a region of 32 bytes even though we need only one. The
+ * reason is that the size of an MPU region must be a multiple of 32 bytes.
+ */
+static volatile uint8_t ucPxnTaskFaultTracker[ 32 ] __attribute__( ( aligned( 32 ) ) ) = { 0 };
+
+static void prvUnprivilegedFunction ( void ) __attribute__( ( section( "unprivileged_functions" ) ) );
+
+portDONT_DISCARD static void prvHandleMemoryFault( uint32_t * pulFaultStackAddress );
+
+void vAssertCalled( const char * pcFile,
+                    unsigned long ulLine )
+{
+    printf( "ASSERT failed! file %s:%lu, \r\n", pcFile, ulLine );
+
+    taskENTER_CRITICAL();
+    {
+        volatile unsigned long looping = 0;
+
+        /* Use the debugger to set ul to a non-zero value in order to step out
+         *      of this function to determine why it was called. */
+        while( looping == 0LU )
+        {
+            portNOP();
+        }
+    }
+    taskEXIT_CRITICAL();
+}
+
+/* This function is assumed to be a naked function without any stack manipulation. */
+static void prvUnprivilegedFunction ( void )
+{
+    __asm volatile
+    (
+        " add r0, 1,2  \n"
+    );
+}
+
+static void prvPxnTask( void * arg )
+{
+    /* Prevent the compiler warning about the unused parameter. */
+    ( void ) arg;
+
+    pulRecoveryAddress = &&RECOVERY_LABEL;
+
+    for ( ;; )
+    {
+        /* This task performs the following sequence:
+         *
+         * 1. Set ucPxnTaskFaultTracker[ 0 ] to 1 before executing from
+         *    the Privileged eXecute Never MPU region. Since this task is a privileged
+         *    task, the execution operation would result in a Memory Fault.
+         *    Setting ucPxnTaskFaultTracker[ 0 ] to 1 tells the Memory Fault
+         *    Handler that this is an expected fault. The handler recovers from
+         *    the expected fault gracefully by jumping to the next statement
+         *    after the 32 bit Privileged eXecute Never MPU region.
+         *
+         * 2. Call the prvUnprivilegedFunction() which is located inside the Privileged eXecute Never
+         *    MPU region resulting in a memory fault.
+         *
+         * 3. Ensure that the execution from  the Privileged eXecute Never
+         *    MPU region did generate MemFault and the fault handler did
+         *    clear the ucPxnTaskFaultTracker[ 0 ].
+         */
+        ucPxnTaskFaultTracker[ 0 ] = 1;
+        prvUnprivilegedFunction();
+        RECOVERY_LABEL:
+            configASSERT( ucPxnTaskFaultTracker[ 0 ] == 0 );
+        printf(" Exception recovered gracefully \r\n");
+        vTaskDelay(1000);
+    }
+}
+
+int main()
+{
+    bsp_serial_init();
+
+    static StackType_t xPxnTaskStack[ configMINIMAL_STACK_SIZE ] __attribute__( ( aligned( 32 ) ) );
+
+    TaskParameters_t xPxnTaskParameters =
+    {
+        .pvTaskCode     = prvPxnTask,
+        .pcName         = NULL,
+        .usStackDepth   = configMINIMAL_STACK_SIZE,
+        .pvParameters   = NULL,
+        .uxPriority     = ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ),
+        .puxStackBuffer = xPxnTaskStack,
+        .xRegions       =   {
+                                { ( void * ) (__unprivileged_functions_start__),   32, tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER                 },
+                                { ( void * ) ucPxnTaskFaultTracker,                32, tskMPU_REGION_READ_WRITE | tskMPU_REGION_EXECUTE_NEVER },
+                                { 0,                                               0,  0                                                      },
+                            }
+    };
+
+    if(xTaskCreateRestricted( &( xPxnTaskParameters ), NULL ) == pdFAIL)
+    {
+        return EXIT_FAILURE;
+    }
+
+    vTaskStartScheduler();
+
+    /* If all is well, the scheduler will now be running, and the following
+     * line will never be reached.  If the following line does execute, then
+     * there was insufficient FreeRTOS heap memory available for the idle and/or
+     * timer tasks	to be created.  See the memory management section on the
+     * FreeRTOS web site for more details.  NOTE: This demo uses static allocation
+     * for the idle and timer tasks so this line should never execute. */
+    for( ; ; )
+    {
+    }
+
+    /* Code execution will never reach this line */
+    return EXIT_FAILURE;
+}
+
+/**
+ * Dummy implementation of the callback function vApplicationStackOverflowHook().
+ */
+#if ( configCHECK_FOR_STACK_OVERFLOW > 0 )
+    void vApplicationStackOverflowHook( TaskHandle_t xTask,
+                                        char * pcTaskName )
+    {
+        ( void ) xTask;
+        ( void ) pcTaskName;
+
+        /* Assert when stack overflow is enabled but no application defined function exists */
+        configASSERT( 0 );
+    }
+#endif
+
+/*---------------------------------------------------------------------------*/
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+/*
+ * vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ */
+    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                        StackType_t ** ppxIdleTaskStackBuffer,
+                                        uint32_t * pulIdleTaskStackSize )
+    {
+        /* Idle task control block and stack */
+        static StaticTask_t Idle_TCB;
+        static StackType_t Idle_Stack[ configMINIMAL_STACK_SIZE ];
+
+        *ppxIdleTaskTCBBuffer = &Idle_TCB;
+        *ppxIdleTaskStackBuffer = &Idle_Stack[ 0 ];
+        *pulIdleTaskStackSize = ( uint32_t ) configMINIMAL_STACK_SIZE;
+    }
+
+/*
+ * vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ */
+    void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                         StackType_t ** ppxTimerTaskStackBuffer,
+                                         uint32_t * pulTimerTaskStackSize )
+    {
+        /* Timer task control block and stack */
+        static StaticTask_t Timer_TCB;
+        static StackType_t Timer_Stack[ configTIMER_TASK_STACK_DEPTH ];
+
+        *ppxTimerTaskTCBBuffer = &Timer_TCB;
+        *ppxTimerTaskStackBuffer = &Timer_Stack[ 0 ];
+        *pulTimerTaskStackSize = ( uint32_t ) configTIMER_TASK_STACK_DEPTH;
+    }
+#endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+
+void vApplicationTickHook( void )
+{
+    /* Provide a stub for this function. */
+}
+
+void vApplicationIdleHook( void )
+{
+    const TickType_t xKitHitCheckPeriod = pdMS_TO_TICKS( 1000UL );
+    static TickType_t xTimeNow, xLastTimeCheck = 0;
+
+    if( ( xTimeNow - xLastTimeCheck ) > xKitHitCheckPeriod )
+    {
+        xLastTimeCheck = xTimeNow;
+    }
+
+    /* Exit. Just a stub. */
+}
+
+void vApplicationMallocFailedHook( void )
+{
+    /* Provide a stub for this function. */
+}
+
+portDONT_DISCARD static void prvHandleMemoryFault( uint32_t * pulFaultStackAddress )
+{
+    /* Is this an expected fault? */
+    if( ucPxnTaskFaultTracker[ 0 ] == 1 )
+    {
+        /* Save the new program counter (recovery address) on the stack. */
+        pulFaultStackAddress[ 6 ] = ( uint32_t ) pulRecoveryAddress;
+
+        /* Mark the fault as handled. */
+        ucPxnTaskFaultTracker[ 0 ] = 0;
+    }
+    else
+    {
+        /* This is an unexpected fault - loop forever. */
+        for( ; ; )
+        {
+        }
+    }
+}
+
+void MemManage_Handler( void ) __attribute__((naked));
+void MemManage_Handler( void )
+{
+	__asm volatile
+	(
+	    ".align 8					                        \n"
+		" tst lr, #4										\n"
+		" ite eq											\n"
+		" mrseq r0, msp										\n"
+		" mrsne r0, psp										\n"
+		" ldr r2, =prvHandleMemoryFault					    \n"
+		" bx r2												\n"
+	);
+}

--- a/CORTEX_M85_MPU_PXN_FVP_GCC/run.sh
+++ b/CORTEX_M85_MPU_PXN_FVP_GCC/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Copyright 2024 Arm Limited and/or its affiliates
+# <open-source-office@arm.com>
+# SPDX-License-Identifier: MIT
+
+FVP_Corstone_SSE-310 -a cpu0*=./build/cortex_m85_mpu_pxn_fvp_example.axf -C mps3_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps3_board.hostbridge.userNetworking=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file="-" -C mps3_board.uart0.unbuffered_output=1 --stat -C mps3_board.DISABLE_GATING=1


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
A new MPU region attribute **Privileged eXecute Never (PXN)** is introduced in Armv8.1-M architecture, where if an MPU region has PXN attribute set and the processor attempts to execute the code inside with privileged level, the Memory Management Fault exception would be triggered, with **IACCVIOL** bit in MemManage Fault State Register set to 1. The PXN feature allows privileged software to ensure specific application tasks (threads) to execute in unprivileged level only. For example, a hacker cannot use stack corruption in a privileged peripheral handler to branch into unprivileged codes and execute them with privileged level.
Please refer to the Security related enhancements section in Introduction to Armv8.1-M architecture white paper document for more information.

This example demonstrates how the new MPU region attribute **Privileged eXecute Never (PXN)** introduced in Armv8.1-M architecture can be used on Cortex-M85 MCU. The example is based on **Corstone-310** Ecosystem Fixed Virtual Platform (Arm Cortex-M85 CPU and Ethos-U55 NPU).

The example simulates a privileged task trying to execute an instruction from an MPU region with **Privileged eXecute Never (PXN)** attribute set, this result in a memory fault exception which recovers gracefully after clearing an entry in a fault tracker buffer indicating that the exception was triggered and recovered.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
