### PR TITLE
dPIC33A freeRTOS demo updated to work with latest DFP's

### DIFF
--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc) 
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc) 
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/configurations.xml
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/dspic33a-freertos-demo.X/nbproject/configurations.xml
@@ -66,7 +66,7 @@
         <targetDevice>dsPIC33AK128MC106</targetDevice>
         <targetHeader></targetHeader>
         <targetPluginBoard></targetPluginBoard>
-        <platformTool>noID</platformTool>
+        <platformTool>pkob4hybrid</platformTool>
         <languageToolchain>XCDSC</languageToolchain>
         <languageToolchainVersion>3.20</languageToolchainVersion>
         <platform>3</platform>

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/serial/serial.c
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/serial/serial.c
@@ -95,10 +95,10 @@ xComPortHandle xSerialPortInitMinimal( unsigned long ulWantedBaud, unsigned port
 #endif    
 
 	/* Setup the UART. */
-	U2CONbits.BRGH		= serLOW_SPEED;
+	U2CONbits.BRGS		= serLOW_SPEED;
 	U2CONbits.STP	= serONE_STOP_BIT;
 	U2CONbits.ABDEN	= serAUTO_BAUD_OFF;
-	U2CONbits.WAKE		= serWAKE_UP_DISABLE;
+	U2CONbits.WUE		= serWAKE_UP_DISABLE;
 	U2CONbits.FLO		= serNO_HARDWARE_FLOW_CONTROL;
 	U2CONbits.MODE		= serNO_IRDA;
 	U2CONbits.SIDL	= serCONTINUE_IN_IDLE_MODE;
@@ -106,12 +106,11 @@ xComPortHandle xSerialPortInitMinimal( unsigned long ulWantedBaud, unsigned port
 
 	U2BRG = (unsigned short)(( (float)configCPU_CLOCK_HZ / ( (float)16 * (float)ulWantedBaud ) ) - (float)0.5);
 
-	U2STAbits.URXISEL	= serINTERRUPT_ON_SINGLE_CHAR;
     U2CONbits.RXEN		= serRX_ENABLE;
 	U2CONbits.TXEN		= serTX_ENABLE;
-	U2CONbits.UTXINV	= serNORMAL_IDLE_STATE;
-	U2STAbits.TXWM	= serINTERRUPT_ON_SINGLE_CHAR;
-	U2STAbits.RXWM	= serINTERRUPT_ON_SINGLE_CHAR;
+	U2CONbits.TXPOL	= serNORMAL_IDLE_STATE;
+	U2STATbits.TXWM	= serINTERRUPT_ON_SINGLE_CHAR;
+	U2STATbits.RXWM	= serINTERRUPT_ON_SINGLE_CHAR;
     
 
 
@@ -128,7 +127,7 @@ xComPortHandle xSerialPortInitMinimal( unsigned long ulWantedBaud, unsigned port
 	IEC2bits.U2RXIE = serINTERRUPT_ENABLE;
 
 	/* Clear the Rx buffer. */
-	while( U2STAbits.RXBE == serCLEAR_FLAG )
+	while( U2STATbits.RXBE == serCLEAR_FLAG )
 	{
 		cChar = U2RXB;
 	}
@@ -194,7 +193,7 @@ portBASE_TYPE xHigherPriorityTaskWoken = pdFALSE;
 	If the post causes a task to wake force a context switch as the woken task
 	may have a higher priority than the task we have interrupted. */
 	IFS2bits.U2RXIF = serCLEAR_FLAG;
-	while( !U2STAbits.RXBE )
+	while( !U2STATbits.RXBE )
 	{
 		cChar = U2RXB;
 		xQueueSendFromISR( xRxedChars, &cChar, &xHigherPriorityTaskWoken );
@@ -216,7 +215,7 @@ portBASE_TYPE xTaskWoken = pdFALSE;
 	Another interrupt will occur the next time there is space so this does
 	not matter. */
 	IFS2bits.U2TXIF = serCLEAR_FLAG;
-	while( !( U2STAbits.UTXBF ) )
+	while( !( U2STATbits.TXBF ) )
 	{
 		if( xQueueReceiveFromISR( xCharsForTx, &cChar, &xTaskWoken ) == pdTRUE )
 		{

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.c
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33a-freertos-demo/traps.c
@@ -84,7 +84,7 @@ inline static void use_failsafe_stack(void)
 /** Bus error.**/
 void ERROR_HANDLER _BusErrorTrap(void)
 {
-    INTCON3bits.BET2 = 0;  //Clear the trap flag
+    INTCON3bits.DMABET = 0;  //Clear the trap flag
     TRAPS_halt_on_error(TRAPS_DMA_BUS_ERR);
 }
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/client/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/client/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/host/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-client-freertos-demo/host/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33c-host-freertos-demo/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33e-freertos-demo/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc)  
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc)  
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/dspic33f-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/dspic33f-freertos-demo/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.20.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC-DSC v3.10.0 or newer (https://www.microchip.com/xcdsc) 
+- MPLAB® X IDE v6.20 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC-DSC v3.20 or newer (https://www.microchip.com/xcdsc) 
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Demo/pic24-freertos-demo/README.md
+++ b/PIC24_DSPIC_MPLABX/Demo/pic24-freertos-demo/README.md
@@ -32,8 +32,8 @@ http://www.freertos.org/FAQHelp.html
 
 ## Software Used 
 
-- MPLAB® X IDE v6.0.0 or newer (https://www.microchip.com/mplabx)
-- MPLAB® XC16 v2.0.0 or newer (https://www.microchip.com/xc) 
+- MPLAB® X IDE v6.0 or newer (https://www.microchip.com/mplabx)
+- MPLAB® XC16 v2.0 or newer (https://www.microchip.com/xc) 
 - Any of the serial terminal application. Example: Tera Term (https://ttssh2.osdn.jp/index.html.en)
 
 

--- a/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/port.c
+++ b/PIC24_DSPIC_MPLABX/Source/portable/MPLAB/dsPIC33A/port.c
@@ -492,5 +492,5 @@ __attribute__(( weak )) void vApplicationSetupTickTimerInterrupt( void )
 	T1CONbits.TCKPS1 = 0;
 #endif    
 	/* Start the timer. */
-	T1CONbits.TON = 1;
+	T1CONbits.ON = 1;
 }


### PR DESCRIPTION
dPIC33A freeRTOS demo updated to work with latest DFP's

Description
-----------
Demo was using register alias's and in the latest DFP's register/Bit-field aliases are being removed. Instead of register aliases actual register/Bit field name's are used.

These changes are already deployed in Microchip's repo: https://github.com/microchip-pic-avr-examples/pic24-dspic33-freertos-demo

Test Steps
-----------

    1. Build the demo using MPLABX IDE and XC16 or XC-DSC compiler
    2. Program the device using the generated hex file
    3. Check the functionalities of the demo


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
