### PR TITLE
Fix failing Cortex-M85 applications

### DIFF
--- a/CORTEX_M85_MPU_PXN_PACBTI_FVP_ARMCLANG_IAR/run.sh
+++ b/CORTEX_M85_MPU_PXN_PACBTI_FVP_ARMCLANG_IAR/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Copyright 2024 Arm Limited and/or its affiliates
+# Copyright 2024, 2026 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
-FVP_Corstone_SSE-315 -a ./build/cortex_m85_mpu_pxn_pacbti_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.ID_ISAR5.PACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1
+FVP_Corstone_SSE-315 -a ./build/cortex_m85_mpu_pxn_pacbti_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1

--- a/CORTEX_M85_MPU_PXN_PACBTI_FVP_ARMCLANG_IAR/trusted_firmware-m/CMakeLists.txt
+++ b/CORTEX_M85_MPU_PXN_PACBTI_FVP_ARMCLANG_IAR/trusted_firmware-m/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, Arm Limited and/or its affiliates
+# Copyright 2023-2024, 2026, Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -7,5 +7,22 @@ set(trusted_firmware-m_SOURCE_DIR
     CACHE INTERNAL
     "Path to Trusted Firmware-M source code"
 )
+
+set(PATCH_FILES_DIRECTORY "${trusted_firmware-m_SOURCE_DIR}/../integration/trusted_firmware-m/patches")
+set(PATCH_FILE
+    "${PATCH_FILES_DIRECTORY}/0001-ethos-u-core-driver-Fix-invalid-URL.patch"
+)
+
+# Check if the patch is already applied by reverse dry-run.
+execute_process(
+    COMMAND patch -R --dry-run -s -p1 -d "${trusted_firmware-m_SOURCE_DIR}" -i "${PATCH_FILE}"
+    RESULT_VARIABLE _rev_rc
+)
+
+if(_rev_rc EQUAL 0)
+    message(STATUS "ApplyPatch: Patch already applied; continuing: ${PATCH_FILE}")
+else()
+    set(TFM_PATCH_COMMAND patch -p1 -d ${trusted_firmware-m_SOURCE_DIR} -i "${PATCH_FILE}")
+endif()
 
 add_subdirectory(integration)

--- a/CORTEX_M85_PACBTI_FVP_ARMCLANG_IAR/run.sh
+++ b/CORTEX_M85_PACBTI_FVP_ARMCLANG_IAR/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Copyright 2024 Arm Limited and/or its affiliates
+# Copyright 2024, 2026 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
-FVP_Corstone_SSE-315 -a ./build/cortex_m85_pacbti_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.ID_ISAR5.PACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1
+FVP_Corstone_SSE-315 -a ./build/cortex_m85_pacbti_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1

--- a/CORTEX_M85_PACBTI_FVP_ARMCLANG_IAR/trusted_firmware-m/CMakeLists.txt
+++ b/CORTEX_M85_PACBTI_FVP_ARMCLANG_IAR/trusted_firmware-m/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, Arm Limited and/or its affiliates
+# Copyright 2023-2024, 2026, Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
@@ -7,5 +7,22 @@ set(trusted_firmware-m_SOURCE_DIR
     CACHE INTERNAL
     "Path to Trusted Firmware-M source code"
 )
+
+set(PATCH_FILES_DIRECTORY "${trusted_firmware-m_SOURCE_DIR}/../integration/trusted_firmware-m/patches")
+set(PATCH_FILE
+    "${PATCH_FILES_DIRECTORY}/0001-ethos-u-core-driver-Fix-invalid-URL.patch"
+)
+
+# Check if the patch is already applied by reverse dry-run.
+execute_process(
+    COMMAND patch -R --dry-run -s -p1 -d "${trusted_firmware-m_SOURCE_DIR}" -i "${PATCH_FILE}"
+    RESULT_VARIABLE _rev_rc
+)
+
+if(_rev_rc EQUAL 0)
+    message(STATUS "ApplyPatch: Patch already applied; continuing: ${PATCH_FILE}")
+else()
+    set(TFM_PATCH_COMMAND patch -p1 -d ${trusted_firmware-m_SOURCE_DIR} -i "${PATCH_FILE}")
+endif()
 
 add_subdirectory(integration)

