### PR TITLE
Added demo support for dsPIC33A Device

### DIFF
--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/FreeRTOSConfig.h
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/FreeRTOSConfig.h
@@ -1,0 +1,86 @@
+/*
+ * FreeRTOS Kernel V10.5.1
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "xc.h"
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE. 
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+#define configUSE_PREEMPTION			1
+#define configUSE_IDLE_HOOK				1
+#define configUSE_TICK_HOOK				0
+#define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#define configCPU_CLOCK_HZ				( ( unsigned long ) 25000000 )  /* Fosc / 2 */
+#define configMAX_PRIORITIES			( 4 )
+#define configMINIMAL_STACK_SIZE		( 200 )
+#define configTOTAL_HEAP_SIZE			( ( size_t ) 10000 )
+#define configMAX_TASK_NAME_LEN			( 4 )
+#define configUSE_TRACE_FACILITY		0
+#define configUSE_16_BIT_TICKS			0
+#define configIDLE_SHOULD_YIELD			1
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 		1
+#define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
+
+#define configTIMER_TASK_STACK_DEPTH            configMINIMAL_STACK_SIZE
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+
+#define INCLUDE_vTaskPrioritySet		1
+#define INCLUDE_uxTaskPriorityGet		0
+#define INCLUDE_vTaskDelete				0
+#define INCLUDE_vTaskCleanUpResources	0
+#define INCLUDE_vTaskSuspend			1
+#define INCLUDE_vTaskDelayUntil			1
+#define INCLUDE_vTaskDelay				1
+
+#define portHAS_STACK_OVERFLOW_CHECKING 1
+#define configSUPPORT_STATIC_ALLOCATION 1
+#define taskYIELD()              portYIELD_WITHIN_API()
+
+#define portPOINTER_SIZE_TYPE int
+#define LED_START    8
+
+
+#define configKERNEL_INTERRUPT_PRIORITY	0x01
+#define pdMS_TO_TICKS( xTimeInMs ) ( ( TickType_t) ( ( ( TickType_t) ( xTimeInMs ) )) * ((( TickType_t) configTICK_RATE_HZ ) / ( TickType_t) 1000 ))
+
+#endif /* FREERTOS_CONFIG_H */

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/ParTest/ParTest.c
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/ParTest/ParTest.c
@@ -1,0 +1,108 @@
+/*
+ * FreeRTOS V202212.01
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+
+/* Demo app includes. */
+#include "partest.h"
+
+#define ptOUTPUT 	0
+#define ptALL_OFF	0
+#define RED_LED_OFFSET 4
+
+
+unsigned portBASE_TYPE uxOutput;
+
+/*-----------------------------------------------------------
+ * Simple parallel port IO routines.
+ *-----------------------------------------------------------*/
+
+void vParTestInitialise( void )
+{
+    TRISA = ptOUTPUT;
+    TRISC = ptOUTPUT;
+    TRISDbits.TRISD0 = ptALL_OFF;
+    TRISDbits.TRISD2 = ptALL_OFF;
+	PORTC = ptALL_OFF;
+    TRISA = ptALL_OFF;
+	uxOutput = ptALL_OFF;
+}
+/*-----------------------------------------------------------*/
+
+void vParTestSetLED( unsigned portBASE_TYPE uxLED, signed portBASE_TYPE xValue )
+{
+    unsigned portBASE_TYPE uxLEDBit;
+
+	/* Which port A bit is being modified? */
+	uxLEDBit = LED_START << uxLED;
+
+	if( xValue )
+	{
+		/* Turn the LED on. */
+		portENTER_CRITICAL();
+		{
+			uxOutput |= uxLEDBit;
+			PORTC = (PORTC & RED_LED_OFFSET) | uxOutput;
+		}
+		portEXIT_CRITICAL();
+	}
+	else
+	{
+		/* Turn the LED off. */
+		portENTER_CRITICAL();
+		{
+			uxOutput &= ~uxLEDBit;
+			PORTC = (PORTC & RED_LED_OFFSET) | uxOutput;
+		}
+		portEXIT_CRITICAL();
+	}
+}
+/*-----------------------------------------------------------*/
+
+void vParTestToggleLED( unsigned portBASE_TYPE uxLED )
+{
+    unsigned portBASE_TYPE uxLEDBit;
+
+	uxLEDBit = LED_START << uxLED;
+	portENTER_CRITICAL();
+	{
+		/* If the LED is already on - turn it off.  If the LED is already
+		off, turn it on. */
+		if( uxOutput & uxLEDBit )
+		{
+			uxOutput &= ~uxLEDBit;
+			PORTC = (PORTC & RED_LED_OFFSET) | uxOutput;;
+		}
+		else
+		{
+			uxOutput |= uxLEDBit;
+			PORTC = (PORTC & RED_LED_OFFSET) | uxOutput;
+		}
+	}
+	portEXIT_CRITICAL();
+}
+

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/README.md
@@ -1,12 +1,12 @@
 ![image](../../../images/microchip.jpg) 
 
-## dsPIC33F FreeRTOS Demo
+## dsPIC33A FreeRTOS Demo
 
 ## Summary
 
-This folder contains the freeRTOS demo for Microchip's dsPIC33FJ256GP710A device.
+This folder contains the freeRTOS demo for dsPIC33AK128MC106 device. 
 For this demo, MPLAB X and MPLAB XC-DSC are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
-The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
+The board to be used to run this demo is dsPIC33A Curiosity Platform Development Board.
 The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
@@ -39,9 +39,9 @@ http://www.freertos.org/FAQHelp.html
 
 ## Hardware Used
 
