### PR TITLE
rp2350: Add Multicore SMP Application for RP2350

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Demos_Dependencies/trusted_firmware-m"]
 	path = Demos_Dependencies/trusted_firmware-m
 	url = https://review.trustedfirmware.org/TF-M/trusted-firmware-m.git
+[submodule "Demos_Dependencies/pico-sdk"]
+	path = Demos_Dependencies/pico-sdk
+	url = https://github.com/raspberrypi/pico-sdk.git

--- a/RP2350_SMP_GCC/CMakeLists.txt
+++ b/RP2350_SMP_GCC/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.15)
+
+# Ensure correct Pico platform and board for RP2350
+if(NOT DEFINED PICO_PLATFORM)
+    set(PICO_PLATFORM "rp2350-arm-s" CACHE STRING "Pico platform" FORCE)
+endif()
+if(NOT DEFINED PICO_BOARD)
+    set(PICO_BOARD "pico2" CACHE STRING "Pico board" FORCE)
+endif()
+
+# Point to the bundled Pico SDK and import it BEFORE project()
+set(PICO_SDK_PATH "${CMAKE_CURRENT_LIST_DIR}/../Demos_Dependencies/pico-sdk" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+include("${PICO_SDK_PATH}/external/pico_sdk_import.cmake")
+
+project(
+  RP2350-SMP-EXAMPLE
+  VERSION 0.1
+  LANGUAGES C CXX ASM
+)
+
+set (CMAKE_BUILD_TYPE Release)
+
+# Initialize the Pico SDK
+pico_sdk_init()
+
+get_filename_component(FREERTOS_DIR_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../.. REALPATH)
+message(DEBUG "FREERTOS_DIR_PATH is ${FREERTOS_DIR_PATH}")
+
+set(KERNEL_DIR_PATH ${FREERTOS_DIR_PATH}/Source)
+message(DEBUG "KERNEL_DIR_PATH is ${KERNEL_DIR_PATH}")
+
+# Select the native compile PORT
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+	set(FREERTOS_PORT "GCC_ARM_CM33_NTZ_NONSECURE" CACHE STRING "" FORCE)
+else()
+	message(FATAL_ERROR "Unsupported compiler: ${CMAKE_C_COMPILER_ID}")
+endif()
+
+set(FREERTOS_HEAP "4" CACHE STRING "" FORCE)
+
+add_library(freertos_config INTERFACE)
+
+target_include_directories(freertos_config SYSTEM
+	INTERFACE
+        config
+        ${PICO_SDK_PATH}/src/rp2350/hardware_regs/include
+)
+
+add_subdirectory(${KERNEL_DIR_PATH} freertos_kernel)
+
+add_executable(rp2350_smp_example)
+
+target_sources(rp2350_smp_example
+	PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/main.c
+        ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Source/system_RP2350.c
+)
+
+target_link_libraries(rp2350_smp_example
+	PRIVATE
+		pico_stdlib
+        freertos_kernel
+        pico_multicore
+)
+
+target_include_directories(rp2350_smp_example
+    PRIVATE
+        ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include
+        ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS/Core/Include
+        ${PICO_SDK_PATH}/src/rp2_common/hardware_irq/include/hardware
+)
+
+# Generates output (.uf2) file, map file, and other useful files
+pico_add_extra_outputs(rp2350_smp_example)
+
+# Enable USB output for stdio, disable UART output
+pico_enable_stdio_usb(rp2350_smp_example 1)
+pico_enable_stdio_uart(rp2350_smp_example 0)

--- a/RP2350_SMP_GCC/LICENSE.md
+++ b/RP2350_SMP_GCC/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RP2350_SMP_GCC/README.md
+++ b/RP2350_SMP_GCC/README.md
@@ -1,0 +1,162 @@
+# FreeRTOS SMP Example on Raspberry Pi Pico 2 (RP2350)
+
+This example demonstrates FreeRTOS SMP on the dual‑core Arm Cortex-M33 (Armv8-M) Raspberry Pi Pico 2 (RP2350) using the Raspberry Pi Pico SDK (pico‑sdk). Two tasks, pinned to different cores, exchange a shared flag and print Ping/Pong messages. Inter‑core preemption is exercised via a doorbell interrupt that yields from ISR.
+
+## Dependencies
+
+- pico‑sdk: Included as a git submodule. The build imports `pico_sdk_import.cmake` and calls `pico_sdk_init()`.
+- Optional: picotool for UF2 flashing (fetched automatically if not found). Optional TinyUSB submodule if you need USB.
+- picocom or any other alternative serial terminal for monitoring the logs.
+
+## Build tools
+
+* [CMake](https://cmake.org/download/)
+  * The example uses `CMake` as the build system.
+
+## Supported toolchains
+
+The example is supported and tested on Arm GNU toolchain v14.2.
+
+## Hardware
+
+- Board: Raspberry Pi Pico 2 (`PICO_BOARD=pico2`).
+- Platform: `rp2350-arm-s` (Cortex‑M33 secure only). See [CMakeLists.txt:9](CMakeLists.txt#L9).
+
+## Build and Flash
+
+### Build
+
+First, run the following command to clone FreeRTOS repository:
+
+```bash
+git clone https://github.com/FreeRTOS/FreeRTOS.git --recurse-submodules
+```
+
+Run the following commands to build the example:
+
+```bash
+cd FreeRTOS/FreeRTOS/Demo/ThirdParty/Partner-Supported-Demos/RP2350_SMP_GCC
+rm -rf build && cmake -B build . -DCMAKE_TOOLCHAIN_FILE=../Demos_Dependencies/pico-sdk/cmake/preload/toolchains/pico_arm_cortex_m33_gcc.cmake && cmake --build build
+```
+
+Artifacts are emitted with extra formats by the SDK:
+
+- `build/rp2350_smp_example.elf`
+- `build/rp2350_smp_example.uf2`
+
+### Flash
+
+Flashing can be done by either of the following approaches:
+
+1.  Mounting the device then copying the output UF2 file to the mass-storage device
+    1. Press and hold BOOTSEL button on the Pico 2 board
+    2. Reset the board
+    3. Release the BOOTSEL button
+    4. Mount the device, for example on Linux, this would look like the following:
+        ```bash
+        udisksctl mount -b /dev/<device>
+        ```
+    5. Copy the output UF2 file to the mass‑storage device:
+        ```bash
+        cp build/rp2350_smp_example.uf2 <mounted_device_location>/RP2350
+        ```
+
+2. Via Picotool
+    ```bash
+    picotool load -f build/rp2350_smp_example.uf2
+    ```
+
+### Monitoring the application
+
+This application overrides the pico-sdk default output configuration to route log output over USB Communication Device Class (CDC) instead of UART. The examples below use `picocom`, but any serial terminal (e.g., `minicom`) should work as well.
+
+- If using USB CDC:
+  ```bash
+  picocom -b 115200 /dev/ttyACM0   # Linux
+  picocom -b 115200 /dev/tty.usbmodem*  # macOS
+  ```
+
+- If using UART:
+  ```bash
+  picocom -b 115200 /dev/ttyUSB0   # Linux
+  picocom -b 115200 /dev/tty.usbserial*  # macOS
+  ```
+
+#### Configuring stdio (USB vs UART)
+
+Default for this demo: USB CDC enabled, UART disabled.
+
+To enable UART and disable USB CDC:
+
+- Edit `CMakeLists.txt`:
+  ```cmake
+  # Use UART instead of USB CDC
+  pico_enable_stdio_usb(rp2350_smp_example 0)
+  pico_enable_stdio_uart(rp2350_smp_example 1)
+  ```
+
+## What The Example Does
+
+- Creates two tasks: `prvTaskCore0` (runs on core 0) prints “Ping”, `prvTaskCore1` (runs on core 1) prints “Pong”. See [main.c:63](main.c#L63) and [main.c:83](main.c#L83).
+- Uses a shared flag `ulSharedFlag` to coordinate between the ping/pong tasks, each write is followed by Data Synchronisation Barrier (`DSB`) instruction for ordering.
+- Pins ping/pong tasks to cores with `vTaskCoreAffinitySet`. See [main.c:158](main.c#L158).
+- Also creates an unpinned task `prvBouncingTask` that bounces between both cores, and periodically prints the running core. This task is created with no affinity to validate that it can run on either core. See [main.c:103](main.c#L103).
+
+## Boot Sequence (SMP)
+
+The FreeRTOS Cortex‑M33 SMP port and pico‑sdk cooperate to bring both cores up deterministically. This demo follows the sequence below, aligning with the FreeRTOS Armv8‑M SMP guidance and the implementation in `xWakeSecondaryCore()` and `prvMakeSecondaryCoreReady()`:
+
+- Primary core (core 0)
+  - C runtime runs, execution enters `main()`. The application installs the FreeRTOS vectors (`SVC`, `PendSV`, and `SysTick`) via `prvSetupInterruptVectors()` before creating tasks. See [main.c:124](main.c#L124).
+  - Application creates tasks, pins ping/pong tasks to cores, and initialises the inter‑core doorbell. Scheduler is started with `vTaskStartScheduler()` (see [main.c:170](main.c#L170)), which calls `xPortStartScheduler()`.
+  - Inside `xPortStartScheduler()` the port:
+    - Configures interrupt priorities.
+    - Starts the tick timer and initialises per‑core critical nesting.
+    - Sets `ucPrimaryCoreInitDoneFlag = 1` to signal shared init is complete.
+    - Calls the application‑defined `configWAKE_SECONDARY_CORES` hook. In this demo it resolves to `xWakeSecondaryCore()`, which launches core 1 via `multicore_launch_core1(prvMakeSecondaryCoreReady)` once the flag is set. See [main.c:294](main.c#L294).
+    - Waits until all entries in `ucSecondaryCoresReadyFlags[]` are set by the secondary core(s).
+    - Calls `vStartFirstTask()` to start scheduling on core 0.
+
+- Secondary core (core 1)
+  - Secondary core is kept at bootrom until it is launched by the primary core using the pico‑sdk `multicore_launch_core1()` with the entry function set to  `prvMakeSecondaryCoreReady`. Launch is gated on `ucPrimaryCoreInitDoneFlag == 1` in `xWakeSecondaryCore()`, which matches the top‑level Armv8‑M SMP boot guidance that secondaries must not proceed until shared init completes.
+  - In `prvMakeSecondaryCoreReady()` (see [main.c:310](main.c#L310)), the application:
+    - Installs the FreeRTOS vectors via `prvSetupInterruptVectors()` and sets up the doorbell IRQ with `prvSetupDoorbellInterrupt()`.
+    - Calls `vPortConfigureInterruptPriorities()` to apply per‑core priorities.
+    - Signals readiness by setting `ucSecondaryCoresReadyFlags[portGET_CORE_ID()-1] = 1`.
+    - Issues `SVC portSVC_START_SCHEDULER`, which in the SVC handler dispatches to `vRestoreContextOfFirstTask()` to begin scheduling on core 1. See [main.c:319](main.c#L319).
+
+Notes
+- On RP2350, the secondary core does not run full C runtime startup, it is explicitly launched from core 0. The demo relies on the pico‑sdk `multicore_*` APIs for this bring‑up.
+
+## Notes on Coherency and Ordering
+
+- RP2350 SRAM is not data‑cached, so inter‑core visibility is naturally coherent for SRAM. Use barriers for ordering across cores.
+- The demo uses Data Synchronisation Barrier (`DSB`) instruction after updating the shared flag, FreeRTOS primitives also include required barriers.
+
+## Expected Output
+
+Over the selected stdio (USB/UART as configured in pico‑sdk):
+
+```
+FreeRTOS SMP Example starting on RP2350...
+Core 0: Doorbell X claimed for inter-core interrupts.
+Core 0: Waking up secondary core.
+Core 1: Secondary core started.
+Ping from Core 0
+Bouncing task running on core X
+Pong from Core 1
+Bouncing task running on core Y
+Ping from Core 0
+Bouncing task running on core X
+Pong from Core 1
+Bouncing task running on core Y
+Ping from Core 0
+Bouncing task running on core X
+Pong from Core 1
+Bouncing task running on core Y
+...
+```
+
+## License
+
+This example is released under the **MIT License**. See the [LICENSE](LICENSE.md) and [Third Party Notices](THIRD_PARTY_NOTICES) files.

--- a/RP2350_SMP_GCC/THIRD_PARTY_NOTICES.md
+++ b/RP2350_SMP_GCC/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,36 @@
+Third‑Party Notices
+
+- This application incorporates the Raspberry Pi Pico SDK (pico-sdk), which is
+  licensed under the BSD-3-Clause license by Raspberry Pi (Trading) Ltd.
+  The full license text for the Pico SDK is reproduced below for compliance
+  when redistributing source or binaries built from this application.
+
+Pico SDK (BSD-3-Clause)
+
+Copyright 2020 (c) 2020 Raspberry Pi (Trading) Ltd.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Notes
+
+- The Pico SDK may include or vendoredly reference additional third‑party components
+  with their own licenses. For comprehensive attributions, consult the Pico SDK
+  repository and its subdirectories.

--- a/RP2350_SMP_GCC/config/FreeRTOSConfig.h
+++ b/RP2350_SMP_GCC/config/FreeRTOSConfig.h
@@ -1,0 +1,207 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates
+ * <open-source-office@arm.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/******************************************************************************
+*   See http://www.freertos.org/a00110.html for an explanation of the
+*   definitions contained in this file.
+******************************************************************************/
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "hardware/regs/addressmap.h"
+#include "hardware/regs/sio.h"
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+* https://www.FreeRTOS.org/a00110.html
+*----------------------------------------------------------*/
+
+/* Ensure definitions are only used by the compiler, and not by the assembler. */
+#if !defined(__ASSEMBLER__)
+    #if defined(__ICCARM__) || defined(__CC_ARM) || defined(__GNUC__)
+        extern uint32_t SystemCoreClock;
+        void vAssertCalled( const char * pcFile, unsigned long ulLine );
+    #endif
+#endif
+
+/* See https://freertos.org/a00110.html#configPROTECTED_KERNEL_OBJECT_POOL_SIZE for details. */
+#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE   150
+/* See https://freertos.org/a00110.html#configSYSTEM_CALL_STACK_SIZE for details. */
+#define configSYSTEM_CALL_STACK_SIZE              128
+
+/* Cortex M33 port configuration. */
+#define configENABLE_MPU                                 0
+#define configENABLE_FPU                                 0
+#define configENABLE_TRUSTZONE                           0
+/* Run FreeRTOS on the secure side and never jump to the non-secure side. */
+#define configRUN_FREERTOS_SECURE_ONLY                   1
+#define configENABLE_MVE                                 0
+
+#define configNUMBER_OF_CORES                            2
+
+/* SMP specific configurations. */
+#if ( configNUMBER_OF_CORES > 1 )
+    #define configUSE_CORE_AFFINITY                      1
+    #define configRUN_MULTIPLE_PRIORITIES                1
+    #define configUSE_PASSIVE_IDLE_HOOK                  0
+    #define configTIMER_SERVICE_TASK_CORE_AFFINITY       0
+    #define configCORE_ID_REGISTER                       ( SIO_BASE + SIO_CPUID_OFFSET )
+    #define configWAKE_SECONDARY_CORES                   xWakeSecondaryCore
+#endif
+
+/* This part has 16 MPU regions. */
+#define configTOTAL_MPU_REGIONS                          8
+
+/* Constants related to the behaviour or the scheduler. */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
+#define configUSE_PREEMPTION                             1
+#define configUSE_TIME_SLICING                           1
+#define configMAX_PRIORITIES                             ( 10 )
+#define configIDLE_SHOULD_YIELD                          1
+#define configTICK_TYPE_WIDTH_IN_BITS                    TICK_TYPE_WIDTH_32_BITS
+
+/* Constants that describe the hardware and memory usage. */
+#define configCPU_CLOCK_HZ                               SystemCoreClock
+#define configMINIMAL_STACK_SIZE                         ( ( uint16_t ) 512 )
+#define configMINIMAL_SECURE_STACK_SIZE                  ( 1024 )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configTOTAL_HEAP_SIZE                            ( 0xF000 )
+
+/* Constants that build features in or out. */
+#define configUSE_MUTEXES                                1
+#define configUSE_TICKLESS_IDLE                          0
+#define configUSE_APPLICATION_TASK_TAG                   0
+#define configUSE_NEWLIB_REENTRANT                       0
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configUSE_QUEUE_SETS                             0
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configUSE_TRACE_FACILITY                         1
+#define configNUM_TX_DESCRIPTORS                         15
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    2
+
+/* Constants that define which hook (callback) functions should be used. */
+#define configUSE_IDLE_HOOK                              1
+#define configUSE_TICK_HOOK                              1
+#define configUSE_MALLOC_FAILED_HOOK                     1
+
+/* Constants provided for debugging and optimisation assistance. */
+#define configCHECK_FOR_STACK_OVERFLOW                   2
+#define configASSERT( x )    if( ( x ) == 0 ) vAssertCalled( __FILE__, __LINE__ );
+#define configQUEUE_REGISTRY_SIZE                        20
+
+/* Software timer definitions. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  NOTE:  Setting an INCLUDE_ parameter to 0 is
+ * only necessary if the linker does not automatically remove functions that are
+ * not referenced anyway. */
+#define INCLUDE_vTaskPrioritySet                         1
+#define INCLUDE_uxTaskPriorityGet                        1
+#define INCLUDE_vTaskDelete                              1
+#define INCLUDE_vTaskCleanUpResources                    0
+#define INCLUDE_vTaskSuspend                             1
+#define INCLUDE_vTaskDelayUntil                          1
+#define INCLUDE_vTaskDelay                               1
+#define INCLUDE_uxTaskGetStackHighWaterMark              1
+#define INCLUDE_uxTaskGetStackHighWaterMark2             1
+#define INCLUDE_xTaskGetIdleTaskHandle                   1
+#define INCLUDE_eTaskGetState                            1
+#define INCLUDE_xTaskResumeFromISR                       1
+#define INCLUDE_xTaskGetCurrentTaskHandle                1
+#define INCLUDE_xTaskGetSchedulerState                   1
+#define INCLUDE_xSemaphoreGetMutexHolder                 1
+#define INCLUDE_xTimerPendFunctionCall                   1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle           1
+#define INCLUDE_xTaskGetHandle                           1
+#define INCLUDE_xTaskAbortDelay                          1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to
+ * human readable ASCII form.  See the notes in the implementation of vTaskList()
+ * within FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS             1
+
+/* Dimensions a buffer that can be used by the FreeRTOS+CLI command interpreter.
+ * See the FreeRTOS+CLI documentation for more information:
+ * https://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_CLI/ */
+#define configCOMMAND_INT_MAX_OUTPUT_SIZE                2048
+
+/* Interrupt priority configuration follows...................... */
+
+/* Use the system definition, if there is one. */
+#ifdef __NVIC_PRIO_BITS
+    #define configPRIO_BITS    __NVIC_PRIO_BITS
+#else
+    #define configPRIO_BITS    3                              /* 8 priority levels. */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+ * function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY         0x07
+
+/* The highest interrupt priority that can be used by any interrupt service
+ * routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT
+ * CALL INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A
+ * HIGHER PRIORITY THAN THIS! (higher priorities are lower numeric values). */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY    5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+* to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY                 ( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+ * See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY            ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << ( 8 - configPRIO_BITS ) )
+
+/* Constants related to the generation of run time stats. */
+#define configGENERATE_RUN_TIME_STATS                   0
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
+#define portGET_RUN_TIME_COUNTER_VALUE()    0
+
+/* Adjust configTICK_RATE_HZ and pdMS_TO_TICKS to simulate a tick per ms on a fast model */
+#define configTICK_RATE_HZ    ( ( TickType_t ) 100 )
+#define pdMS_TO_TICKS( xTimeInMs )    ( ( TickType_t ) xTimeInMs )
+
+
+/* Enable dynamic allocation. */
+#define configSUPPORT_STATIC_ALLOCATION     0
+#define configSUPPORT_DYNAMIC_ALLOCATION    1
+
+#endif /* FREERTOS_CONFIG_H */

--- a/RP2350_SMP_GCC/main.c
+++ b/RP2350_SMP_GCC/main.c
@@ -1,0 +1,332 @@
+/* Copyright 2023-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+#include "portmacro.h"
+
+/* Pico SDK includes. */
+#include "RP2350.h"
+#include "pico/multicore.h"
+#include "pico/stdlib.h"
+#include "irq.h"
+
+#define DELAY_100_MS                   ( pdMS_TO_TICKS( 100 ) )      /* 100 milliseconds delay */
+#define DELAY_50_MS                    ( pdMS_TO_TICKS( 50 ) )       /* 50 milliseconds delay */
+#define MIN_INTERRUPT_PRIORITY         ( 255UL )                     /* Lowest interrupt priority */
+#define CORE_0_AND_CORE_1_MASK         ( 0b11 )                      /* Mask for both cores */
+
+static SemaphoreHandle_t xMutex = NULL;
+static volatile uint32_t ulSharedFlag = 0;
+static TaskHandle_t prvTaskCore0Handle;
+static TaskHandle_t prvTaskCore1Handle;
+static int8_t cDoorbellNum = -1;
+
+extern PRIVILEGED_DATA volatile uint8_t ucPrimaryCoreInitDoneFlag;
+extern PRIVILEGED_DATA volatile uint8_t ucSecondaryCoresReadyFlags[ configNUMBER_OF_CORES - 1 ];
+
+static void prvDoorbellInterruptHandler();
+static void prvMakeSecondaryCoreReady( void );
+static void prvSetupInterruptVectors( void );
+static void prvSetupDoorbellInterrupt( void );
+static void prvDoorbellInit ( void );
+
+extern void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+extern void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+extern void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+void vAssertCalled( const char * pcFile,
+                    unsigned long ulLine )
+{
+    printf( "ASSERT failed! file %s:%lu, \r\n", pcFile, ulLine );
+
+    taskENTER_CRITICAL();
+    {
+        volatile unsigned long looping = 0;
+
+        /* Use the debugger to set ul to a non-zero value in order to step out
+         *      of this function to determine why it was called. */
+        while( looping == 0LU )
+        {
+            portNOP();
+        }
+    }
+    taskEXIT_CRITICAL();
+}
+
+static void prvTaskCore0( void * arg )
+{
+    /* Prevent the compiler warning about the unused parameter. */
+    ( void ) arg;
+    while( 1 )
+    {
+        if ( xSemaphoreTake( xMutex, portMAX_DELAY ) == pdTRUE )
+        {
+            if( ulSharedFlag == 0U )
+            {
+                printf( "Ping from Core %d\r\n", ucPortGetCoreID() );
+                ulSharedFlag = 1U;
+                __DSB();
+            }
+            xSemaphoreGive( xMutex );
+            vTaskDelay( DELAY_100_MS );
+        }
+    }
+}
+
+static void prvTaskCore1( void * arg )
+{
+    /* Prevent the compiler warning about the unused parameter. */
+    ( void ) arg;
+    while( 1 )
+    {
+        if ( xSemaphoreTake( xMutex, portMAX_DELAY ) == pdTRUE )
+        {
+            if( ulSharedFlag == 1U )
+            {
+                printf( "Pong from Core %d\r\n", ucPortGetCoreID() );
+                ulSharedFlag = 0U;
+                __DSB();
+            }
+            xSemaphoreGive( xMutex );
+            vTaskDelay( DELAY_100_MS );
+        }
+    }
+}
+
+static void prvBouncingTask( void * arg )
+{
+    /* Prevent the compiler warning about the unused parameter. */
+    ( void ) arg;
+    while( 1 )
+    {
+        if ( xSemaphoreTake( xMutex, portMAX_DELAY ) == pdTRUE )
+        {
+            printf( "Bouncing task running on core %d\r\n", ucPortGetCoreID() );
+            xSemaphoreGive( xMutex );
+            vTaskDelay( DELAY_50_MS );
+        }
+    }
+}
+
+int main()
+{
+    /* Initialize stdio */
+    stdio_init_all();
+
+    /* Setup Systick, PendSV, and SVC interrupt vectors */
+    prvSetupInterruptVectors();
+
+    printf( "FreeRTOS SMP Example starting on RP2350...\n" );
+
+    if( xTaskCreate( prvTaskCore0,
+        NULL,
+        configMINIMAL_STACK_SIZE,
+        NULL,
+        ( tskIDLE_PRIORITY + 1 ),
+        &prvTaskCore0Handle ) == pdFAIL )
+    {
+        return EXIT_FAILURE;
+    }
+
+    if( xTaskCreate( prvTaskCore1,
+        NULL,
+        configMINIMAL_STACK_SIZE,
+        NULL,
+        ( tskIDLE_PRIORITY + 1 ),
+        &prvTaskCore1Handle ) == pdFAIL )
+    {
+        return EXIT_FAILURE;
+    }
+
+    if( xTaskCreate( prvBouncingTask,
+        NULL,
+        configMINIMAL_STACK_SIZE,
+        NULL,
+        ( tskIDLE_PRIORITY ),
+        NULL ) == pdFAIL )
+    {
+        return EXIT_FAILURE;
+    }
+
+    vTaskCoreAffinitySet( prvTaskCore0Handle, 1UL << 0 );  /* Pin to Core 0 */
+    vTaskCoreAffinitySet( prvTaskCore1Handle, 1UL << 1 );  /* Pin to Core 1 */
+
+    xMutex = xSemaphoreCreateMutex();
+
+    if ( xMutex == NULL )
+    {
+        return EXIT_FAILURE;  /* Failed to create mutex */
+    }
+
+    prvDoorbellInit(); /* Initialize doorbell for inter-core interrupts */
+
+    vTaskStartScheduler();
+
+    /* If all is well, the scheduler will now be running, and the following
+    * line will never be reached.  If the following line does execute, then
+    * there was insufficient FreeRTOS heap memory available for the idle and/or
+    * timer tasks	to be created.  See the memory management section on the
+    * FreeRTOS web site for more details.  NOTE: This demo uses static allocation
+    * for the idle and timer tasks so this line should never execute. */
+    for( ; ; )
+    {
+    }
+}
+
+/**
+ * Dummy implementation of the callback function vApplicationStackOverflowHook().
+ */
+#if ( configCHECK_FOR_STACK_OVERFLOW > 0 )
+    void vApplicationStackOverflowHook( TaskHandle_t xTask,
+                                        char * pcTaskName )
+    {
+        ( void ) xTask;
+        ( void ) pcTaskName;
+
+        /* Assert when stack overflow is enabled but no application defined function exists */
+        configASSERT( 0 );
+    }
+#endif
+
+/*---------------------------------------------------------------------------*/
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+/*
+ * vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ */
+
+    __WEAK void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                               StackType_t ** ppxIdleTaskStackBuffer,
+                                               StackType_t * pulIdleTaskStackSize )
+    {
+        /* Idle task control block and stack */
+        static StaticTask_t Idle_TCB = { 0 };
+        static StackType_t Idle_Stack[ configMINIMAL_STACK_SIZE ] = { 0 };
+
+        *ppxIdleTaskTCBBuffer = &Idle_TCB;
+        *ppxIdleTaskStackBuffer = &Idle_Stack[ 0 ];
+        *pulIdleTaskStackSize = ( uint32_t ) configMINIMAL_STACK_SIZE;
+    }
+
+/*
+ * vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ */
+    __WEAK void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                                StackType_t ** ppxTimerTaskStackBuffer,
+                                                StackType_t * pulTimerTaskStackSize )
+    {
+        /* Timer task control block and stack */
+        static StaticTask_t Timer_TCB = { 0 };
+        static StackType_t Timer_Stack[ configTIMER_TASK_STACK_DEPTH ] = { 0 };
+
+        *ppxTimerTaskTCBBuffer = &Timer_TCB;
+        *ppxTimerTaskStackBuffer = &Timer_Stack[ 0 ];
+        *pulTimerTaskStackSize = ( uint32_t ) configTIMER_TASK_STACK_DEPTH;
+    }
+#endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+
+void vApplicationTickHook( void )
+{
+    /* Provide a stub for this function. */
+}
+
+void vApplicationIdleHook( void )
+{
+    const TickType_t xKitHitCheckPeriod = pdMS_TO_TICKS( 1000UL );
+    static TickType_t xTimeNow, xLastTimeCheck = 0;
+
+    if( ( xTimeNow - xLastTimeCheck ) > xKitHitCheckPeriod )
+    {
+        xLastTimeCheck = xTimeNow;
+    }
+
+    /* Exit. Just a stub. */
+}
+
+void vApplicationMallocFailedHook( void )
+{
+    /* Provide a stub for this function. */
+}
+
+void vInterruptCore( uint8_t ucCoreID )
+{
+    ( void ) ucCoreID;
+    multicore_doorbell_set_other_core( cDoorbellNum );
+}
+
+static void prvDoorbellInterruptHandler( void )
+{
+    if ( cDoorbellNum >= 0 && multicore_doorbell_is_set_current_core( cDoorbellNum ) )
+    {
+        multicore_doorbell_clear_current_core( cDoorbellNum );
+        /* Request a context switch */
+        portYIELD_FROM_ISR( pdTRUE );
+    }
+}
+
+static void prvDoorbellInit ( void )
+{
+    /* Claim a doorbell for inter-core interrupts to be used by both cores */
+    cDoorbellNum = ( int8_t ) multicore_doorbell_claim_unused( CORE_0_AND_CORE_1_MASK, true );
+    multicore_doorbell_clear_current_core( cDoorbellNum );
+    multicore_doorbell_clear_other_core( cDoorbellNum );
+    printf( "Core %u: Doorbell %d claimed for inter-core interrupts.\n", portGET_CORE_ID(), cDoorbellNum );
+}
+
+static void prvSetupDoorbellInterrupt( void )
+{
+    /* Install Doorbell handler to receive interrupt from other core */
+    uint32_t ulDoorbellIRQn = multicore_doorbell_irq_num( cDoorbellNum );
+    NVIC_SetPriority( ulDoorbellIRQn, MIN_INTERRUPT_PRIORITY );
+    NVIC_SetVector( ulDoorbellIRQn, ( uint32_t ) prvDoorbellInterruptHandler );
+    NVIC_EnableIRQ( ulDoorbellIRQn );
+}
+
+BaseType_t xWakeSecondaryCore( void )
+{
+    if ( ucPrimaryCoreInitDoneFlag == 1U )
+    {
+        printf( "Core %u: Waking up secondary core.\n", portGET_CORE_ID() );
+        /* Wake secondary core with prvMakeSecondaryCoreReady as the entry point */
+        multicore_launch_core1( prvMakeSecondaryCoreReady );
+        return pdTRUE;
+    }
+    else
+    {
+        printf( "Core %u: Primary core initialization not done yet. Cannot wake secondary core.\n", portGET_CORE_ID() );
+        return pdFALSE;
+    }
+}
+
+static void prvMakeSecondaryCoreReady( void )
+{
+    printf( "Core %u: Secondary core started.\n", portGET_CORE_ID() );
+    prvSetupInterruptVectors();
+    prvSetupDoorbellInterrupt();
+    vPortConfigureInterruptPriorities();
+
+    /* Signal that this secondary core is ready */
+    ucSecondaryCoresReadyFlags[ portGET_CORE_ID() - 1 ] = 1U;
+    __asm volatile (
+        "SVC %0 \n"
+        :
+        : "i" ( portSVC_START_SCHEDULER )
+        : "memory"
+    );
+}
+
+static void prvSetupInterruptVectors( void )
+{
+    NVIC_SetVector( SVCall_IRQn, ( uint32_t ) SVC_Handler );
+    NVIC_SetVector( PendSV_IRQn, ( uint32_t ) PendSV_Handler );
+    NVIC_SetVector( SysTick_IRQn, ( uint32_t ) SysTick_Handler );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Add a new SMP application for the RP2350 platform, including:
- A new `CMakeLists.txt` file to configure the build system.
- A `README.md` file providing detailed instructions on building and flashing the application.
- `THIRD_PARTY_NOTICES.md` and `LICENSE.md` files for license compliance.
- A `FreeRTOSConfig.h` file for FreeRTOS configuration.
- A `main.c` file implementing the SMP example.
- Addition of the `pico-sdk` as a submodule.

This setup demonstrates FreeRTOS SMP on the dual-core Arm Cortex-M33 Raspberry Pi Pico 2 (RP2350) using the Raspberry Pi Pico SDK. The example includes tasks pinned to different cores, unpinned tasks, inter-core communication, and preemption via interrupts.

This PR depends on the kernel [PR!1385](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1385).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