--- a/CORTEX_M85_TASK_DEDICATED_PAC_KEY_FVP_ARMCLANG/run.sh
+++ b/CORTEX_M85_TASK_DEDICATED_PAC_KEY_FVP_ARMCLANG/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Copyright 2024 Arm Limited and/or its affiliates
+# Copyright 2024, 2026 Arm Limited and/or its affiliates
 # <open-source-office@arm.com>
 # SPDX-License-Identifier: MIT
 
-FVP_Corstone_SSE-315 -a ./build/cortex_m85_task_dedicated_pac_key_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.ID_ISAR5.PACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1
+FVP_Corstone_SSE-315 -a ./build/cortex_m85_task_dedicated_pac_key_fvp_example_merged.elf -C mps4_board.visualisation.disable-visualisation=1 -C core_clk.mul=200000000 -C mps4_board.hostbridge.userNetworking=1 -C mps4_board.telnetterminal0.start_telnet=0 -C mps4_board.uart0.out_file="-" -C mps4_board.uart0.unbuffered_output=1 -C vis_hdlcd.disable_visualisation=1 --stat -C mps4_board.subsystem.cpu0.CFGPACBTI=1 -C mps4_board.subsystem.cpu0.semihosting-enable=1

--- a/Demos_Dependencies/integration/trusted_firmware-m/patches/0001-ethos-u-core-driver-Fix-invalid-URL.patch
+++ b/Demos_Dependencies/integration/trusted_firmware-m/patches/0001-ethos-u-core-driver-Fix-invalid-URL.patch
@@ -1,0 +1,29 @@
+From bfffd2c851b2b8ed2357cb89c93539c21112d638 Mon Sep 17 00:00:00 2001
+From: Ahmed Ismail <Ahmed.Ismail@arm.com>
+Date: Tue, 27 Jan 2026 17:01:00 +0000
+Subject: [PATCH] ethos-u-core-driver: Fix invalid URL
+
+The review.mlplatform url is not valid anymore. Hence,
+switch to using the new git.gitlab.arm domain.
+
+Signed-off-by: Ahmed Ismail <Ahmed.Ismail@arm.com>
+---
+ lib/ext/ethos_u_core_driver/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/ext/ethos_u_core_driver/CMakeLists.txt b/lib/ext/ethos_u_core_driver/CMakeLists.txt
+index 18e277751..fb02230dc 100644
+--- a/lib/ext/ethos_u_core_driver/CMakeLists.txt
++++ b/lib/ext/ethos_u_core_driver/CMakeLists.txt
+@@ -10,7 +10,7 @@ fetch_remote_library(
+     LIB_SOURCE_PATH_VAR     ETHOS_DRIVER_PATH
+     LIB_PATCH_DIR           ${CMAKE_CURRENT_LIST_DIR}
+     FETCH_CONTENT_ARGS
+-        GIT_REPOSITORY      "https://review.mlplatform.org/ml/ethos-u/ethos-u-core-driver"
++        GIT_REPOSITORY      "https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver.git"
+         GIT_TAG             "24.05"
+         GIT_SHALLOW         TRUE
+         GIT_PROGRESS        TRUE
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This PR includes the following:

* Remove unsupported PACBTI FVP flag as the latest release of Corstone-315 Ecosystem FVP does not support the mps4_board.subsystem.cpu0.ID_ISAR5.PACBTI configuration option.
* The review.mlplatform domain that the trusted-firmware_m module references is not valid anymore. Hence, adding a new patch file to switch to using the new git.gitlab.arm domain.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