-- Explorer 16/32 Development Board (https://www.microchip.com/DM240001-2)
-- dsPIC33FJ256GP710A PIM (https://www.microchip.com/MA330011)
+- dsPIC33A Curiosity Platform Development Board (https://www.microchip.com/EV74H48A)
+- dsPIC33AK128MC106 DIM (https://www.microchip.com/EV02G02A)
 
 ## Hardware Setup
-- For UART communication task - short pins p49 and p50 on Jumper48 or Jumper49
+- For UART communication task - short pins p100 and p102 on Jumper J10.
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/Makefile
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/Makefile
@@ -1,0 +1,113 @@
+#
+#  There exist several targets which are by default empty and which can be 
+#  used for execution of your targets. These targets are usually executed 
+#  before and after some main targets. They are: 
+#
+#     .build-pre:              called before 'build' target
+#     .build-post:             called after 'build' target
+#     .clean-pre:              called before 'clean' target
+#     .clean-post:             called after 'clean' target
+#     .clobber-pre:            called before 'clobber' target
+#     .clobber-post:           called after 'clobber' target
+#     .all-pre:                called before 'all' target
+#     .all-post:               called after 'all' target
+#     .help-pre:               called before 'help' target
+#     .help-post:              called after 'help' target
+#
+#  Targets beginning with '.' are not intended to be called on their own.
+#
+#  Main targets can be executed directly, and they are:
+#  
+#     build                    build a specific configuration
+#     clean                    remove built files from a configuration
+#     clobber                  remove all built files
+#     all                      build all configurations
+#     help                     print help mesage
+#  
+#  Targets .build-impl, .clean-impl, .clobber-impl, .all-impl, and
+#  .help-impl are implemented in nbproject/makefile-impl.mk.
+#
+#  Available make variables:
+#
+#     CND_BASEDIR                base directory for relative paths
+#     CND_DISTDIR                default top distribution directory (build artifacts)
+#     CND_BUILDDIR               default top build directory (object files, ...)
+#     CONF                       name of current configuration
+#     CND_ARTIFACT_DIR_${CONF}   directory of build artifact (current configuration)
+#     CND_ARTIFACT_NAME_${CONF}  name of build artifact (current configuration)
+#     CND_ARTIFACT_PATH_${CONF}  path to build artifact (current configuration)
+#     CND_PACKAGE_DIR_${CONF}    directory of package (current configuration)
+#     CND_PACKAGE_NAME_${CONF}   name of package (current configuration)
+#     CND_PACKAGE_PATH_${CONF}   path to package (current configuration)
+#
+# NOCDDL
+
+
+# Environment 
+MKDIR=mkdir
+CP=cp
+CCADMIN=CCadmin
+RANLIB=ranlib
+
+
+# build
+build: .build-post
+
+.build-pre:
+# Add your pre 'build' code here...
+
+.build-post: .build-impl
+# Add your post 'build' code here...
+
+
+# clean
+clean: .clean-post
+
+.clean-pre:
+# Add your pre 'clean' code here...
+# WARNING: the IDE does not call this target since it takes a long time to
+# simply run make. Instead, the IDE removes the configuration directories
+# under build and dist directly without calling make.
+# This target is left here so people can do a clean when running a clean
+# outside the IDE.
+
+.clean-post: .clean-impl
+# Add your post 'clean' code here...
+
+
+# clobber
+clobber: .clobber-post
+
+.clobber-pre:
+# Add your pre 'clobber' code here...
+
+.clobber-post: .clobber-impl
+# Add your post 'clobber' code here...
+
+
+# all
+all: .all-post
+
+.all-pre:
+# Add your pre 'all' code here...
+
+.all-post: .all-impl
+# Add your post 'all' code here...
+
+
+# help
+help: .help-post
+
+.help-pre:
+# Add your pre 'help' code here...
+
+.help-post: .help-impl
+# Add your post 'help' code here...
+
+
+
+# include project implementation makefile
+include nbproject/Makefile-impl.mk
+
+# include project make variables
+include nbproject/Makefile-variables.mk

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/configurations.xml
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/configurations.xml
@@ -1,0 +1,841 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configurationDescriptor version="65">
+  <logicalFolder name="root" displayName="root" projectFiles="true">
+    <logicalFolder name="HeaderFiles"
+                   displayName="Header Files"
+                   projectFiles="true">
+      <itemPath>../../../Source/include/semphr.h</itemPath>
+      <itemPath>../../../Source/include/task.h</itemPath>
+      <itemPath>../../../Source/include/croutine.h</itemPath>
+      <itemPath>../../../Source/include/queue.h</itemPath>
+      <itemPath>../FreeRTOSConfig.h</itemPath>
+      <itemPath>../../../Source/portable/MPLAB/dsPIC33A/portmacro.h</itemPath>
+    </logicalFolder>
+    <logicalFolder name="ExternalFiles"
+                   displayName="Important Files"
+                   projectFiles="true">
+      <itemPath>Makefile</itemPath>
+    </logicalFolder>
+    <logicalFolder name="LinkerScript"
+                   displayName="Linker Files"
+                   projectFiles="true">
+    </logicalFolder>
+    <logicalFolder name="SourceFiles"
+                   displayName="Source Files"
+                   projectFiles="true">
+      <logicalFolder name="FreeRTOS Source"
+                     displayName="FreeRTOS Source"
+                     projectFiles="true">
+        <itemPath>../../../Source/croutine.c</itemPath>
+        <itemPath>../../../Source/portable/MemMang/heap_1.c</itemPath>
+        <itemPath>../../../Source/list.c</itemPath>
+        <itemPath>../../../Source/queue.c</itemPath>
+        <itemPath>../../../Source/tasks.c</itemPath>
+        <itemPath>../../../Source/portable/MPLAB/dsPIC33A/port.c</itemPath>
+      </logicalFolder>
+      <logicalFolder name="Standard Demo Source"
+                     displayName="Standard Demo Source"
+                     projectFiles="true">
+        <itemPath>../../Common/Minimal/BlockQ.c</itemPath>
+        <itemPath>../../Common/Minimal/blocktim.c</itemPath>
+        <itemPath>../../Common/Minimal/comtest.c</itemPath>
+        <itemPath>../../Common/Minimal/crflash.c</itemPath>
+        <itemPath>../../Common/Minimal/integer.c</itemPath>
+      </logicalFolder>
+      <itemPath>../main.c</itemPath>
+      <itemPath>../ParTest/ParTest.c</itemPath>
+      <itemPath>../serial/serial.c</itemPath>
+      <itemPath>../traps.c</itemPath>
+    </logicalFolder>
+  </logicalFolder>
+  <sourceRootList>
+    <Elem>..</Elem>
+    <Elem>..\serial</Elem>
+    <Elem>..\..\..\Source\portable\MemMang</Elem>
+    <Elem>..\ParTest</Elem>
+    <Elem>..\..\..\Source\include</Elem>
+    <Elem>..\..\Common\Minimal</Elem>
+    <Elem>..\..\..\Source</Elem>
+    <Elem>..\..\..\Source\portable\MPLAB\dsPIC33A</Elem>
+  </sourceRootList>
+  <projectmakefile>Makefile</projectmakefile>
+  <confs>
+    <conf name="default" type="2">
+      <toolsSet>
+        <developmentServer>localhost</developmentServer>
+        <targetDevice>dsPIC33AK128MC106</targetDevice>
+        <targetHeader></targetHeader>
+        <targetPluginBoard></targetPluginBoard>
+        <platformTool>noID</platformTool>
+        <languageToolchain>XCDSC</languageToolchain>
+        <languageToolchainVersion>3.20</languageToolchainVersion>
+        <platform>3</platform>
+      </toolsSet>
+      <packs>
+        <pack name="dsPIC33AK-MC_DFP" vendor="Microchip" version="1.0.33"/>
+      </packs>
+      <ScriptingSettings>
+      </ScriptingSettings>
+      <compileType>
+        <linkerTool>
+          <linkerLibItems>
+          </linkerLibItems>
+        </linkerTool>
+        <archiverTool>
+        </archiverTool>
+        <loading>
+          <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
+          <alternateLoadableFile></alternateLoadableFile>
+        </loading>
+        <subordinates>
+        </subordinates>
+      </compileType>
+      <makeCustomizationType>
+        <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
+        <makeUseCleanTarget>false</makeUseCleanTarget>
+        <makeCustomizationPreStep></makeCustomizationPreStep>
+        <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
+        <makeCustomizationPostStep></makeCustomizationPostStep>
+        <makeCustomizationPutChecksumInUserID>false</makeCustomizationPutChecksumInUserID>
+        <makeCustomizationEnableLongLines>false</makeCustomizationEnableLongLines>
+        <makeCustomizationNormalizeHexFile>false</makeCustomizationNormalizeHexFile>
+      </makeCustomizationType>
+      <C30>
+        <property key="cast-align" value="false"/>
+        <property key="code-model" value="default"/>
+        <property key="const-model" value="default"/>
+        <property key="data-model" value="default"/>
+        <property key="disable-instruction-scheduling" value="false"/>
+        <property key="enable-all-warnings" value="true"/>
+        <property key="enable-ansi-std" value="false"/>
+        <property key="enable-ansi-warnings" value="false"/>
+        <property key="enable-fatal-warnings" value="false"/>
+        <property key="enable-large-arrays" value="false"/>
+        <property key="enable-omit-frame-pointer" value="false"/>
+        <property key="enable-procedural-abstraction" value="false"/>
+        <property key="enable-short-double" value="false"/>
+        <property key="enable-symbols" value="true"/>
+        <property key="enable-unroll-loops" value="false"/>
+        <property key="expand-pragma-config" value="false"/>
+        <property key="extra-include-directories"
+                  value="..;..\..\..\..\Source\include;..\..\..\..\include;..\..\..\Common\include;..\..\..\Source\include;..\..\..\include;..\..\Common\include;..\..\include;..\FileSystem;..\include;.;..\..\..\Source\portable\MPLAB\dsPIC33A"/>
+        <property key="isolate-each-function" value="true"/>
+        <property key="keep-inline" value="false"/>
+        <property key="oXC16gcc-cnsts-mauxflash" value="false"/>
+        <property key="oXC16gcc-data-sects" value="false"/>
+        <property key="oXC16gcc-errata" value=""/>
+        <property key="oXC16gcc-fillupper" value=""/>
+        <property key="oXC16gcc-large-aggregate" value="false"/>
+        <property key="oXC16gcc-mauxflash" value="false"/>
+        <property key="oXC16gcc-mpa-lvl" value=""/>
+        <property key="oXC16gcc-name-text-sec" value=""/>
+        <property key="oXC16gcc-near-chars" value="false"/>
+        <property key="oXC16gcc-no-isr-warn" value="false"/>
+        <property key="oXC16gcc-sfr-warn" value="false"/>
+        <property key="oXC16gcc-smar-io-lvl" value="1"/>
+        <property key="oXC16gcc-smart-io-fmt" value=""/>
+        <property key="optimization-level" value="1"/>
+        <property key="post-instruction-scheduling" value="default"/>
+        <property key="pre-instruction-scheduling" value="default"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="scalar-model" value="default"/>
+        <property key="use-cci" value="false"/>
+        <property key="use-iar" value="false"/>
+        <appendMe value="-fno-schedule-insns -fno-schedule-insns2"/>
+      </C30>
+      <C30-AR>
+        <property key="additional-options-chop-files" value="false"/>
+      </C30-AR>
+      <C30-AS>
+        <property key="assembler-symbols" value=""/>
+        <property key="expand-macros" value="false"/>
+        <property key="extra-include-directories-for-assembler" value="..;."/>
+        <property key="extra-include-directories-for-preprocessor"
+                  value="..;..\..\..\Source\portable\MPLAB\dsPIC33A;..\..\..\..\include;..\..\..\Common\include;..\..\..\Source\include;..\..\..\include;..\..\Common\include;..\..\include;..\FileSystem;..\include;."/>
+        <property key="false-conditionals" value="false"/>
+        <property key="keep-locals" value="false"/>
+        <property key="list-assembly" value="false"/>
+        <property key="list-section-info" value="false"/>
+        <property key="list-source" value="false"/>
+        <property key="list-symbols" value="false"/>
+        <property key="oXC16asm-extra-opts" value=""/>
+        <property key="oXC16asm-list-to-file" value="false"/>
+        <property key="omit-debug-dirs" value="false"/>
+        <property key="omit-forms" value="false"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="relax" value="false"/>
+        <property key="warning-level" value="emit-warnings"/>
+        <appendMe value="-g"/>
+      </C30-AS>
+      <C30-CO>
+        <property key="coverage-enable" value=""/>
+        <property key="stack-guidance" value="false"/>
+      </C30-CO>
+      <C30-LD>
+        <property key="additional-options-use-response-files" value="false"/>
+        <property key="boot-eeprom" value="no_eeprom"/>
+        <property key="boot-flash" value="no_flash"/>
+        <property key="boot-ram" value="no_ram"/>
+        <property key="boot-write-protect" value="no_write_protect"/>
+        <property key="enable-check-sections" value="false"/>
+        <property key="enable-data-init" value="true"/>
+        <property key="enable-default-isr" value="true"/>
+        <property key="enable-handles" value="true"/>
+        <property key="enable-pack-data" value="true"/>
+        <property key="extra-lib-directories" value="..;."/>
+        <property key="fill-flash-options-addr" value=""/>
+        <property key="fill-flash-options-const" value=""/>
+        <property key="fill-flash-options-how" value="0"/>
+        <property key="fill-flash-options-inc-const" value=""/>
+        <property key="fill-flash-options-increment" value=""/>
+        <property key="fill-flash-options-seq" value=""/>
+        <property key="fill-flash-options-what" value="0"/>
+        <property key="general-code-protect" value="no_code_protect"/>
+        <property key="general-write-protect" value="no_write_protect"/>
+        <property key="generate-cross-reference-file" value="false"/>
+        <property key="heap-size" value="0"/>
+        <property key="input-libraries" value=""/>
+        <property key="linker-stack" value="true"/>
+        <property key="linker-symbols" value=""/>
+        <property key="map-file" value=""/>
+        <property key="no-ivt" value="false"/>
+        <property key="oXC16ld-extra-opts" value=""/>
+        <property key="oXC16ld-fill-upper" value="0"/>
+        <property key="oXC16ld-force-link" value="false"/>
+        <property key="oXC16ld-no-smart-io" value="false"/>
+        <property key="oXC16ld-nostdlib" value="false"/>
+        <property key="oXC16ld-stackguard" value="16"/>
+        <property key="preprocessor-macros" value=""/>
+        <property key="psv-override" value="false"/>
+        <property key="remove-unused-sections" value="true"/>
+        <property key="report-memory-usage" value="true"/>
+        <property key="secure-eeprom" value="no_eeprom"/>
+        <property key="secure-flash" value="no_flash"/>
+        <property key="secure-ram" value="no_ram"/>
+        <property key="secure-write-protect" value="no_write_protect"/>
+        <property key="stack-size" value="16"/>
+        <property key="symbol-stripping" value=""/>
+        <property key="trace-symbols" value=""/>
+        <property key="warn-section-align" value="false"/>
+      </C30-LD>
+      <C30Global>
+        <property key="combine-sourcefiles" value="false"/>
+        <property key="common-include-directories" value=""/>
+        <property key="dual-boot-partition" value="0"/>
+        <property key="fast-math" value="false"/>
+        <property key="generic-16-bit" value="false"/>
+        <property key="legacy-libc" value="true"/>
+        <property key="mpreserve-all" value="false"/>
+        <property key="oXC16glb-macros" value=""/>
+        <property key="omit-pack-options" value="1"/>
+        <property key="output-file-format" value="elf"/>
+        <property key="preserve-all" value="false"/>
+        <property key="preserve-file" value=""/>
+        <property key="relaxed-math" value="false"/>
+        <property key="save-temps" value="true"/>
+      </C30Global>
+      <ICD3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="false"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram" value="true"/>
+        <property key="memories.instruction.ram.end"
+                  value="${memories.instruction.ram.end.value}"/>
+        <property key="memories.instruction.ram.start"
+                  value="${memories.instruction.ram.start.value}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.end" value="0x2abff"/>
+        <property key="memories.programmemory.partition2" value="true"/>
+        <property key="memories.programmemory.partition2.end"
+                  value="${memories.programmemory.partition2.end.value}"/>
+        <property key="memories.programmemory.partition2.start"
+                  value="${memories.programmemory.partition2.start.value}"/>
+        <property key="memories.programmemory.start" value="0x0"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveprogramrange.end" value="0x2abff"/>
+        <property key="programoptions.preserveprogramrange.start" value="0x0"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.25"/>
+      </ICD3PlatformTool>
+      <ICD4Tool>
+        <property key="ADC1" value="true"/>
+        <property key="ADC2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="BISS1" value="true"/>
+        <property key="CCP 1" value="true"/>
+        <property key="CCP 2" value="true"/>
+        <property key="CCP 3" value="true"/>
+        <property key="CCP 4" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CLC" value="true"/>
+        <property key="CM1" value="true"/>
+        <property key="CM2" value="true"/>
+        <property key="CM3" value="true"/>
+        <property key="CM4" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DAC" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="FRZ" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="HPC" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="IOIM1" value="true"/>
+        <property key="IOIM2" value="true"/>
+        <property key="IOIM3" value="true"/>
+        <property key="IOIM4" value="true"/>
+        <property key="NVMCRC" value="true"/>
+        <property key="NVMECC" value="true"/>
+        <property key="PG1" value="true"/>
+        <property key="PG2" value="true"/>
+        <property key="PG3" value="true"/>
+        <property key="PG4" value="true"/>
+        <property key="PTG" value="true"/>
+        <property key="QEI1" value="true"/>
+        <property key="RAMXECC" value="true"/>
+        <property key="RAMYECC" value="true"/>
+        <property key="SENT1" value="true"/>
+        <property key="SENT2" value="true"/>
+        <property key="SPI1" value="true"/>
+        <property key="SPI2" value="true"/>
+        <property key="SPI3" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UpdateOptions"
+                  value="ToolFirmwareOption.UseLatest"/>
+        <property key="ToolFirmwareToolPack"
+                  value="Press to select which tool pack to use"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="communication.activationmode" value="nohv"/>
+        <property key="communication.interface"
+                  value="${communication.interface.default}"/>
+        <property key="communication.interface.jtag" value="2wire"/>
+        <property key="communication.speed" value="${communication.speed.default}"/>
+        <property key="debugoptions.debug-startup" value="Use system settings"/>
+        <property key="debugoptions.reset-behaviour" value="Use system settings"/>
+        <property key="debugoptions.simultaneous.debug" value="false"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="event.recorder.debugger.behavior" value="Running"/>
+        <property key="event.recorder.enabled" value="false"/>
+        <property key="event.recorder.scvd.files" value=""/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="lastid" value=""/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.exclude.configurationmemory" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="800000-81ffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.ledbrightness" value="5"/>
+        <property key="programoptions.pgcconfig" value="pull down"/>
+        <property key="programoptions.pgcresistor.value" value="4.7"/>
+        <property key="programoptions.pgdconfig" value="pull down"/>
+        <property key="programoptions.pgdresistor.value" value="4.7"/>
+        <property key="programoptions.pgmentry.voltage" value="low"/>
+        <property key="programoptions.pgmspeed" value="Med"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges"
+                  value="${memories.dataflash.default}"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.program.otpconfig" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.smart.program" value="When debugging only"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="toolpack.updateoptions"
+                  value="toolpack.updateoptions.uselatestoolpack"/>
+        <property key="toolpack.updateoptions.packversion"
+                  value="Press to select which tool pack to use"/>
+        <property key="voltagevalue" value="3.25"/>
+      </ICD4Tool>
+      <PICkit3PlatformTool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="debugoptions.debug-startup" value="Use system settings"/>
+        <property key="debugoptions.reset-behaviour" value="Use system settings"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="event.recorder.enabled" value="false"/>
+        <property key="event.recorder.scvd.files" value=""/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="lastid" value=""/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="0-7fffff"/>
+        <property key="poweroptions.powerenable" value="true"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmspeed" value="2"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges"
+                  value="${programoptions.preservedataflash.ranges}"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="voltagevalue" value="3.5"/>
+      </PICkit3PlatformTool>
+      <Tool>
+        <property key="ADC 1" value="true"/>
+        <property key="ADC 2" value="true"/>
+        <property key="ADC1" value="true"/>
+        <property key="ADC2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="BISS1" value="true"/>
+        <property key="CCP 1" value="true"/>
+        <property key="CCP 2" value="true"/>
+        <property key="CCP 3" value="true"/>
+        <property key="CCP 4" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CLC" value="true"/>
+        <property key="CM1" value="true"/>
+        <property key="CM2" value="true"/>
+        <property key="CM3" value="true"/>
+        <property key="CM4" value="true"/>
+        <property key="COMPARATOR" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DAC" value="true"/>
+        <property key="DCI" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="FRZ" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="HPC" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="INPUT CAPTURE 1" value="true"/>
+        <property key="INPUT CAPTURE 10" value="true"/>
+        <property key="INPUT CAPTURE 11" value="true"/>
+        <property key="INPUT CAPTURE 12" value="true"/>
+        <property key="INPUT CAPTURE 13" value="true"/>
+        <property key="INPUT CAPTURE 14" value="true"/>
+        <property key="INPUT CAPTURE 15" value="true"/>
+        <property key="INPUT CAPTURE 16" value="true"/>
+        <property key="INPUT CAPTURE 2" value="true"/>
+        <property key="INPUT CAPTURE 3" value="true"/>
+        <property key="INPUT CAPTURE 4" value="true"/>
+        <property key="INPUT CAPTURE 5" value="true"/>
+        <property key="INPUT CAPTURE 6" value="true"/>
+        <property key="INPUT CAPTURE 7" value="true"/>
+        <property key="INPUT CAPTURE 8" value="true"/>
+        <property key="INPUT CAPTURE 9" value="true"/>
+        <property key="IOIM1" value="true"/>
+        <property key="IOIM2" value="true"/>
+        <property key="IOIM3" value="true"/>
+        <property key="IOIM4" value="true"/>
+        <property key="NVMCRC" value="true"/>
+        <property key="NVMECC" value="true"/>
+        <property key="OUTPUT COMPARE 1" value="true"/>
+        <property key="OUTPUT COMPARE 10" value="true"/>
+        <property key="OUTPUT COMPARE 11" value="true"/>
+        <property key="OUTPUT COMPARE 12" value="true"/>
+        <property key="OUTPUT COMPARE 13" value="true"/>
+        <property key="OUTPUT COMPARE 14" value="true"/>
+        <property key="OUTPUT COMPARE 15" value="true"/>
+        <property key="OUTPUT COMPARE 16" value="true"/>
+        <property key="OUTPUT COMPARE 2" value="true"/>
+        <property key="OUTPUT COMPARE 3" value="true"/>
+        <property key="OUTPUT COMPARE 4" value="true"/>
+        <property key="OUTPUT COMPARE 5" value="true"/>
+        <property key="OUTPUT COMPARE 6" value="true"/>
+        <property key="OUTPUT COMPARE 7" value="true"/>
+        <property key="OUTPUT COMPARE 8" value="true"/>
+        <property key="OUTPUT COMPARE 9" value="true"/>
+        <property key="PARALLEL MASTER/SLAVE PORT" value="true"/>
+        <property key="PG1" value="true"/>
+        <property key="PG2" value="true"/>
+        <property key="PG3" value="true"/>
+        <property key="PG4" value="true"/>
+        <property key="PTG" value="true"/>
+        <property key="PWM" value="true"/>
+        <property key="QEI1" value="true"/>
+        <property key="RAMXECC" value="true"/>
+        <property key="RAMYECC" value="true"/>
+        <property key="REAL TIME CLOCK AND CALENDAR" value="true"/>
+        <property key="SENT1" value="true"/>
+        <property key="SENT2" value="true"/>
+        <property key="SPI 1" value="true"/>
+        <property key="SPI 2" value="true"/>
+        <property key="SPI 3" value="true"/>
+        <property key="SPI 4" value="true"/>
+        <property key="SPI1" value="true"/>
+        <property key="SPI2" value="true"/>
+        <property key="SPI3" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="TIMER2" value="true"/>
+        <property key="TIMER3" value="true"/>
+        <property key="TIMER4" value="true"/>
+        <property key="TIMER5" value="true"/>
+        <property key="TIMER6" value="true"/>
+        <property key="TIMER7" value="true"/>
+        <property key="TIMER8" value="true"/>
+        <property key="TIMER9" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UpdateOptions"
+                  value="ToolFirmwareOption.UseLatest"/>
+        <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
+        <property key="ToolFirmwareToolPack"
+                  value="Press to select which tool pack to use"/>
+        <property key="UART 1" value="true"/>
+        <property key="UART 2" value="true"/>
+        <property key="UART 3" value="true"/>
+        <property key="UART 4" value="true"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="USB" value="true"/>
+        <property key="communication.activationmode" value="nohv"/>
+        <property key="communication.interface" value=""/>
+        <property key="communication.interface.jtag" value="2wire"/>
+        <property key="communication.speed" value="${communication.speed.default}"/>
+        <property key="debugoptions.debug-startup" value="Use system settings"/>
+        <property key="debugoptions.reset-behaviour" value="Use system settings"/>
+        <property key="debugoptions.simultaneous.debug" value="false"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="event.recorder.debugger.behavior" value="Running"/>
+        <property key="event.recorder.enabled" value="false"/>
+        <property key="event.recorder.scvd.files" value=""/>
+        <property key="freeze.timers" value="false"/>
+        <property key="hwtoolclock.frcindebug" value="false"/>
+        <property key="lastid" value=""/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.exclude.configurationmemory" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="800000-81ffff"/>
+        <property key="poweroptions.powerenable" value="false"/>
+        <property key="programmerToGoFilePath"
+                  value="D:/MCU16CE/pic24-dspic33-freertos-demo/pic24-dspic33-freertos-demo/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/debug/default/dspic33a-freertos-demo_ptg"/>
+        <property key="programmertogo.imagename" value=""/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.ledbrightness" value="5"/>
+        <property key="programoptions.pgcconfig" value="pull down"/>
+        <property key="programoptions.pgcresistor.value" value="4.7"/>
+        <property key="programoptions.pgdconfig" value="pull down"/>
+        <property key="programoptions.pgdresistor.value" value="4.7"/>
+        <property key="programoptions.pgmentry.voltage" value="low"/>
+        <property key="programoptions.pgmspeed" value="Min"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges"
+                  value="${memories.dataflash.default}"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.program.otpconfig" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.smart.program" value="When debugging only"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="programoptions.usehighvoltageonmclr" value="false"/>
+        <property key="programoptions.uselvpprogramming" value="false"/>
+        <property key="toolpack.updateoptions"
+                  value="toolpack.updateoptions.specifictoolpack"/>
+        <property key="toolpack.updateoptions.packversion" value="1.14.1168"/>
+        <property key="voltagevalue" value="3.25"/>
+      </Tool>
+      <pkob4hybrid>
+        <property key="ADC1" value="true"/>
+        <property key="ADC2" value="true"/>
+        <property key="AutoSelectMemRanges" value="auto"/>
+        <property key="BISS1" value="true"/>
+        <property key="CCP 1" value="true"/>
+        <property key="CCP 2" value="true"/>
+        <property key="CCP 3" value="true"/>
+        <property key="CCP 4" value="true"/>
+        <property key="CHANGE NOTICE A" value="true"/>
+        <property key="CHANGE NOTICE B" value="true"/>
+        <property key="CHANGE NOTICE C" value="true"/>
+        <property key="CHANGE NOTICE D" value="true"/>
+        <property key="CLC" value="true"/>
+        <property key="CM1" value="true"/>
+        <property key="CM2" value="true"/>
+        <property key="CM3" value="true"/>
+        <property key="CM4" value="true"/>
+        <property key="CRC" value="true"/>
+        <property key="DAC" value="true"/>
+        <property key="DMA" value="true"/>
+        <property key="FRZ" value="true"/>
+        <property key="Freeze All Other Peripherals" value="true"/>
+        <property key="HPC" value="true"/>
+        <property key="I2C1" value="true"/>
+        <property key="I2C2" value="true"/>
+        <property key="IOIM1" value="true"/>
+        <property key="IOIM2" value="true"/>
+        <property key="IOIM3" value="true"/>
+        <property key="IOIM4" value="true"/>
+        <property key="NVMCRC" value="true"/>
+        <property key="NVMECC" value="true"/>
+        <property key="PG1" value="true"/>
+        <property key="PG2" value="true"/>
+        <property key="PG3" value="true"/>
+        <property key="PG4" value="true"/>
+        <property key="PTG" value="true"/>
+        <property key="QEI1" value="true"/>
+        <property key="RAMXECC" value="true"/>
+        <property key="RAMYECC" value="true"/>
+        <property key="SENT1" value="true"/>
+        <property key="SENT2" value="true"/>
+        <property key="SPI1" value="true"/>
+        <property key="SPI2" value="true"/>
+        <property key="SPI3" value="true"/>
+        <property key="SecureSegment.SegmentProgramming" value="FullChipProgramming"/>
+        <property key="TIMER1" value="true"/>
+        <property key="ToolFirmwareFilePath"
+                  value="Press to browse for a specific firmware version"/>
+        <property key="ToolFirmwareOption.UpdateOptions"
+                  value="ToolFirmwareOption.UseLatest"/>
+        <property key="ToolFirmwareToolPack"
+                  value="Press to select which tool pack to use"/>
+        <property key="UART1" value="true"/>
+        <property key="UART2" value="true"/>
+        <property key="UART3" value="true"/>
+        <property key="communication.interface" value=""/>
+        <property key="communication.interface.jtag" value="2wire"/>
+        <property key="communication.speed" value="${communication.speed.default}"/>
+        <property key="debugoptions.debug-startup" value="Use system settings"/>
+        <property key="debugoptions.reset-behaviour" value="Use system settings"/>
+        <property key="debugoptions.simultaneous.debug" value="false"/>
+        <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="event.recorder.debugger.behavior" value="Running"/>
+        <property key="event.recorder.enabled" value="false"/>
+        <property key="event.recorder.scvd.files" value=""/>
+        <property key="freeze.timers" value="false"/>
+        <property key="lastid" value=""/>
+        <property key="memories.aux" value="false"/>
+        <property key="memories.bootflash" value="true"/>
+        <property key="memories.configurationmemory" value="true"/>
+        <property key="memories.configurationmemory2" value="true"/>
+        <property key="memories.dataflash" value="true"/>
+        <property key="memories.eeprom" value="true"/>
+        <property key="memories.exclude.configurationmemory" value="true"/>
+        <property key="memories.flashdata" value="true"/>
+        <property key="memories.id" value="true"/>
+        <property key="memories.instruction.ram.ranges"
+                  value="${memories.instruction.ram.ranges}"/>
+        <property key="memories.programmemory" value="true"/>
+        <property key="memories.programmemory.ranges" value="800000-81ffff"/>
+        <property key="programoptions.donoteraseauxmem" value="false"/>
+        <property key="programoptions.eraseb4program" value="true"/>
+        <property key="programoptions.pgmentry.voltage" value="low"/>
+        <property key="programoptions.pgmspeed" value="Min"/>
+        <property key="programoptions.preservedataflash" value="false"/>
+        <property key="programoptions.preservedataflash.ranges"
+                  value="${memories.dataflash.default}"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom.ranges" value=""/>
+        <property key="programoptions.preserveprogram.ranges" value=""/>
+        <property key="programoptions.preserveprogramrange" value="false"/>
+        <property key="programoptions.preserveuserid" value="false"/>
+        <property key="programoptions.program.otpconfig" value="false"/>
+        <property key="programoptions.programcalmem" value="false"/>
+        <property key="programoptions.programuserotp" value="false"/>
+        <property key="programoptions.smart.program" value="When debugging only"/>
+        <property key="programoptions.testmodeentrymethod" value="VDDFirst"/>
+        <property key="toolpack.updateoptions"
+                  value="toolpack.updateoptions.specifictoolpack"/>
+        <property key="toolpack.updateoptions.packversion" value="1.14.1168"/>
+      </pkob4hybrid>
+    </conf>
+  </confs>
+</configurationDescriptor>

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/project.xml
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/project.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>com.microchip.mplab.nbide.embedded.makeproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/make-project/1">
+            <name>dspic33a-freertos-demo</name>
+            <creation-uuid>35a98026-c295-4ad8-be63-863fde1be90c</creation-uuid>
+            <make-project-type>0</make-project-type>
+            <c-extensions>c</c-extensions>
+            <cpp-extensions/>
+            <header-extensions>h</header-extensions>
+            <asminc-extensions/>
+            <sourceEncoding>ISO-8859-1</sourceEncoding>
+            <make-dep-projects/>
+            <sourceRootList>
+                <sourceRootElem>..</sourceRootElem>
+                <sourceRootElem>..\serial</sourceRootElem>
+                <sourceRootElem>..\..\..\Source\portable\MemMang</sourceRootElem>
+                <sourceRootElem>..\ParTest</sourceRootElem>
+                <sourceRootElem>..\..\..\Source\include</sourceRootElem>
+                <sourceRootElem>..\..\Common\Minimal</sourceRootElem>
+                <sourceRootElem>..\..\..\Source</sourceRootElem>
+                <sourceRootElem>..\..\..\Source\portable\MPLAB\dsPIC33A</sourceRootElem>
+            </sourceRootList>
+            <confList>
+                <confElem>
+                    <name>default</name>
+                    <type>2</type>
+                </confElem>
+            </confList>
+            <formatting>
+                <project-formatting-style>false</project-formatting-style>
+            </formatting>
+        </data>
+    </configuration>
+</project>

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/serial/serial.c
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/serial/serial.c
@@ -1,0 +1,240 @@
+/*
+ * FreeRTOS V202212.01
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+/* BASIC INTERRUPT DRIVEN SERIAL PORT DRIVER. 
+
+NOTE:  This driver is primarily to test the scheduler functionality.  It does
+not effectively use the buffers or DMA and is therefore not intended to be
+an example of an efficient driver. */
+
+/* Standard include file. */
+#include <stdlib.h>
+
+/* Scheduler include files. */
+#include "FreeRTOS.h"
+
+#include "queue.h"
+#include "task.h"
+
+/* Demo app include files. */
+#include "serial.h"
+
+/* Hardware setup. */
+#define serOUTPUT						0
+#define serINPUT						1
+#define serLOW_SPEED					0
+#define serONE_STOP_BIT					0
+#define serEIGHT_DATA_BITS_NO_PARITY	0
+#define serNORMAL_IDLE_STATE			0
+#define serAUTO_BAUD_OFF				0
+#define serLOOPBACK_OFF					0
+#define serWAKE_UP_DISABLE				0
+#define serNO_HARDWARE_FLOW_CONTROL		0
+#define serSTANDARD_IO					0
+#define serNO_IRDA						0
+#define serCONTINUE_IN_IDLE_MODE		0
+#define serUART_ENABLED					1
+#define serINTERRUPT_ON_SINGLE_CHAR		0
+#define serTX_ENABLE					1
+#define serRX_ENABLE					1
+#define serINTERRUPT_ENABLE				1
+#define serINTERRUPT_DISABLE			0
+#define serCLEAR_FLAG					0
+#define serSET_FLAG						1
+
+
+/* The queues used to communicate between tasks and ISR's. */
+static QueueHandle_t xRxedChars; 
+static QueueHandle_t xCharsForTx; 
+
+static portBASE_TYPE xTxHasEnded;
+/*-----------------------------------------------------------*/
+
+xComPortHandle xSerialPortInitMinimal( unsigned long ulWantedBaud, unsigned portBASE_TYPE uxQueueLength )
+{
+    char cChar;
+    ANSELD = 0x00;
+	/* Create the queues used by the com test task. */
+	xRxedChars = xQueueCreate( uxQueueLength, ( portBASE_TYPE ) sizeof( signed char ) );
+	xCharsForTx = xQueueCreate( uxQueueLength, ( portBASE_TYPE ) sizeof( signed char ) );
+    
+    //PPS Mapping
+#if defined (__dsPIC33EP512MU810__)
+    RPOR9bits.RP101R = 3;   //RF5 as U2TX
+    _U2RXR = 100;           //RF4 as U2RX
+#elif defined (__dsPIC33AK128MC106__)
+    //RPINR9bits.U2RXR = 0x0017UL; //RB6->UART2:U2RX;
+    //RPOR5bits.RP24R = 0x000BUL;  //RB7->UART2:U2TX;
+    //Curiosity Board
+    RPINR9bits.U2RXR = 0x003BUL; //RD10->UART2:U2RX;
+    RPOR14bits.RP58R = 0x000BUL;  //RD9->UART2:U2TX;
+#endif    
+
+	/* Setup the UART. */
+	U2CONbits.BRGH		= serLOW_SPEED;
+	U2CONbits.STP	= serONE_STOP_BIT;
+	U2CONbits.ABDEN	= serAUTO_BAUD_OFF;
+	U2CONbits.WAKE		= serWAKE_UP_DISABLE;
+	U2CONbits.FLO		= serNO_HARDWARE_FLOW_CONTROL;
+	U2CONbits.MODE		= serNO_IRDA;
+	U2CONbits.SIDL	= serCONTINUE_IN_IDLE_MODE;
+	U2CONbits.ON	= serUART_ENABLED;
+
+	U2BRG = (unsigned short)(( (float)configCPU_CLOCK_HZ / ( (float)16 * (float)ulWantedBaud ) ) - (float)0.5);
+
+	U2STAbits.URXISEL	= serINTERRUPT_ON_SINGLE_CHAR;
+    U2CONbits.RXEN		= serRX_ENABLE;
+	U2CONbits.TXEN		= serTX_ENABLE;
+	U2CONbits.UTXINV	= serNORMAL_IDLE_STATE;
+	U2STAbits.TXWM	= serINTERRUPT_ON_SINGLE_CHAR;
+	U2STAbits.RXWM	= serINTERRUPT_ON_SINGLE_CHAR;
+    
+
+
+	/* It is assumed that this function is called prior to the scheduler being
+	started.  Therefore interrupts must not be allowed to occur yet as they
+	may attempt to perform a context switch. */
+	portDISABLE_INTERRUPTS();
+
+	IFS2bits.U2RXIF = serCLEAR_FLAG;
+	IFS2bits.U2TXIF = serCLEAR_FLAG;
+	IPC11bits.U2RXIP = configKERNEL_INTERRUPT_PRIORITY;
+	IPC11bits.U2TXIP = configKERNEL_INTERRUPT_PRIORITY;
+	IEC2bits.U2TXIE = serINTERRUPT_ENABLE;
+	IEC2bits.U2RXIE = serINTERRUPT_ENABLE;
+
+	/* Clear the Rx buffer. */
+	while( U2STAbits.RXBE == serCLEAR_FLAG )
+	{
+		cChar = U2RXB;
+	}
+
+	xTxHasEnded = pdTRUE;
+
+	return NULL;
+}
+/*-----------------------------------------------------------*/
+
+portBASE_TYPE xSerialGetChar( xComPortHandle pxPort, signed char *pcRxedChar, TickType_t xBlockTime )
+{
+	/* Only one port is supported. */
+	( void ) pxPort;
+
+	/* Get the next character from the buffer.  Return false if no characters
+	are available or arrive before xBlockTime expires. */
+	if( xQueueReceive( xRxedChars, pcRxedChar, xBlockTime ) )
+	{
+		return pdTRUE;
+	}
+	else
+	{
+		return pdFALSE;
+	}
+}
+/*-----------------------------------------------------------*/
+
+portBASE_TYPE xSerialPutChar( xComPortHandle pxPort, signed char cOutChar, TickType_t xBlockTime )
+{
+	/* Only one port is supported. */
+	( void ) pxPort;
+
+	/* Return false if after the block time there is no room on the Tx queue. */
+	if( xQueueSend( xCharsForTx, &cOutChar, xBlockTime ) != pdPASS )
+	{
+		return pdFAIL;
+	}
+
+	/* A critical section should not be required as xTxHasEnded will not be
+	written to by the ISR if it is already 0 (is this correct?). */
+	if( xTxHasEnded )
+	{
+		xTxHasEnded = pdFALSE;
+		IFS2bits.U2TXIF = serSET_FLAG;
+	}
+
+	return pdPASS;
+}
+/*-----------------------------------------------------------*/
+
+void vSerialClose( xComPortHandle xPort )
+{
+}
+/*-----------------------------------------------------------*/
+
+void __attribute__((__interrupt__, auto_psv)) _U2RXInterrupt( void )
+{
+char cChar;
+portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
+
+	/* Get the character and post it on the queue of Rxed characters.
+	If the post causes a task to wake force a context switch as the woken task
+	may have a higher priority than the task we have interrupted. */
+	IFS2bits.U2RXIF = serCLEAR_FLAG;
+	while( !U2STAbits.RXBE )
+	{
+		cChar = U2RXB;
+		xQueueSendFromISR( xRxedChars, &cChar, &xHigherPriorityTaskWoken );
+	}
+
+	if( xHigherPriorityTaskWoken != pdFALSE )
+	{
+		taskYIELD();
+	}
+}
+/*-----------------------------------------------------------*/
+
+void __attribute__((__interrupt__, auto_psv)) _U2TXInterrupt( void )
+{
+signed char cChar;
+portBASE_TYPE xTaskWoken = pdFALSE;
+
+	/* If the transmit buffer is full we cannot get the next character.
+	Another interrupt will occur the next time there is space so this does
+	not matter. */
+	IFS2bits.U2TXIF = serCLEAR_FLAG;
+	while( !( U2STAbits.UTXBF ) )
+	{
+		if( xQueueReceiveFromISR( xCharsForTx, &cChar, &xTaskWoken ) == pdTRUE )
+		{
+			/* Send the next character queued for Tx. */
+			U2TXB = cChar;
+		}
+		else
+		{
+			/* Queue empty, nothing to send. */
+			xTxHasEnded = pdTRUE;
+			break;
+		}
+	}
+
+	if( xTaskWoken != pdFALSE )
+	{
+		taskYIELD();
+	}
+}
+
+

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.c
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.c
@@ -1,0 +1,124 @@
+/**
+ * TRAPS Generated Driver Source File 
+ * 
+ * @file      traps.c
+ *            
+ * @ingroup   trapsdriver
+ *            
+ * @brief     This is the generated driver source file for TRAPS driver          
+ *
+ * @skipline @version   PLIB Version 1.0.1-rc.1
+ *            
+ * @skipline  Device : dsPIC33AK128MC106
+*/
+
+/*
+© [2024] Microchip Technology Inc. and its subsidiaries.
+
+    Subject to your compliance with these terms, you may use Microchip 
+    software and any derivatives exclusively with Microchip products. 
+    You are responsible for complying with 3rd party license terms  
+    applicable to your use of 3rd party software (including open source  
+    software) that may accompany Microchip software. SOFTWARE IS ?AS IS.? 
+    NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS 
+    SOFTWARE, INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT,  
+    MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT 
+    WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY 
+    KIND WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF 
+    MICROCHIP HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE 
+    FORESEEABLE. TO THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP?S 
+    TOTAL LIABILITY ON ALL CLAIMS RELATED TO THE SOFTWARE WILL NOT 
+    EXCEED AMOUNT OF FEES, IF ANY, YOU PAID DIRECTLY TO MICROCHIP FOR 
+    THIS SOFTWARE.
+*/
+
+// Section: Included Files
+#include <xc.h>
+#include "traps.h"
+
+#define ERROR_HANDLER __attribute__((interrupt,no_auto_psv))
+#define FAILSAFE_STACK_GUARDSIZE 8
+
+// A private place to store the error code if we run into a severe error
+
+static uint16_t TRAPS_error_code = -1;
+
+// Section: Driver Interface Function Definitions
+
+//@brief Halts 
+void __attribute__((weak)) TRAPS_halt_on_error(uint16_t code)
+{
+    TRAPS_error_code = code;
+#ifdef __DEBUG    
+    /* If we are in debug mode, cause a software breakpoint in the debugger */
+    __builtin_software_breakpoint();
+    while(1)
+    {
+    
+    }
+#else
+    // Trigger software reset
+    __asm__ volatile ("reset");
+#endif
+}
+
+// @brief Sets the stack pointer to a backup area of memory, in case we run into
+//   a stack error (in which case we can't really trust the stack pointer)
+
+inline static void use_failsafe_stack(void)
+{
+    static uint8_t failsafe_stack[32];
+    asm volatile (
+        "   mov    %[pstack], W15\n"
+        :
+        : [pstack]"r"(failsafe_stack)
+    );
+    
+    /* Controls where the stack pointer limit is, relative to the end of the
+     * failsafe stack
+     */ 
+    SPLIM = (uint32_t)(((uint8_t *)failsafe_stack) + sizeof(failsafe_stack) - (uint32_t) FAILSAFE_STACK_GUARDSIZE);
+}
+
+/** Bus error.**/
+void ERROR_HANDLER _BusErrorTrap(void)
+{
+    INTCON3bits.BET2 = 0;  //Clear the trap flag
+    TRAPS_halt_on_error(TRAPS_DMA_BUS_ERR);
+}
+
+/** Address error.**/
+void ERROR_HANDLER _AddressErrorTrap(void)
+{
+    INTCON1bits.ADDRERR = 0;  //Clear the trap flag
+    TRAPS_halt_on_error(TRAPS_ADDRESS_ERR);
+}
+
+/** Illegal instruction.**/
+void ERROR_HANDLER _IllegalInstructionTrap(void)
+{
+    INTCON1bits.BADOPERR = 0;  //Clear the trap flag
+    TRAPS_halt_on_error(TRAPS_ILLEGALINSTRUCTION);
+}
+
+/** Math error.**/
+void ERROR_HANDLER _MathErrorTrap(void)
+{
+    INTCON4bits.DIV0ERR = 0;  //Clear the trap flag
+    TRAPS_halt_on_error(TRAPS_DIV0_ERR);
+}
+
+/** Stack error.**/
+void ERROR_HANDLER _StackErrorTrap(void)
+{
+    /* We use a failsafe stack: the presence of a stack-pointer error
+     * means that we cannot trust the stack to operate correctly unless
+     * we set the stack pointer to a safe place.
+     */
+    //use_failsafe_stack(); //To do
+    
+    INTCON1bits.STKERR = 0;  //Clear the trap flag
+    TRAPS_halt_on_error(TRAPS_STACK_ERR);
+}
+

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.h
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.h
@@ -1,0 +1,74 @@
+/**
+ * TRAPS Generated Driver Header File 
+ * 
+ * @file      traps.h
+ *            
+ * @defgroup  trapsdriver Traps Driver
+ *            
+ * @brief     Traps driver with handler for all types of traps using dsPIC MCUs.           
+ *
+ * @skipline @version   PLIB Version 1.0.1-rc.1
+ *            
+ * @skipline  Device : dsPIC33AK128MC106
+*/
+
+/*
+© [2024] Microchip Technology Inc. and its subsidiaries.
+
+    Subject to your compliance with these terms, you may use Microchip 
+    software and any derivatives exclusively with Microchip products. 
+    You are responsible for complying with 3rd party license terms  
+    applicable to your use of 3rd party software (including open source  
+    software) that may accompany Microchip software. SOFTWARE IS ?AS IS.? 
+    NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS 
+    SOFTWARE, INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT,  
+    MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT 
+    WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, 
+    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY 
+    KIND WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF 
+    MICROCHIP HAS BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE 
+    FORESEEABLE. TO THE FULLEST EXTENT ALLOWED BY LAW, MICROCHIP?S 
+    TOTAL LIABILITY ON ALL CLAIMS RELATED TO THE SOFTWARE WILL NOT 
+    EXCEED AMOUNT OF FEES, IF ANY, YOU PAID DIRECTLY TO MICROCHIP FOR 
+    THIS SOFTWARE.
+*/
+
+#ifndef TRAPS_H
+#define TRAPS_H
+
+// Section: Included Files
+#include <stdint.h>
+
+// Section: Data Type Definitions
+
+/**
+ @ingroup  trapsdriver
+ @enum     TRAPS_ERROR_CODE
+ @brief    Defines the TRAPS error codes
+*/
+enum TRAPS_ERROR_CODE 
+{
+// Traps
+    TRAPS_DMA_BUS_ERR = 0, /**< Bus error. */
+    TRAPS_ILLEGALINSTRUCTION = 1, /**< Illegal instruction. */
+    TRAPS_ADDRESS_ERR = 2, /**< Address error. */
+    TRAPS_STACK_ERR = 3, /**< Stack error. */
+    TRAPS_DIV0_ERR = 4, /**< Math error. */
+    TRAPS_DMT_ERR = 5, /**< General error. */
+    TRAPS_WDT_ERR = 6, /**< General error. */
+};
+
+// Section: Driver Interface Function
+
+/**
+ * @ingroup    trapsdriver
+ * @brief      Stores the trap error code and waits forever.
+ *             This is a weak attribute function. The user can 
+ *             override and implement the same function without weak attribute.
+ * @param[in]  code - trap error code
+ * @return     none  
+ */
+void TRAPS_halt_on_error(uint16_t code);
+
+#endif
+

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/client/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/client/README.md
@@ -1,13 +1,13 @@
 ![image](../../../../images/microchip.jpg) 
 
-## PIC24 dsPIC33 FreeRTOS Demo
+## dsPIC33C FreeRTOS Demo
 
 ## Summary
 
-This repository contains the freeRTOS demos for Microchip device families like PIC24, dsPIC33E, dsPIC33F and dsPIC33C.
-For the demo applications, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
-The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
-The version of freeRTOS used in this demo is : freeRTOS v10
+This folder contains the freeRTOS demo for Microchip's dsPIC33CH128MP508 device.
+For this demo, MPLAB X and MPLAB XC-DSC are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
+The board to be used to run this demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
+The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
 
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.0.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC16 v2.0.0 or newer (https://www.microchip.com/xc) 
+- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/host/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/host/README.md
@@ -1,13 +1,13 @@
 ![image](../../../../images/microchip.jpg) 
 
-## PIC24 dsPIC33 FreeRTOS Demo
+## dsPIC33C FreeRTOS Demo
 
 ## Summary
 
-This repository contains the freeRTOS demos for Microchip device families like PIC24, dsPIC33E, dsPIC33F and dsPIC33C.
-For the demo applications, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
+This folder contains the freeRTOS demo for Microchip's dsPIC33CH128MP508 device.
+For this demo, MPLAB X and MPLAB XC-DSC are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
 The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
-The version of freeRTOS used in this demo is : freeRTOS v10
+The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
 
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.0.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC16 v2.0.0 or newer (https://www.microchip.com/xc) 
+- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/README.md
@@ -1,13 +1,13 @@
 ![image](../../../images/microchip.jpg) 
 
-## PIC24 dsPIC33 FreeRTOS Demo
+## dsPIC33C FreeRTOS Demo
 
 ## Summary
 
-This repository contains the freeRTOS demos for Microchip device families like PIC24, dsPIC33E, dsPIC33F and dsPIC33C.
-For the demo applications, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
+This folder contains the freeRTOS demo for Microchip's dsPIC33CH128MP508 device .
+For this demo, MPLAB X and MPLAB SC-DSC are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
 The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
-The version of freeRTOS used in this demo is : freeRTOS v10
+The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
 
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.0.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC16 v2.0.0 or newer (https://www.microchip.com/xc) 
+- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/dspic33c-host-freertos-demo.X/nbproject/configurations.xml
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/dspic33c-host-freertos-demo.X/nbproject/configurations.xml
@@ -10,11 +10,6 @@
       <itemPath>../../../Source/include/queue.h</itemPath>
       <itemPath>../FreeRTOSConfig.h</itemPath>
     </logicalFolder>
-    <logicalFolder name="ExternalFiles"
-                   displayName="Important Files"
-                   projectFiles="true">
-      <itemPath>Makefile</itemPath>
-    </logicalFolder>
     <logicalFolder name="LinkerScript"
                    displayName="Linker Files"
                    projectFiles="true">
@@ -46,6 +41,11 @@
       <itemPath>../ParTest/ParTest.c</itemPath>
       <itemPath>../serial/serial.c</itemPath>
       <itemPath>../lcd.c</itemPath>
+    </logicalFolder>
+    <logicalFolder name="ExternalFiles"
+                   displayName="Important Files"
+                   projectFiles="false">
+      <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
   <sourceRootList>

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/README.md
@@ -1,13 +1,13 @@
 ![image](../../../images/microchip.jpg) 
 
-## PIC24 dsPIC33 FreeRTOS Demo
+## dsPIC33E FreeRTOS Demo
 
 ## Summary
 
-This repository contains the freeRTOS demos for Microchip device families like PIC24, dsPIC33E, dsPIC33F and dsPIC33C.
-For the demo applications, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
+This folder contains the freeRTOS demo for Microchip's dsPIC33EP512MU810 device.
+For this demo, MPLAB X and MPLAB XC-DSC are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
 The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
-The version of freeRTOS used in this demo is : freeRTOS v10
+The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
 
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.0.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC16 v2.0.0 or newer (https://www.microchip.com/xc) 
+- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/dspic33e-freertos-demo.X/nbproject/configurations.xml
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/dspic33e-freertos-demo.X/nbproject/configurations.xml
@@ -10,11 +10,6 @@
       <itemPath>../../../Source/include/queue.h</itemPath>
       <itemPath>../FreeRTOSConfig.h</itemPath>
     </logicalFolder>
-    <logicalFolder name="ExternalFiles"
-                   displayName="Important Files"
-                   projectFiles="true">
-      <itemPath>Makefile</itemPath>
-    </logicalFolder>
     <logicalFolder name="LinkerScript"
                    displayName="Linker Files"
                    projectFiles="true">
@@ -47,6 +42,11 @@
       <itemPath>../serial/serial.c</itemPath>
       <itemPath>../timertest.c</itemPath>
       <itemPath>../lcd.c</itemPath>
+    </logicalFolder>
+    <logicalFolder name="ExternalFiles"
+                   displayName="Important Files"
+                   projectFiles="false">
+      <itemPath>Makefile</itemPath>
     </logicalFolder>
   </logicalFolder>
   <sourceRootList>

--- a/PIC24_DSPIC_MPLABX/Demo/pic24-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/pic24-freertos-demo/README.md
@@ -1,13 +1,13 @@
 ![image](../../../images/microchip.jpg) 
 
-## PIC24 dsPIC33 FreeRTOS Demo
+## PIC24 FreeRTOS Demo
 
 ## Summary
 
-This repository contains the freeRTOS demos for Microchip device families like PIC24, dsPIC33E, dsPIC33F and dsPIC33C.
-For the demo applications, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
+This folder contains the freeRTOS demo for Microchip's PIC24FJ128GA010 device.
+For this demo, MPLAB X and MPLAB XC16 are the preferred IDE and compiler respectively with which to build the FreeRTOS demos. 
 The board to be used to run the demo is Explorer 16/32 (Explore 16/32 is backward compatible with Explorer 16).
-The version of freeRTOS used in this demo is : freeRTOS v10
+The version of freeRTOS used in this demo is : freeRTOS v10.5
 
 ## Related Documentation
 

--- a/PIC24_DSPIC_MPLABX/Source/include/portable.h
+++ b/PIC24_DSPIC_MPLABX/Source/include/portable.h
@@ -50,7 +50,11 @@
  * included here.  In this case the path to the correct portmacro.h header file
  * must be set in the compiler's include path. */
 #ifndef portENTER_CRITICAL
+#ifdef __dsPIC33A__
+    #include "../../Source/portable/MPLAB/dsPIC33A/portmacro.h"
+#else
     #include "../../Source/portable/MPLAB/PIC24_dsPIC/portmacro.h"
+#endif
 #endif
 
 #if portBYTE_ALIGNMENT == 32

--- a/PIC24_DSPIC_MPLABX/Source/include/task.h
+++ b/PIC24_DSPIC_MPLABX/Source/include/task.h
@@ -193,7 +193,9 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                        portYIELD()
+#ifndef taskYIELD
+#define taskYIELD()              portYIELD()
+#endif
 
 /**
  * task. h

--- a/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/port.c
+++ b/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/port.c
@@ -1,0 +1,496 @@
+/*
+ * FreeRTOS Kernel V10.5.1
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+#include "FreeRTOS.h"
+#include "portmacro.h"
+#include "task.h"
+
+#define portTIMER_PRESCALE 8
+#define INLINE inline __attribute__((always_inline))
+/* Defined for backward compatability with project created prior to
+FreeRTOS.org V4.3.0. */
+#ifndef configKERNEL_INTERRUPT_PRIORITY
+    #define configKERNEL_INTERRUPT_PRIORITY 1
+#endif
+
+/* Use _T1Interrupt as the interrupt handler name if the application writer has
+not provided their own. */
+#ifndef configTICK_INTERRUPT_HANDLER
+	#define configTICK_INTERRUPT_HANDLER _T1Interrupt
+#endif /* configTICK_INTERRUPT_HANDLER */
+
+
+/* Records the nesting depth of calls to portENTER_CRITICAL(). */
+UBaseType_t uxCriticalNesting = 0;
+
+#if configKERNEL_INTERRUPT_PRIORITY != 1
+    #error If configKERNEL_INTERRUPT_PRIORITY must be = 1 - almost lowest priority 
+#endif
+
+volatile StackType_t TopOfStack_addr = 0;
+
+/* Hardware specifics. */
+#define portINITIAL_SR  0x00000000  // SR Initial value for Task; CTX=0, IPL=0 
+
+#define MAX_RAM_LIM_ADDRESS 0x00007FFC
+
+
+INLINE void set_SPLIM(uint32_t new_splim);
+__attribute__(( weak )) void vApplicationSetupTickTimerInterrupt( void );
+/*-----------------------------------------------------------*/
+
+/*
+ * Initialise the stack of a task to look exactly as if a call to
+ * portSAVE_CONTEXT had been called.
+ *
+ * See header file for description.
+ */
+
+#if ( portHAS_STACK_OVERFLOW_CHECKING == 1 )
+ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, StackType_t * pxEndOfStack, TaskFunction_t pxCode, void *pvParameters )
+ {
+    /* Setup the stack as if a yield had occurred. */
+    *pxTopOfStack++ = 0xBAAAAAAD;  
+    *pxTopOfStack++ = 0xCAFEB0BA;  
+    *pxTopOfStack++ = 0xBEEFBABE;  
+    *pxTopOfStack++ = 0xDEADBEEF;  
+
+    *pxTopOfStack++ = portINITIAL_SR;                /*  Used when context-switch on portYIELD() - ISR-RETFIE  */
+    *pxTopOfStack++ = ( StackType_t ) pxCode;        /*  Save the program counter - RETFIE will restore it */
+    *pxTopOfStack++ = portINITIAL_SR;                /*  this may not be needed, since we unified the context switching always from ISR */
+    *pxTopOfStack++ = ( StackType_t ) pvParameters;  /*  Parameters are passed in W0 */
+
+    // Registers default value, unique for debugging   
+    *pxTopOfStack++ = 0x000000A1;    // W1
+    *pxTopOfStack++ = 0x000000A2;    // W2
+    *pxTopOfStack++ = 0x000000A3;    // W3
+    *pxTopOfStack++ = 0x000000A4;    // W4
+    *pxTopOfStack++ = 0x000000A5;    // W5
+    *pxTopOfStack++ = 0x000000A6;    // W6
+    *pxTopOfStack++ = 0x000000A7;    // W7
+    *pxTopOfStack++ = 0x000000A8;    // W8
+    *pxTopOfStack++ = 0x000000A9;    // W9
+    *pxTopOfStack++ = 0x00000A10;    // W10
+    *pxTopOfStack++ = 0x00000A11;    // W11
+    *pxTopOfStack++ = 0x00000A12;    // W12
+    *pxTopOfStack++ = 0x00000A13;    // W13
+    *pxTopOfStack++ = 0x00000A14;    // W14
+
+    *pxTopOfStack++ = 0x000000F0;    // F0
+    *pxTopOfStack++ = 0x000000F1;    // F1
+    *pxTopOfStack++ = 0x000000F2;    // F2
+    *pxTopOfStack++ = 0x000000F3;    // F3
+    *pxTopOfStack++ = 0x000000F4;    // F4
+    *pxTopOfStack++ = 0x000000F5;    // F5
+    *pxTopOfStack++ = 0x000000F6;    // F6
+    *pxTopOfStack++ = 0x000000F7;    // F7
+    *pxTopOfStack++ = 0x000000F8;    // F8
+    *pxTopOfStack++ = 0x000000F9;    // F9
+    *pxTopOfStack++ = 0x00000F10;    // F10
+    *pxTopOfStack++ = 0x00000F11;    // F11
+    *pxTopOfStack++ = 0x00000F12;    // F12
+    *pxTopOfStack++ = 0x00000F13;    // F13
+    *pxTopOfStack++ = 0x00000F14;    // F14
+    *pxTopOfStack++ = 0x00000F15;    // F15
+
+    *pxTopOfStack++ = 0x00000F16;    // F16
+    *pxTopOfStack++ = 0x00000F17;    // F17
+    *pxTopOfStack++ = 0x00000F18;    // F18
+    *pxTopOfStack++ = 0x00000F19;    // F19
+    *pxTopOfStack++ = 0x00000F20;    // F20
+    *pxTopOfStack++ = 0x00000F21;    // F21
+    *pxTopOfStack++ = 0x00000F22;    // F22
+    *pxTopOfStack++ = 0x00000F23;    // F23
+    *pxTopOfStack++ = 0x00000F24;    // F24
+    *pxTopOfStack++ = 0x00000F25;    // F24
+    *pxTopOfStack++ = 0x00000F26;    // F26
+    *pxTopOfStack++ = 0x00000F27;    // F27
+    *pxTopOfStack++ = 0x00000F28;    // F28
+    *pxTopOfStack++ = 0x00000F29;    // F29
+    *pxTopOfStack++ = 0x00000F30;    // F30
+    *pxTopOfStack++ = 0x00000F31;    // F31
+    *pxTopOfStack++ = 0x00000000;    // FCR
+    *pxTopOfStack++ = 0x00000000;    // FSR
+    *pxTopOfStack++ = 0x00000000;    // FEAR    
+ 
+    *pxTopOfStack++ = 0x00000000;    // RCOUNT
+    *pxTopOfStack++ = 0x00000000;    // CORCON
+    *pxTopOfStack++ = 0x00000101;    // MODCON
+    *pxTopOfStack++ = 0x00000000;    // XMODSRT
+    *pxTopOfStack++ = 0x00000000;    // XMODEND
+    *pxTopOfStack++ = 0x00000000;    // YMODSRT
+    *pxTopOfStack++ = 0x00000000;    // YMODEND
+    *pxTopOfStack++ = 0x00000000;    // XBREV
+
+    *pxTopOfStack++ = 0x00000000;    // ACCAL
+    *pxTopOfStack++ = 0x00000000;    // ACCAH
+    *pxTopOfStack++ = 0x00000000;    // ACCAU
+    *pxTopOfStack++ = 0x00000000;    // ACCBL
+    *pxTopOfStack++ = 0x00000000;    // ACCBH
+    *pxTopOfStack++ = 0x00000000;    // ACCBU    
+
+    *pxTopOfStack++ = 0x00000000;    // critical nesting - W0 
+    *pxTopOfStack++ = ( StackType_t ) pxEndOfStack - 4; // SPLIM 
+
+    return pxTopOfStack;
+
+}
+
+#else
+
+ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+ {
+    /* Setup the stack as if a yield had occurred. */
+
+    *pxTopOfStack++ = 0xBAAAAAAD;  
+    *pxTopOfStack++ = 0xCAFEB0BA;     
+    *pxTopOfStack++ = 0xBEEFBABE;  
+    *pxTopOfStack++ = 0xDEADBEEF;  
+
+    *pxTopOfStack++ = portINITIAL_SR;                /*  Used when context-switch on portYIELD() - ISR-RETFIE  */
+    *pxTopOfStack++ = ( StackType_t ) pxCode;        /*  Save the program counter - RETFIE will restore it */
+    *pxTopOfStack++ = portINITIAL_SR;                /*  this may not be needed, since we unified the context switching always from ISR */
+    *pxTopOfStack++ = ( StackType_t ) pvParameters;  /*  Parameters are passed in W0 */
+
+    // Registers default value, unique for debugging 
+    *pxTopOfStack++ = 0x000000A1;    // W1
+    *pxTopOfStack++ = 0x000000A2;    // W2
+    *pxTopOfStack++ = 0x000000A3;    // W3
+    *pxTopOfStack++ = 0x000000A4;    // W4
+    *pxTopOfStack++ = 0x000000A5;    // W5
+    *pxTopOfStack++ = 0x000000A6;    // W6
+    *pxTopOfStack++ = 0x000000A7;    // W7
+    *pxTopOfStack++ = 0x000000A8;    // W8
+    *pxTopOfStack++ = 0x000000A9;    // W9
+    *pxTopOfStack++ = 0x00000A10;    // W10
+    *pxTopOfStack++ = 0x00000A11;    // W11
+    *pxTopOfStack++ = 0x00000A12;    // W12
+    *pxTopOfStack++ = 0x00000A13;    // W13
+    *pxTopOfStack++ = 0x00000A14;    // W14
+
+    *pxTopOfStack++ = 0x000000F0;    // F0
+    *pxTopOfStack++ = 0x000000F1;    // F1
+    *pxTopOfStack++ = 0x000000F2;    // F2
+    *pxTopOfStack++ = 0x000000F3;    // F3
+    *pxTopOfStack++ = 0x000000F4;    // F4
+    *pxTopOfStack++ = 0x000000F5;    // F5
+    *pxTopOfStack++ = 0x000000F6;    // F6
+    *pxTopOfStack++ = 0x000000F7;    // F7
+    *pxTopOfStack++ = 0x000000F8;    // F8
+    *pxTopOfStack++ = 0x000000F9;    // F9
+    *pxTopOfStack++ = 0x00000F10;    // F10
+    *pxTopOfStack++ = 0x00000F11;    // F11
+    *pxTopOfStack++ = 0x00000F12;    // F12
+    *pxTopOfStack++ = 0x00000F13;    // F13
+    *pxTopOfStack++ = 0x00000F14;    // F14
+    *pxTopOfStack++ = 0x00000F15;    // F15
+
+    *pxTopOfStack++ = 0x00000F16;    // F16
+    *pxTopOfStack++ = 0x00000F17;    // F17
+    *pxTopOfStack++ = 0x00000F18;    // F18
+    *pxTopOfStack++ = 0x00000F19;    // F19
+    *pxTopOfStack++ = 0x00000F20;    // F20
+    *pxTopOfStack++ = 0x00000F21;    // F21
+    *pxTopOfStack++ = 0x00000F22;    // F22
+    *pxTopOfStack++ = 0x00000F23;    // F23
+    *pxTopOfStack++ = 0x00000F24;    // F24
+    *pxTopOfStack++ = 0x00000F25;    // F24
+    *pxTopOfStack++ = 0x00000F26;    // F26
+    *pxTopOfStack++ = 0x00000F27;    // F27
+    *pxTopOfStack++ = 0x00000F28;    // F28
+    *pxTopOfStack++ = 0x00000F29;    // F29
+    *pxTopOfStack++ = 0x00000F30;    // F30
+    *pxTopOfStack++ = 0x00000F31;    // F31
+ 
+    *pxTopOfStack++ = 0x00000000;    // RCOUNT
+    *pxTopOfStack++ = 0x00000000;    // CORCON
+    *pxTopOfStack++ = 0x00000101;    // MODCON
+    *pxTopOfStack++ = 0x00000000;    // XMODSRT
+    *pxTopOfStack++ = 0x00000000;    // XMODEND
+    *pxTopOfStack++ = 0x00000000;    // YMODSRT
+    *pxTopOfStack++ = 0x00000000;    // YMODEND
+    *pxTopOfStack++ = 0x00000000;    // XBREV
+
+    *pxTopOfStack++ = 0x00000000;    // ACCAH
+    *pxTopOfStack++ = 0x00000000;    // ACCAL
+    *pxTopOfStack++ = 0x00000000;    // ACCAU
+    *pxTopOfStack++ = 0x00000000;    // ACCBH
+    *pxTopOfStack++ = 0x00000000;    // ACCBL
+    *pxTopOfStack++ = 0x00000000;    // ACCBU    
+
+    *pxTopOfStack++ = 0x00000000;    // critical nesting - W0 
+    *pxTopOfStack++ = MAX_RAM_LIM_ADDRESS; // SPLIM 
+
+    return pxTopOfStack;
+
+}
+#endif
+
+/*-----------------------------------------------------------*/
+BaseType_t xPortStartScheduler( void )
+{
+    /* Setup a timer for the tick ISR. */
+    vApplicationSetupTickTimerInterrupt();
+
+    __asm__ volatile ("NOP");
+    __asm__ volatile ("NOP");
+
+    /* Restore the context of the first task to run. */
+    portRESTORE_CONTEXT();
+    
+    __asm__ volatile ( "retfie" ); 
+
+    /* should not get here */
+    __asm__ volatile ("NOP");
+    __asm__ volatile ("NOP");
+
+    /* Should not reach here. */
+    return pdTRUE;
+}
+
+
+void vPortEndScheduler( void )
+{
+    /* Not implemented in ports where there is nothing to return to.
+    Artificially force an assert. */
+    configASSERT( uxCriticalNesting == 1000UL );
+}
+
+
+void vPortEnterCritical( void )
+{
+    portDISABLE_INTERRUPTS();
+    uxCriticalNesting++;
+}
+
+
+void vPortExitCritical( void )
+{
+    configASSERT( uxCriticalNesting );
+    uxCriticalNesting--;
+    if( uxCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}
+
+
+/* Critical section management. */
+inline void portDISABLE_INTERRUPTS(void)
+{                   
+   /* TickTimer should operate at IPL = configKERNEL_INTERRUPT_PRIORITY, to block the tick ISR, 
+    * elevate IPL to a level above than  configKERNEL_INTERRUPT_PRIORITY */
+
+   uint8_t new_ipl_level = configKERNEL_INTERRUPT_PRIORITY+1;
+
+   __asm__ volatile(   "DISICTL %0 \n\t" \
+                        : /* no output */
+                        : "r"(new_ipl_level)
+                        : /* no clobbers */
+                    );
+}
+
+/* Critical section management. */
+inline void portENABLE_INTERRUPTS(void)
+{   
+   /* FreeRtos Tasks runs at IPL=0 */
+   __asm__ volatile(   "DISICTL #0x0 \n\t" \
+                        : /* no output */
+                        : /* no inputs */
+                        : /* no clobbers */
+                    );                     
+}
+
+
+void __attribute__ ((naked)) portYIELD(void) 
+{               
+   /* portYIELD enters on :
+        1 : Systick_Callback CTX=1, IPL1 
+            but we want to save/restore Ctx-0 regs (IPL0 Task regs)
+        2: SW Interrupts:
+            Handled as trap IPL > 8, but CTX=0
+            changing CTX is redundant for a SW Trap, but takes longer to test 
+            for CTX value than just always change CTX=0 */
+    
+   __asm__ volatile ("CTXTSWP #0x0");                          
+
+   /* Now focused on CTX-0, save the context, Save the context of the current task */
+   portSAVE_CONTEXT(); 
+
+   /* Switch to a different thread if ready */
+   vTaskSwitchContext(); 
+
+   /* Temporary override SPLIM to the MAX RAM Address to avoid Stack-error-trap the appropriate SPLIM 
+    * for the next task will be restored inside portRESTORE_CONTEXT */
+   set_SPLIM(MAX_RAM_LIM_ADDRESS); 
+
+   /* we should still be on ctx-0 after pointing to the new TCB, Restore the context of whichever task is going to run */
+   portRESTORE_CONTEXT();  
+
+                    
+   /* A portYIELD_WITHIN_API elevates IPL using portDISABLE_INTERRUPTS to avoid collisions with other ISR that 
+    * could yield it just in case portYIELD was called from API */
+   portENABLE_INTERRUPTS();
+   
+   /* No return to entry-isr , force a retfie to restore PC and SR to next-task */
+    __asm__ volatile ( "retfie" ); 
+}
+
+void __attribute__((__interrupt__, naked)) configTICK_INTERRUPT_HANDLER( void )
+{   
+    IFS1bits.T1IF = 0;
+    if( xTaskIncrementTick() != pdFALSE )
+    { 
+        /* Elevate IPL to avoid collisions with other ISR that could yield */
+        portDISABLE_INTERRUPTS(); 
+        /* goto portYIELD but don't return */
+        __asm__ volatile ( "GOTO _portYIELD" ); 
+    }
+}
+
+
+void  __attribute__ ((interrupt, naked)) _GeneralTrap(void) 
+{
+    /* _GeneralTrap covers multiple Traps only portYIELD if the software trap was triggered */            
+    if (INTCON5bits.SOFT == 1) {
+        INTCON5bits.SOFT = 0;   
+        /* goto portYIELD but don't return */
+        __asm__ volatile ( "GOTO _portYIELD" ); 
+    }
+}
+
+
+/*-----------------------------------------------------------*/
+
+/* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an
+implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
+used by the Idle task. */
+void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize )
+{
+/* If the buffers to be provided to the Idle task are declared inside this
+function then they must be declared static - otherwise they will be allocated on
+the stack and so not exists after this function exits. */
+static StaticTask_t xIdleTaskTCB;
+static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Idle task's
+    state will be stored. */
+    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+    /* Pass out the array that will be used as the Idle task's stack. */
+    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+}
+/*-----------------------------------------------------------*/
+
+/* configUSE_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
+application must provide an implementation of vApplicationGetTimerTaskMemory()
+to provide the memory that is used by the Timer service task. */
+void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize )
+{
+/* If the buffers to be provided to the Timer task are declared inside this
+function then they must be declared static - otherwise they will be allocated on
+the stack and so not exists after this function exits. */
+static StaticTask_t xTimerTaskTCB;
+static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the Timer
+    task's state will be stored. */
+    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+    Note that, as the array is necessarily of type StackType_t,
+    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+}
+
+/*-----------------------------------------------------------*/
+
+
+void vApplicationStackOverflowHook( TaskHandle_t xTask, char *pcTaskName )
+{
+    /* When stack overflow happens, trap instead of attempting to recover.
+    Read input arguments to learn about the offending task. */
+    for( ;; )
+    {
+        /* Doesn't do anything yet. */
+       __asm__ volatile ("NOP");
+       __asm__ volatile ("NOP");
+    }
+}
+
+
+
+INLINE void set_SPLIM(uint32_t new_splim)
+{
+   __asm__ volatile(   "MOV.l  %0, SPLIM \n\t" \
+                        : /* no outputs */
+                        : "r"(new_splim)
+                        : /* no clobbers */
+                    );
+}
+
+__attribute__(( weak )) void vApplicationSetupTickTimerInterrupt( void )
+{
+    const uint32_t ulCompareMatch = ( ( configCPU_CLOCK_HZ / portTIMER_PRESCALE ) / configTICK_RATE_HZ ) - 1;
+
+	/* Prescale of 8. */
+	T1CON = 0;
+	TMR1 = 0;
+
+	PR1 = ( uint32_t ) ulCompareMatch;
+
+	/* Setup timer 1 interrupt priority. */
+	IPC6bits.T1IP = configKERNEL_INTERRUPT_PRIORITY;
+
+	/* Clear the interrupt as a starting condition. */
+	IFS1bits.T1IF = 0;
+
+	/* Enable the interrupt. */
+	IEC1bits.T1IE = 1;
+
+#if defined (__dsPIC33C__)
+	/* Setup the prescale value. */
+	T1CONbits.TCKPS = 1;
+#elif defined (__dsPIC33A__)
+    T1CONbits.TCKPS = 1;
+#else
+    T1CONbits.TCKPS0 = 1;
+	T1CONbits.TCKPS1 = 0;
+#endif    
+	/* Start the timer. */
+	T1CONbits.TON = 1;
+}

--- a/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/portmacro.h
+++ b/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/portmacro.h
@@ -1,0 +1,299 @@
+/*
+ * FreeRTOS Kernel V10.5.1
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Type definitions. */
+#define portCHAR		char
+#define portFLOAT		float
+#define portDOUBLE		int64_t
+#define portLONG		long
+#define portSTACK_TYPE	int
+#define portSHORT       short
+#define portBASE_TYPE	int
+
+typedef portSTACK_TYPE StackType_t;
+typedef int BaseType_t;
+typedef unsigned int UBaseType_t;
+
+typedef uint32_t TickType_t;
+#define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+
+/* Hardware specifics. */
+#define portBYTE_ALIGNMENT			4
+#define portSTACK_GROWTH			1
+#define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+
+
+/* Note that exiting a critical sectino will set the IPL bits to 0, nomatter
+what their value was prior to entering the critical section. */
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+
+#define portENTER_CRITICAL()		vPortEnterCritical()
+#define portEXIT_CRITICAL()			vPortExitCritical()
+
+/* Critical section management. */
+void portDISABLE_INTERRUPTS(void);
+
+/* Critical section management. */
+void portENABLE_INTERRUPTS(void);
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
+
+
+/* Required by the kernel aware debugger. */
+#ifdef __DEBUG
+	#define portREMOVE_STATIC_QUALIFIER
+#endif
+
+#define portNOP()         asm volatile ( "NOP" )
+
+
+void __attribute__ ((naked)) portYIELD(void);
+
+// When yielding from API (outside an ISR), we need to manually save the SR
+// required by the RETFIE instruction executed at the end of the portYIELD procedure
+// The PC saved when calling the function portYIELD, is the PC
+// used by RETFIE.  Note that a RETFIE is manually implanted at the end of portYIELD
+// Procedure:
+//    push SR -> stack
+//    rcall _portYIELD
+//        then inside retfie -> restores PC, and the manually saved SR 
+//
+// NOTE: It is critical to protect portYIELD from beign interrupted
+//       by systick, otherwise the YIELD procedure could be corrupted by 
+//       a second YIELD started from systick.
+//
+//    *  Temporay disable the SysTick timer interrupt IEC1bits.T1IE = 0, so the portYIELD_WITHIN_API
+//       and SysTick portYIELD dont collide and step on each other, and higher IPL interrupts can 
+//       still be processed 
+//
+//    *  After testing, there may be other interrupts with higher IPL 
+//       that could cause a portYIELD from ISR, in this case, the 
+//       portYIELD_WITHIN_API() may be corrupted, it is safer to elevate the IPL
+//       and cover the whole group of interrupts, rather than just disable the SysTick ISR
+//       using IEC1bits.T1IE = 0, see portDISABLE_INTERRUPTS()
+//
+ 
+#define portYIELD_WITHIN_API() ({                                             \
+                                  portDISABLE_INTERRUPTS();                   \
+                                  __asm__ volatile ("MOV.l   SR, [W15++]");   \
+                                  __asm__ volatile ("RCALL _portYIELD");      \
+                                  __asm__ volatile ("NOP");                   \
+                                  __asm__ volatile ("NOP");                   \
+                               });
+
+
+
+
+#define portSAVE_CONTEXT() ({           \
+                                        \
+       __asm__ volatile ("NOP");        \
+       __asm__ volatile ("NOP");        \
+                                        \
+    __asm__ volatile(   "MOV.l   SR, [W15++]                \n"      \
+                        "PUSH.l  W0                         \n"      \
+                        "PUSH.l  W1                         \n"      \
+                        "PUSH.l  W2                         \n"      \
+                        "PUSH.l  W3                         \n"      \
+                        "PUSH.l  W4                         \n"      \
+                        "PUSH.l  W5                         \n"      \
+                        "PUSH.l  W6                         \n"      \
+                        "PUSH.l  W7                         \n"      \
+                        "PUSH.l  W8                         \n"      \
+                        "PUSH.l  W9                         \n"      \
+                        "PUSH.l  W10                        \n"      \
+                        "PUSH.l  W11                        \n"      \
+                        "PUSH.l  W12                        \n"      \
+                        "PUSH.l  W13                        \n"      \
+                        "PUSH.l  W14                        \n"      \
+                        "                                   \n"      \
+                        "PUSH.l  F0                         \n"      \
+                        "PUSH.l  F1                         \n"      \
+                        "PUSH.l  F2                         \n"      \
+                        "PUSH.l  F3                         \n"      \
+                        "PUSH.l  F4                         \n"      \
+                        "PUSH.l  F5                         \n"      \
+                        "PUSH.l  F6                         \n"      \
+                        "PUSH.l  F7                         \n"      \
+                        "PUSH.l  F8                         \n"      \
+                        "PUSH.l  F9                         \n"      \
+                        "PUSH.l  F10                        \n"      \
+                        "PUSH.l  F11                        \n"      \
+                        "PUSH.l  F12                        \n"      \
+                        "PUSH.l  F13                        \n"      \
+                        "PUSH.l  F14                        \n"      \
+                        "PUSH.l  F15                        \n"      \
+                        "                                   \n"      \
+                        "PUSH.l  F16                        \n"      \
+                        "PUSH.l  F17                        \n"      \
+                        "PUSH.l  F18                        \n"      \
+                        "PUSH.l  F19                        \n"      \
+                        "PUSH.l  F20                        \n"      \
+                        "PUSH.l  F21                        \n"      \
+                        "PUSH.l  F22                        \n"      \
+                        "PUSH.l  F23                        \n"      \
+                        "PUSH.l  F24                        \n"      \
+                        "PUSH.l  F25                        \n"      \
+                        "PUSH.l  F26                        \n"      \
+                        "PUSH.l  F27                        \n"      \
+                        "PUSH.l  F28                        \n"      \
+                        "PUSH.l  F29                        \n"      \
+                        "PUSH.l  F30                        \n"      \
+                        "PUSH.l  F31                        \n"      \
+                        "PUSH.l  FCR                        \n"      \
+                        "PUSH.l  FSR                        \n"      \
+                        "PUSH.l  FEAR                       \n"      \
+                        "                                   \n"      \
+                        "PUSH.l  RCOUNT                     \n"      \
+                        "PUSH.l  CORCON                     \n"      \
+                        "PUSH.l  MODCON                     \n"      \
+                        "PUSH.l  XMODSRT                    \n"      \
+                        "PUSH.l  XMODEND                    \n"      \
+                        "PUSH.l  YMODSRT                    \n"      \
+                        "PUSH.l  YMODEND                    \n"      \
+                        "PUSH.l  XBREV                      \n"      \
+                        "                                   \n"      \
+                        "SLAC.l  A, [W15++]                 \n"      \
+                        "SAC.l   A, [W15++]                 \n"      \
+                        "SUAC.l  A, [W15++]                 \n"      \
+                        "SLAC.l  B, [W15++]                 \n"      \
+                        "SAC.l   B, [W15++]                 \n"      \
+                        "SUAC.l  B, [W15++]                 \n"      \
+                        "                                   \n"      \
+                        "MOV.l   _uxCriticalNesting, W0     \n"      \
+                        "PUSH.l  W0                         \n"      \
+                        "PUSH.l  SPLIM                      \n"      \
+                        "MOV.l   _pxCurrentTCB, W0          \n"      \
+                        "MOV.l   W15, [W0]                  \n"      \
+                        ); \
+});
+
+
+
+
+
+#define portRESTORE_CONTEXT() ({        \
+                                        \
+       __asm__ volatile ("NOP");        \
+       __asm__ volatile ("NOP");        \
+                                        \
+    __asm__ volatile(   "                                   \n"      \
+                        "MOV.l   _pxCurrentTCB, W0          \n"      \
+                        "MOV.l   [W0], W15                  \n"      \
+                        "POP.l   SPLIM                      \n"      \
+                        "POP.l   W0                         \n"      \
+                        "MOV.l   W0, _uxCriticalNesting     \n"      \
+                        "                                   \n"      \
+                        "LUAC.l  [--W15], B                 \n"      \
+                        "LAC.l   [--W15], B                 \n"      \
+                        "LLAC.l  [--W15], B                 \n"      \
+                        "LUAC.l  [--W15], A                 \n"      \
+                        "LAC.l   [--W15], A                 \n"      \
+                        "LLAC.l  [--W15], A                 \n"      \
+                        "                                   \n"      \
+                        "POP.l   XBREV                      \n"      \
+                        "POP.l   YMODEND                    \n"      \
+                        "POP.l   YMODSRT                    \n"      \
+                        "POP.l   XMODEND                    \n"      \
+                        "POP.l   XMODSRT                    \n"      \
+                        "POP.l   MODCON                     \n"      \
+                        "POP.l   CORCON                     \n"      \
+                        "POP.l   RCOUNT                     \n"      \
+                        "                                   \n"      \
+                        "POP.l   FEAR                       \n"      \
+                        "POP.l   FSR                        \n"      \
+                        "POP.l   FCR                        \n"      \
+                        "POP.l   F31                        \n"      \
+                        "POP.l   F30                        \n"      \
+                        "POP.l   F29                        \n"      \
+                        "POP.l   F28                        \n"      \
+                        "POP.l   F27                        \n"      \
+                        "POP.l   F26                        \n"      \
+                        "POP.l   F25                        \n"      \
+                        "POP.l   F24                        \n"      \
+                        "POP.l   F23                        \n"      \
+                        "POP.l   F22                        \n"      \
+                        "POP.l   F21                        \n"      \
+                        "POP.l   F20                        \n"      \
+                        "POP.l   F19                        \n"      \
+                        "POP.l   F18                        \n"      \
+                        "POP.l   F17                        \n"      \
+                        "POP.l   F16                        \n"      \
+                        "                                   \n"      \
+                        "POP.l   F15                        \n"      \
+                        "POP.l   F14                        \n"      \
+                        "POP.l   F13                        \n"      \
+                        "POP.l   F12                        \n"      \
+                        "POP.l   F11                        \n"      \
+                        "POP.l   F10                        \n"      \
+                        "POP.l   F9                         \n"      \
+                        "POP.l   F8                         \n"      \
+                        "POP.l   F7                         \n"      \
+                        "POP.l   F6                         \n"      \
+                        "POP.l   F5                         \n"      \
+                        "POP.l   F4                         \n"      \
+                        "POP.l   F3                         \n"      \
+                        "POP.l   F2                         \n"      \
+                        "POP.l   F1                         \n"      \
+                        "POP.l   F0                         \n"      \
+                        "                                   \n"      \
+                        "POP.l   W14                        \n"      \
+                        "POP.l   W13                        \n"      \
+                        "POP.l   W12                        \n"      \
+                        "POP.l   W11                        \n"      \
+                        "POP.l   W10                        \n"      \
+                        "POP.l   W9                         \n"      \
+                        "POP.l   W8                         \n"      \
+                        "POP.l   W7                         \n"      \
+                        "POP.l   W6                         \n"      \
+                        "POP.l   W5                         \n"      \
+                        "POP.l   W4                         \n"      \
+                        "POP.l   W3                         \n"      \
+                        "POP.l   W2                         \n"      \
+                        "POP.l   W1                         \n"      \
+                        "POP.l   W0                         \n"      \
+                        "MOV.l   [--W15], SR                \n\t"    \
+                     ); \
+});
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTMACRO_H */


### PR DESCRIPTION
Added demo support for dsPIC33A Device

Description
-----------
Added a new demo for the dsPIC33A device family.
These changes are already deployed in Microchip's repo: https://github.com/microchip-pic-avr-examples/pic24-dspic33-freertos-demo

Test Steps
-----------
1. Build the demo using MPLABX IDE and XC16 or XC-DSC compiler
2. Program the device using the generated hex file
3. Check the functionalities of the demo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
